### PR TITLE
Fix Application.cfc lifecycle target page

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -11011,6 +11011,28 @@ impl CfmlVirtualMachine {
         }
     }
 
+    /// Return the page path exposed to Application.cfc lifecycle methods.
+    ///
+    /// The VM keeps `source_file` as the physical path for include and
+    /// component resolution, but CFML engines pass web-root-relative paths
+    /// such as `/_moopa.cfm` to onRequestStart/onRequest/onRequestEnd.
+    fn lifecycle_target_page(&self) -> String {
+        let source = self.source_file.clone().unwrap_or_default();
+        let canonical_source = self.vfs.canonicalize(&source).unwrap_or(source.clone());
+        let source_path = std::path::Path::new(&canonical_source);
+
+        if let Some(ref server_state) = self.server_state {
+            if let Some(ref webroot) = server_state.webroot {
+                if let Ok(relative) = source_path.strip_prefix(webroot) {
+                    let relative = relative.to_string_lossy().replace('\\', "/");
+                    return format!("/{}", relative.trim_start_matches('/'));
+                }
+            }
+        }
+
+        source
+    }
+
     /// Execute with Application.cfc lifecycle
     pub fn execute_with_lifecycle(&mut self) -> CfmlResult {
         // 1. Find Application.cfc
@@ -11324,7 +11346,7 @@ impl CfmlVirtualMachine {
         }
 
         // 6. onRequestStart
-        let target_page = self.source_file.clone().unwrap_or_default();
+        let target_page = self.lifecycle_target_page();
         match self.call_lifecycle_method(
             &mut template,
             "onRequestStart",

--- a/crates/cfml-vm/tests/lifecycle_target_page.rs
+++ b/crates/cfml-vm/tests/lifecycle_target_page.rs
@@ -1,0 +1,108 @@
+//! Regression coverage for Application.cfc lifecycle target-page arguments.
+//!
+//! Requests are executed from physical source paths, but CFML lifecycle
+//! methods receive web-root-relative paths such as `/_moopa.cfm`.
+
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::dynamic::CfmlValue;
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlVirtualMachine, ServerState};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+#[test]
+fn request_lifecycle_methods_receive_webroot_relative_target_page() {
+    let output = run_lifecycle_target_page_request(format!("{}/_moopa.cfm", VROOT));
+
+    assert_eq!(
+        "start=/_moopa.cfm|request=/_moopa.cfm|end=/_moopa.cfm",
+        output
+    );
+}
+
+#[test]
+fn lifecycle_target_page_canonicalizes_source_before_stripping_webroot() {
+    let output = run_lifecycle_target_page_request("_moopa.cfm");
+
+    assert_eq!(
+        "start=/_moopa.cfm|request=/_moopa.cfm|end=/_moopa.cfm",
+        output
+    );
+}
+
+fn run_lifecycle_target_page_request(source_file: impl Into<String>) -> String {
+    let mut files: HashMap<String, Vec<u8>> = HashMap::new();
+    files.insert(
+        "Application.cfc".to_string(),
+        r##"
+component {
+    this.name = "lifecycle-target-page-test";
+
+    function onRequestStart(targetPage) {
+        writeOutput("start=" & arguments.targetPage & "|");
+    }
+
+    function onRequest(targetPage) {
+        writeOutput("request=" & arguments.targetPage);
+    }
+
+    function onRequestEnd(targetPage) {
+        writeOutput("|end=" & arguments.targetPage);
+    }
+}
+"##
+        .as_bytes()
+        .to_vec(),
+    );
+    files.insert("_moopa.cfm".to_string(), b"<cfset ok = true>".to_vec());
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/_moopa.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut server_state = ServerState::with_production(false);
+    server_state.webroot = Some(PathBuf::from(VROOT));
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(source_file.into());
+    vm.base_template_path = Some(page_path);
+    vm.server_state = Some(server_state);
+
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+    vm.globals
+        .entry("url".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("cgi".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("form".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+
+    vm.execute_with_lifecycle().unwrap();
+
+    vm.output_buffer
+}


### PR DESCRIPTION
## Summary

This adds Lucee-compatible target-page handling for `Application.cfc` request lifecycle methods.

When a request is executed from a physical source path under the web root, `onRequestStart(targetPage)`, `onRequest(targetPage)`, and `onRequestEnd(targetPage)` should receive the web-root-relative page path, e.g. `/_moopa.cfm`, rather than the VM/source path, e.g. `/app/_moopa.cfm`.

This came up while porting Moopa Starter, which uses `onRequest(targetPage)` as part of its front-controller dispatch flow.

## Changes

- Adds `CfmlVirtualMachine::lifecycle_target_page()` to normalize lifecycle target-page arguments against `ServerState.webroot`.
- Uses that normalized value for `onRequestStart`, `onRequest`, and `onRequestEnd`.
- Adds regression coverage for all three lifecycle methods receiving the same web-root-relative target page.

## Tests

- `cargo test -p cfml-vm --test lifecycle_target_page`
- `cargo test -p cfml-vm --test lazy_session`
