### PR TITLE
Add cross-engine tests for three Wheels framework gaps

### DIFF
--- a/tests/core/test_local_at_template_scope.cfm
+++ b/tests/core/test_local_at_template_scope.cfm
@@ -1,0 +1,75 @@
+<cfscript>
+suiteBegin("Core: local scope at template (page) scope");
+
+// ============================================================
+// Background
+// ============================================================
+// Inside a function, `local` is the magic auto-vivifying scope for the
+// function-local variables. Outside a function — at the top of a .cfm
+// template, inside an included script block, or in a CFC pseudo-
+// constructor — CFML engines have historically treated `local` as a
+// regular auto-vivifying struct on first subscript-write.
+//
+// Lucee 5/6/7, Adobe ColdFusion 2018-2025, and BoxLang all allow:
+//     local.x = 42;
+//     writeOutput(local.x);    -- prints 42
+//
+// CFWheels/Wheels uses this pattern in 581 sites across `vendor/wheels/`
+// .cfm templates -- every test runner, every populate.cfm, etc. Without
+// it, the framework's test harness throws on the very first assignment.
+//
+// This file exercises the at-template-scope behavior. The in-function
+// behavior of `local` is already covered by tests/core/test_scopes.cfm
+// and tests/core/test_localmode.cfm.
+// ============================================================
+
+// ------------------------------------------------------------
+// Auto-vivify on first subscript write
+// ------------------------------------------------------------
+local.x = 42;
+assert("local.x reads back as 42 after auto-vivify",
+    local.x, 42);
+
+// ------------------------------------------------------------
+// local should be a struct after vivification
+// ------------------------------------------------------------
+assertTrue("local is a struct at template scope",
+    isStruct(local));
+
+// ------------------------------------------------------------
+// Multiple keys on the same auto-vivified local
+// ------------------------------------------------------------
+local.greeting = "hello";
+local.target   = "world";
+assert("multi-key local: greeting", local.greeting, "hello");
+assert("multi-key local: target",   local.target,   "world");
+
+// structKeyExists works as expected
+assertTrue("structKeyExists(local, 'x') after write",
+    structKeyExists(local, "x"));
+assertFalse("structKeyExists(local, 'never_written') is false",
+    structKeyExists(local, "never_written"));
+
+// ------------------------------------------------------------
+// Nested keys
+// ------------------------------------------------------------
+local.config = {host: "localhost", port: 8585};
+assert("nested struct: local.config.host",
+    local.config.host, "localhost");
+assert("nested struct: local.config.port",
+    local.config.port, 8585);
+
+// ------------------------------------------------------------
+// for (key in struct) iterating local
+// ------------------------------------------------------------
+total = 0;
+keys  = [];
+for (k in local) {
+    arrayAppend(keys, k);
+    total = total + 1;
+}
+assertTrue("for-in over local visits all keys (total >= 4)",
+    total >= 4);
+
+suiteEnd();
+</cfscript>

--- a/tests/oop/test_metadata_name_value.cfm
+++ b/tests/oop/test_metadata_name_value.cfm
@@ -1,0 +1,73 @@
+<cfscript>
+suiteBegin("OOP: getMetadata().name reflects component identity");
+
+// ============================================================
+// Background
+// ============================================================
+// CFML reflects a component's identity through `getMetadata(cfc).name`
+// (and equivalently `getComponentMetadata(cfc).name`). The contract is
+// that `name` is a non-empty string that uniquely identifies the
+// component class — typically the dotted path used to load it, or the
+// fully-qualified name derived from its filesystem location.
+//
+// Frameworks rely on this:
+//   - CFWheels/Wheels uses `getMetadata(this).name` to derive table
+//     names from model class names (a `User` model → `users` table).
+//   - DI containers use it to dedupe singleton registrations.
+//   - Logging / error reporting includes class names for diagnostics.
+//
+// Lucee and Adobe ColdFusion both return the dotted path the component
+// was loaded under (e.g. "oop.Greeter"). BoxLang returns the simple
+// classname.
+//
+// The minimum contract this test asserts:
+//   1. `name` is non-empty
+//   2. `name` is NOT the literal string "Anonymous" — that's a sentinel
+//      meaning the engine failed to track the class identity
+//   3. The last segment of the name matches the .cfc filename
+//
+// The existing tests/oop/test_metadata.cfm only checks that the `name`
+// KEY exists on the metadata struct — it never asserts the VALUE. A
+// component whose name resolves to "Anonymous" passes the existing
+// check, masking a regression.
+// ============================================================
+
+g = createObject("component", "oop.Greeter").init();
+md = getMetadata(g);
+
+// 1. structure sanity
+assertNotNull("getMetadata returns non-null", md);
+assertTrue("metadata is a struct", isStruct(md));
+assertTrue("metadata has .name key", structKeyExists(md, "name"));
+
+// 2. name is non-empty
+assertTrue("metadata.name is non-empty",
+    len(toString(md.name)) > 0);
+
+// 3. name is not the sentinel "Anonymous"
+assertFalse("metadata.name is not literally 'Anonymous'",
+    compareNoCase(toString(md.name), "Anonymous") == 0);
+
+// 4. last segment of dotted name matches the .cfc filename
+// Works on Lucee/Adobe (returns "oop.Greeter") and BoxLang (returns
+// "Greeter") — we look at the last list element either way.
+assert("metadata.name ends with 'Greeter'",
+    listLast(md.name, "."), "Greeter");
+
+// ------------------------------------------------------------
+// Inherited component — same contract
+// ------------------------------------------------------------
+d = createObject("component", "oop.Dog").init();
+dmd = getMetadata(d);
+
+assertTrue("inherited metadata has .name key",
+    structKeyExists(dmd, "name"));
+
+assertFalse("inherited metadata.name is not 'Anonymous'",
+    compareNoCase(toString(dmd.name), "Anonymous") == 0);
+
+assert("inherited metadata.name ends with 'Dog'",
+    listLast(dmd.name, "."), "Dog");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -166,5 +166,15 @@ try { include "native/test_cfc_extends_rust.cfm"; } catch (any e) { writeOutput(
 // invoke a single file directly:
 //   cargo run -- tests/s3/test_s3_functions.cfm
 
+// --- Cross-engine compatibility (Wheels framework gaps) ---
+// These tests exercise CFML behaviors Wheels depends on that are currently
+// gaps in RustCFML but pass on Lucee 7. Registered last so the existing
+// suite runs uninterrupted: the script-tag-body test below triggers a
+// fatal parse error in RustCFML that the surrounding try/catch can't
+// catch (an include parse error escapes the try wrapper).
+try { include "core/test_local_at_template_scope.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_at_template_scope.cfm | " & e.message & chr(10)); }
+try { include "oop/test_metadata_name_value.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_metadata_name_value.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tags_script_syntax_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_script_syntax_body.cfm | " & e.message & chr(10)); }
+
 printSummary();
 </cfscript>

--- a/tests/tags/test_tags_script_syntax_body.cfm
+++ b/tests/tags/test_tags_script_syntax_body.cfm
@@ -1,0 +1,133 @@
+<cfscript>
+suiteBegin("Tags: Script-syntax with body block");
+
+// ============================================================
+// Background
+// ============================================================
+// Modern CFML lets you invoke body-block tags from cfscript via the
+// `cfXXX(args) { body }` function-call form. This is the dominant idiom
+// in BoxLang, Lucee 5+, and Adobe ColdFusion 2018+. Frameworks like
+// CFWheels/Wheels use it heavily in components — e.g. Global.cfc has
+// `cfmail(attributeCollection = local.args) { ... }`.
+//
+// Both forms must produce equivalent behavior:
+//
+//   <cfsavecontent variable="x">body</cfsavecontent>
+//   cfsavecontent(variable="x") { writeOutput("body"); }
+//
+// This file exercises the script-call-with-body form for the body-block
+// tags that have non-side-effect-y semantics (no SMTP, no real DB
+// connection, no filesystem mutation). The pure-tag form is already
+// covered by sibling test files (test_tags_savecontent.cfm,
+// test_tags_cfmail.cfm).
+// ============================================================
+
+// ------------------------------------------------------------
+// cfsavecontent(...) { body }
+// ------------------------------------------------------------
+cfsavecontent(variable = "captured") {
+    writeOutput("hello from script-syntax savecontent");
+}
+assert("cfsavecontent script: captures plain text",
+    trim(captured), "hello from script-syntax savecontent");
+
+cfsavecontent(variable = "captured2") {
+    for (i = 1; i <= 3; i++) {
+        writeOutput(i);
+    }
+}
+assert("cfsavecontent script: captures loop output",
+    trim(captured2), "123");
+
+// Verify it doesn't leak into the surrounding output buffer.
+cfsavecontent(variable = "captured3") {
+    writeOutput("inside");
+}
+assertTrue("cfsavecontent script: returns a string",
+    isSimpleValue(captured3));
+
+// ------------------------------------------------------------
+// cflock(...) { body }
+// ------------------------------------------------------------
+lockResult = "";
+cflock(name = "rustcfml-script-lock-test", type = "exclusive", timeout = 10) {
+    lockResult = "inside-lock";
+}
+assert("cflock script: body executes",
+    lockResult, "inside-lock");
+
+// Nested lock with different name should work.
+nestedResult = "";
+cflock(name = "rustcfml-outer", timeout = 10) {
+    cflock(name = "rustcfml-inner", timeout = 10) {
+        nestedResult = "nested-ok";
+    }
+}
+assert("cflock script: nested locks",
+    nestedResult, "nested-ok");
+
+// ------------------------------------------------------------
+// transaction action="..." { body }   (cfscript keyword form)
+// ------------------------------------------------------------
+// Cf2018+/Lucee/BoxLang let you write `transaction action="begin" { }`
+// in cfscript without the `cf` prefix — same shape as `lock { }` and
+// `savecontent { }`. This is the form Wheels' Migrator.cfc and Seeder.cfc
+// use, plus all migrator templates (create-table.cfc etc.).
+//
+// Without a configured datasource, `commit` will throw — that's fine, we
+// only care that the body parsed and executed before the implicit commit.
+txResult = "";
+try {
+    transaction {
+        txResult = "tx-body-ran";
+    }
+} catch (any e) {
+    // Implicit commit can throw without a datasource. Body should have
+    // run before that point.
+}
+assert("transaction keyword: body executes before commit",
+    txResult, "tx-body-ran");
+
+// ------------------------------------------------------------
+// cftransaction(...) { body }   (script function-call form)
+// ------------------------------------------------------------
+ctxResult = "";
+try {
+    cftransaction() {
+        ctxResult = "cftx-body-ran";
+    }
+} catch (any e) {
+    // Same — implicit commit may throw, body still runs.
+}
+assert("cftransaction script: body executes before commit",
+    ctxResult, "cftx-body-ran");
+
+// ------------------------------------------------------------
+// cfmail(...) { body }   (parses but doesn't send — caught)
+// ------------------------------------------------------------
+// We can't actually send mail without an SMTP server, but the file must
+// at minimum *parse* and the function must at minimum *enter the body*.
+// We rely on cfmail throwing without a configured mail server (matches
+// the behavior verified by tests/tags/test_tags_cfmail.cfm for the tag
+// form).
+mailBodyRan = false;
+mailThrew   = false;
+try {
+    cfmail(to = "nowhere@example.com",
+           from = "noreply@example.com",
+           subject = "script-form parse check",
+           type = "text") {
+        mailBodyRan = true;
+        writeOutput("hi");
+    }
+} catch (any e) {
+    mailThrew = true;
+}
+// The body either runs (engine has a mail spooler that accepts it) or
+// the call throws (no server configured). Either is acceptable — what
+// matters is that the file parsed and the call dispatched.
+assertTrue("cfmail script: parsed and dispatched (body ran OR threw)",
+    mailBodyRan OR mailThrew);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
Hi! Peter (Alurium / wheels-dev) reached out on Slack — you'd offered to take a look at self-contained test cases that pass on Lucee. Here are three that fall out of investigating CFWheels/Wheels framework compatibility with RustCFML.

## What's in the PR

Three new test files, each exercising a CFML behavior Wheels depends on heavily. All follow the existing `tests/<category>/test_<feature>.cfm` convention and use the `suiteBegin/assert/suiteEnd` harness:

| File | What it tests |
|---|---|
| `tests/tags/test_tags_script_syntax_body.cfm` | Script-syntax tag-with-body: `cfsavecontent(variable="x") { writeOutput("y"); }`, `cflock(...) { ... }`, `transaction { ... }`, `cftransaction(...) { ... }`, `cfmail(...) { ... }` |
| `tests/core/test_local_at_template_scope.cfm` | `local.x = 42` at top of a .cfm template (auto-vivify on first subscript write outside a function) |
| `tests/oop/test_metadata_name_value.cfm` | `getMetadata(cfc).name` reflects the component's identity. Existing `test_metadata.cfm` only checks `structKeyExists(md, "name")`, never the value |

Registered at the end of `tests/runner.cfm` rather than in their natural category slots — see "runner.cfm placement" below.

## Cross-engine verification

Verified against Lucee 7.0.3+43 via CommandBox in the project webroot:

\`\`\`
PASS | Tags: Script-syntax with body block | 8/8 passed
PASS | Core: local scope at template (page) scope | 9/9 passed
PASS | OOP: getMetadata().name reflects component identity | 9/9 passed
SUMMARY: 2640/2642 passed across 324 suites
\`\`\`

(The 2 pre-existing failures are in \`Date Functions > quoted text segment\` / \`escaped apostrophe\` — unrelated to this PR.)

## RustCFML behavior on the same tests (v0.20.1)

\`\`\`
ERROR | core/test_local_at_template_scope.cfm | Variable 'local' is undefined
FAIL  | OOP: getMetadata().name reflects component identity | 5/9 passed (4 failed)
        FAIL: metadata.name is not literally 'Anonymous' | expected falsy | got: [true]
        FAIL: metadata.name ends with 'Greeter' | expected: [Greeter] | got: [Anonymous]
        FAIL: inherited metadata.name is not 'Anonymous' | expected falsy | got: [true]
        FAIL: inherited metadata.name ends with 'Dog' | expected: [Dog] | got: [Anonymous]
Runtime Error: Parse error in 'tests/tags/test_tags_script_syntax_body.cfm' [line 29, col 56]: Expected RBrace, found Semicolon
\`\`\`

## runner.cfm placement

Two reasons the three registrations are clustered at the end instead of in their natural sections:

1. **\`test_tags_script_syntax_body.cfm\` triggers a parse error in RustCFML that aborts the whole runner.** The surrounding \`try { include ... } catch ...\` can't catch it — parse errors escape the include's try wrapper. Putting these last keeps the existing 1100+ tests running to completion before the abort.

2. This is itself probably worth a separate look at some point — a parse error in one included file shouldn't be able to kill the whole test suite. Not part of this PR.

## Why these specific tests

These are the three Wheels can't get past when loading the framework:

- \`Global.cfc::\$mail()\` uses \`cfmail(attributeCollection = local.args) { ... }\` — the parse error there makes Global fail to load, which cascades to every CFC extending \`wheels.Global\` (Model, Controller, Dispatch, Migrator, etc. — ~8 of 22 top-level framework CFCs).
- \`Wheels\` uses \`local.X = Y\` at template scope in 581 sites across \`vendor/wheels/**.cfm\` — every test runner, every populate.cfm.
- \`Wheels\` uses \`getMetadata(this).name\` to derive table names from model classes (\`User\` → \`users\`) and for several other reflection paths.

Happy to refine any of these, scope them down, or add more cases — just let me know.

— Peter (peter@alurium.com)