### PR TITLE
Add cross-engine tests for two more Wheels framework gaps

### DIFF
--- a/tests/core/ForInThisLoopFixture.cfc
+++ b/tests/core/ForInThisLoopFixture.cfc
@@ -1,0 +1,26 @@
+component {
+
+    // The exact shape Wheels' public/Application.cfc uses to scan plugin
+    // folders:  for (this.wheels.folder in this.wheels.pluginFolders) { ... }
+    // A `this`-headed for-in loop variable. Lucee/ACF/BoxLang accept it;
+    // RustCFML 0.20.2 fails to PARSE it ("Expected Semicolon, found In"),
+    // which degrades this whole component at instantiation.
+    function scanArray() {
+        this.wheels = {folder: "", pluginFolders: ["x", "y", "z"]};
+        this.joined = "";
+        for (this.wheels.folder in this.wheels.pluginFolders) {
+            this.joined = this.joined & this.wheels.folder;
+        }
+        return this.joined;
+    }
+
+    // The value a `this`-scoped loop variable holds after the loop ends
+    // (engine-consistent across Lucee/ACF/BoxLang: the final element).
+    function lastFolder() {
+        this.wheels = {folder: "", pluginFolders: ["x", "y", "z"]};
+        for (this.wheels.folder in this.wheels.pluginFolders) {
+        }
+        return this.wheels.folder;
+    }
+
+}

--- a/tests/core/test_forin_member_loop_var.cfm
+++ b/tests/core/test_forin_member_loop_var.cfm
@@ -1,0 +1,79 @@
+<cfscript>
+suiteBegin("Core: for-in with a member-path loop variable");
+
+// ============================================================
+// Background
+// ============================================================
+// CFScript's for-in loop lets the loop variable be ANY assignable
+// expression (lvalue), not just a bare name. Lucee 5/6/7, Adobe
+// ColdFusion 2018-2025, and BoxLang all accept a struct member path as
+// the loop variable:
+//
+//     for (ctx.item in myArray)          // array element -> ctx.item
+//     for (ctx.key  in myStruct)         // struct key   -> ctx.key
+//     for (this.wheels.folder in arr)    // `this`-scoped member path
+//
+// CFWheels/Wheels relies on the `this`-scoped form in
+// public/Application.cfc, whose pseudo-constructor scans the plugin
+// directory with:
+//
+//     for (this.wheels.folder in this.wheels.pluginFolders) { ... }
+//
+// RustCFML v0.20.2 only supports a BARE-NAME loop variable. A member-path
+// loop variable fails in two distinct ways:
+//
+//   (1) A plain member path (ctx.item, a.b.c) PARSES, but the loop never
+//       binds the variable and its body never runs -- the iteration is
+//       silently skipped (the sum stays 0, the join stays ""). This is
+//       the run-time gap the first assertions below pin down.
+//
+//   (2) A `this`-headed path fails to PARSE outright
+//       (`Parse error: Expected Semicolon, found In`). Because Wheels'
+//       Application.cfc uses exactly this form, the component degrades to
+//       an empty object at instantiation and its pseudo-constructor never
+//       completes. The fixture assertions below pin this down via
+//       ForInThisLoopFixture (the parse failure is contained to that
+//       component -- it does NOT abort this run).
+//
+// A bare-name loop variable -- for (item in myArray) -- works on RustCFML
+// and is already covered by
+// tests/compat_engine/test_language_controlflow.cfm. All assertions in
+// this file PASS on Lucee/ACF/BoxLang.
+// ============================================================
+
+// ------------------------------------------------------------
+// (1) Plain struct-member path, iterating an array: parses on RustCFML
+//     but does not iterate.
+// ------------------------------------------------------------
+ctx = {arr: [10, 20, 30], sum: 0};
+for (ctx.item in ctx.arr) {
+    ctx.sum = ctx.sum + ctx.item;
+}
+assert("for (struct.member in array): sums every element",
+    ctx.sum, 60);
+
+// ------------------------------------------------------------
+// (1) Plain struct-member path, iterating a struct (key iteration).
+// ------------------------------------------------------------
+ctx2 = {src: {a: 1, b: 2, c: 3}, keys: ""};
+for (ctx2.k in ctx2.src) {
+    ctx2.keys = listAppend(ctx2.keys, ctx2.k);
+}
+assert("for (struct.member in struct): visits every key",
+    listLen(ctx2.keys), 3);
+
+// ------------------------------------------------------------
+// (2) `this`-headed path -- the exact shape Wheels' Application.cfc uses,
+//     exercised through a fixture component. PARSE error on RustCFML
+//     0.20.2; degrades the component so the methods return "".
+// ------------------------------------------------------------
+probe = createObject("component", "ForInThisLoopFixture");
+
+assert("for (this.wheels.folder in array): the Wheels Application.cfc shape",
+    probe.scanArray(), "xyz");
+
+assert("`this`-scoped loop var holds the final element after the loop",
+    probe.lastFolder(), "z");
+
+suiteEnd();
+</cfscript>

--- a/tests/functions/test_expandpath_trailing_slash.cfm
+++ b/tests/functions/test_expandpath_trailing_slash.cfm
@@ -1,0 +1,88 @@
+<cfscript>
+suiteBegin("Functions: expandPath trailing-slash preservation");
+
+// ============================================================
+// Background
+// ============================================================
+// expandPath() resolves a relative path against the current base and
+// returns an absolute path. A long-standing cross-engine convention --
+// honored by Lucee 5/6/7, Adobe ColdFusion 2018-2025, and BoxLang -- is
+// that expandPath MIRRORS the trailing slash of its input: if the input
+// ends in a slash, so does the result; if it doesn't, the result doesn't
+// gain one.
+//
+//     expandPath("foo/")  ->  "<base>/foo/"     (slash preserved)
+//     expandPath("foo")   ->  "<base>/foo"      (no slash added)
+//
+// CFWheels/Wheels depends on this in public/Application.cfc:
+//
+//     this.appDir           = expandPath("../app/");      // keeps the slash
+//     this.wheels.pluginDir = this.appDir & "../plugins";
+//
+// The kept slash makes `appDir & "../plugins"` resolve to a traversable
+// "<root>/app/../plugins". On RustCFML v0.20.2 expandPath DROPS the
+// trailing slash, but ONLY for a path that already EXISTS on disk: for an
+// existing directory it canonicalizes the path (resolving "..", resolving
+// symlinks) and the trailing slash is lost; for a non-existent path it
+// falls back to a lexical join that keeps the slash. Wheels' "../app/"
+// resolves to a real directory, so it hits the canonicalizing path and
+// the slash is dropped. The concatenation then fuses into the malformed
+// "<root>/app../plugins" (note "app.." -- no slash), and the subsequent
+// DirectoryList() throws "No such file or directory", aborting the
+// Application.cfc pseudo-constructor.
+//
+// To reproduce the EXISTING-path code path portably, this test creates a
+// real probe directory under the current base, then asserts the trailing-
+// slash PROPERTY and the malformed-fusion SUBSTRING (never an absolute
+// path) so the assertions hold regardless of where the test tree lives.
+// ============================================================
+
+// Compute the probe directory's absolute path via expandPath itself (so
+// the create step and the assert step share one base), then materialize
+// it on disk so expandPath takes its existing-path branch.
+probeRel = "rustcfml_probe_expand";
+probeAbs = expandPath(probeRel);
+if (!directoryExists(probeAbs)) {
+    directoryCreate(probeAbs);
+}
+
+// ------------------------------------------------------------
+// Slash on the input is preserved on the output (the directory now exists)
+// ------------------------------------------------------------
+withSlash = expandPath(probeRel & "/");
+assert("expandPath preserves a trailing slash present in the input",
+    right(withSlash, 1), "/");
+
+// ------------------------------------------------------------
+// No slash on the input -> no slash added (symmetry / sanity:
+// passes on every engine, pins down that the gap is "preserve", not "add")
+// ------------------------------------------------------------
+noSlash = expandPath(probeRel);
+assertFalse("expandPath does not append a slash when the input lacks one",
+    right(noSlash, 1) EQ "/");
+
+// ------------------------------------------------------------
+// Concatenating "../x" onto a dir-with-slash must not fuse into "dir.."
+// ------------------------------------------------------------
+fused = expandPath(probeRel & "/") & "../sibling";
+assertFalse("dir-with-slash + '../' must not collapse into 'dir..'",
+    find(probeRel & "..", fused) GT 0);
+
+// ------------------------------------------------------------
+// The exact two-step shape Wheels' Application.cfc uses: the result must
+// stay traversable (contains a "/../" segment, not a fused "dir..").
+// ------------------------------------------------------------
+appDir    = expandPath(probeRel & "/");
+pluginDir = appDir & "../plugins";
+assertTrue("Wheels shape: expandPath('dir/') & '../plugins' stays traversable ('/../' present)",
+    find("/../", pluginDir) GT 0);
+
+// ------------------------------------------------------------
+// Clean up the probe directory.
+// ------------------------------------------------------------
+if (directoryExists(probeAbs)) {
+    directoryDelete(probeAbs, true);
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -167,14 +167,31 @@ try { include "native/test_cfc_extends_rust.cfm"; } catch (any e) { writeOutput(
 //   cargo run -- tests/s3/test_s3_functions.cfm
 
 // --- Cross-engine compatibility (Wheels framework gaps) ---
-// These tests exercise CFML behaviors Wheels depends on that are currently
-// gaps in RustCFML but pass on Lucee 7. Registered last so the existing
-// suite runs uninterrupted: the script-tag-body test below triggers a
-// fatal parse error in RustCFML that the surrounding try/catch can't
-// catch (an include parse error escapes the try wrapper).
+// These tests exercise CFML behaviors Wheels depends on that pass on Lucee
+// 7 but are (or were) gaps in RustCFML. Registered last as a cluster;
+// none of them aborts the run on RustCFML, so ordering here is not
+// load-bearing -- each one fails its own assertions in isolation and the
+// run still reaches printSummary().
+//
+//   - local_at_template_scope, metadata_name_value, script_syntax_body:
+//     parse/behavioral gaps that 0.20.x has since closed; kept as
+//     regression tests -- they pass on both engines now.
+//   - expandpath_trailing_slash: behavioral gap, still open on 0.20.2 --
+//     for an EXISTING path, expandPath canonicalizes and drops the trailing
+//     slash, so the Wheels "appDir & '../plugins'" shape fuses into a
+//     malformed path. Fails its assertions but does NOT abort the run.
+//   - forin_member_loop_var: two distinct for-in gaps on 0.20.2, both
+//     non-fatal here. (1) A plain member-path loop var (ctx.item) PARSES
+//     but never iterates -- the body is silently skipped. (2) A `this`-
+//     headed loop var fails to PARSE, but that parse error is CONTAINED
+//     inside a runtime-instantiated fixture CFC (ForInThisLoopFixture),
+//     which degrades to a non-object silently instead of aborting. Both
+//     modes fail their assertions without taking down the run.
 try { include "core/test_local_at_template_scope.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_at_template_scope.cfm | " & e.message & chr(10)); }
 try { include "oop/test_metadata_name_value.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_metadata_name_value.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_script_syntax_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_script_syntax_body.cfm | " & e.message & chr(10)); }
+try { include "functions/test_expandpath_trailing_slash.cfm"; } catch (any e) { writeOutput("ERROR | functions/test_expandpath_trailing_slash.cfm | " & e.message & chr(10)); }
+try { include "core/test_forin_member_loop_var.cfm"; } catch (any e) { writeOutput("ERROR | core/test_forin_member_loop_var.cfm | " & e.message & chr(10)); }
 
 printSummary();
 </cfscript>


### PR DESCRIPTION
Follow-up to #4. Thanks for landing those three in 0.20.2 (`local` at template scope, `getMetadata().name`, script-syntax tag-with-body) — re-running them against the 0.20.2 binary they all pass on both Lucee and RustCFML now, so they stay in as regression markers. Here are two more gaps from the same CFWheels/Wheels framework-load investigation that are still open on 0.20.2.

## What's in the PR

Two new test files, same `tests/<category>/test_<feature>.cfm` convention and `suiteBegin/assert/suiteEnd` harness:

| File | What it tests |
|---|---|
| `tests/functions/test_expandpath_trailing_slash.cfm` | `expandPath()` mirrors a trailing slash present in its input — `expandPath("foo/")` keeps the slash, `expandPath("foo")` doesn't gain one |
| `tests/core/test_forin_member_loop_var.cfm` | CFScript for-in with a non-bare loop variable: a plain struct-member path (`for (ctx.item in arr)`) and a `this`-headed path (`for (this.wheels.folder in arr)`) |

A small fixture CFC (`tests/core/ForInThisLoopFixture.cfc`) carries the `this`-headed loop so its parse error is contained at runtime — see "runner.cfm placement" below.

## Verification — one full `runner.cfm` run on RustCFML 0.20.2

The Wheels-compat cluster, taken straight from a complete run of the committed `runner.cfm` against the 0.20.2 binary:

```
PASS | Core: local scope at template (page) scope | 9/9 passed          # from #4
PASS | OOP: getMetadata().name reflects component identity | 9/9 passed # from #4
PASS | Tags: Script-syntax with body block | 8/8 passed                 # from #4
FAIL | Functions: expandPath trailing-slash preservation | 1/4 passed (3 failed)
FAIL | Core: for-in with a member-path loop variable | 0/4 passed (4 failed)

SUMMARY: 2714/2731 passed across 330 suites
```

The three from #4 are now green; the two new suites are the only new red, and the run completes (no abort). On Lucee 7.0.3+43 both new suites pass 4/4 (8/8 together).

The new failures in detail:

```
FAIL: expandPath preserves a trailing slash present in the input | expected: [/] | got: [d]
FAIL: dir-with-slash + '../' must not collapse into 'dir..'      | expected falsy | got: [true]
FAIL: Wheels shape: expandPath('dir/') & '../plugins' stays traversable ('/../' present) | expected truthy | got: [false]
FAIL: for (struct.member in array): sums every element           | expected: [60] | got: [0]
FAIL: for (struct.member in struct): visits every key            | expected: [3]  | got: [0]
FAIL: for (this.wheels.folder in array): the Wheels Application.cfc shape | expected: [xyz] | got: []
FAIL: `this`-scoped loop var holds the final element after the loop       | expected: [z]   | got: []
```

The one expandPath pass is the symmetry/sanity assertion (`expandPath("foo")` must NOT gain a slash) — it pins the gap down as "preserve", not "add".

## The two gaps in detail

**expandPath trailing slash.** For a path that EXISTS on disk, RustCFML canonicalizes (resolves `..`, resolves symlinks) and drops the trailing slash; for a non-existent path it falls back to a lexical join that keeps it. Wheels' `"../app/"` resolves to a real directory, so it hits the canonicalizing branch. The test creates a real probe dir first so it portably exercises that branch. The `got: [d]` is the last char of the canonicalized `…/rustcfml_probe_expand` — the `/` is gone.

**for-in member-path loop variable.** CFScript for-in allows any assignable expression as the loop variable, not just a bare name. Two distinct modes:
1. A plain struct-member path — `for (ctx.item in arr)` — PARSES but never iterates; the body is silently skipped (sum stays 0, key-join stays empty).
2. A `this`-headed path — `for (this.wheels.folder in arr)` — fails to PARSE (`Expected Semicolon, found In`).

A bare-name loop variable (`for (item in arr)`) already works and is covered by `tests/compat_engine/test_language_controlflow.cfm`, so the gap is specifically the non-bare lvalue forms.

## runner.cfm placement

Registered with the existing Wheels-compat cluster at the end of `tests/runner.cfm`. Unlike #4's script-syntax-tag test, **neither of these aborts the run** on RustCFML:

- The expandPath test is purely behavioral — it fails assertions, doesn't throw.
- The `this`-headed for-in parse error is the same "a parse error in an included file kills the whole suite" class flagged in #4. To keep it from aborting the run, I moved that loop into a fixture CFC instantiated at runtime via `createObject`. There the parse error is contained: the component degrades to a non-object silently, method calls return `""`, the assertions fail cleanly, and the run reaches `printSummary()`. (The plain member-path form in the same file parses fine and exercises mode #1 directly.)

So ordering within the cluster is no longer load-bearing for these two.

## Why these specific tests

Both block Wheels at `public/Application.cfc` load:

- `this.appDir = expandPath("../app/"); this.wheels.pluginDir = this.appDir & "../plugins";` — the dropped slash fuses into the malformed `app../plugins`, and the subsequent `DirectoryList()` throws "No such file or directory", aborting the pseudo-constructor.
- `for (this.wheels.folder in this.wheels.pluginFolders) { ... }` — the exact `this`-headed for-in that fails to parse, degrading Application.cfc at instantiation.

Happy to refine, scope down, or add more cases — just let me know.

— Peter (peter@alurium.com)