### PR TITLE
Make len() coerce scalar values

### DIFF
--- a/crates/cfml-stdlib/src/builtins.rs
+++ b/crates/cfml-stdlib/src/builtins.rs
@@ -857,6 +857,9 @@ fn write_dump(args: Vec<CfmlValue>) -> CfmlResult {
 fn fn_len(args: Vec<CfmlValue>) -> CfmlResult {
     match args.first() {
         Some(CfmlValue::String(s)) => Ok(CfmlValue::Int(s.len() as i64)),
+        Some(CfmlValue::Bool(_)) | Some(CfmlValue::Int(_)) | Some(CfmlValue::Double(_)) => Ok(
+            CfmlValue::Int(args.first().unwrap().as_string().chars().count() as i64),
+        ),
         Some(CfmlValue::Array(a)) => Ok(CfmlValue::Int(a.len() as i64)),
         Some(CfmlValue::Struct(s)) => Ok(CfmlValue::Int(s.len() as i64)),
         Some(CfmlValue::Binary(b)) => Ok(CfmlValue::Int(b.len() as i64)),

--- a/crates/cfml-vm/tests/scalar_len.rs
+++ b/crates/cfml-vm/tests/scalar_len.rs
@@ -1,0 +1,51 @@
+//! Regression coverage for Lucee-style len() coercion of scalar values.
+
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::CfmlVirtualMachine;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+#[test]
+fn len_stringifies_simple_non_string_values() {
+    let mut files = HashMap::new();
+    files.insert(
+        "index.cfm".to_string(),
+        r##"<cfoutput>#len(false)#|#len(true)#|#len(42)#</cfoutput>"##
+            .as_bytes()
+            .to_vec(),
+    );
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+
+    vm.execute().unwrap();
+    assert_eq!("5|4|2", vm.get_output().trim());
+}

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -79,6 +79,7 @@ try { include "stdlib/test_higher_order_functions.cfm"; } catch (any e) { writeO
 try { include "stdlib/test_bitmask_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_bitmask_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_xml_dom_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_xml_dom_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_misc_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_misc_functions.cfm | " & e.message & chr(10)); }
+try { include "stdlib/test_len_scalar_coercion.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_len_scalar_coercion.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_valuelist_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_valuelist_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_callstack.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_callstack.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_precisionevaluate.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_precisionevaluate.cfm | " & e.message & chr(10)); }

--- a/tests/stdlib/test_len_scalar_coercion.cfm
+++ b/tests/stdlib/test_len_scalar_coercion.cfm
@@ -1,0 +1,9 @@
+<cfscript>
+suiteBegin("Len scalar coercion");
+
+assert("len(false) stringifies scalar", len(false), 5);
+assert("len(true) stringifies scalar", len(true), 4);
+assert("len(number) stringifies scalar", len(42), 2);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

This adds Lucee-compatible scalar coercion for `len()`.

Lucee treats simple scalar values as strings for `len()`:

- `len(false)` => `5`
- `len(true)` => `4`
- `len(42)` => `2`

RustCFML previously returned `0` for these scalar values because `len()` only handled strings, arrays, structs, binary values, and query columns.

## Tests

Added a CFML runner regression:

- `tests/stdlib/test_len_scalar_coercion.cfm`

Added a Rust VM regression:

- `crates/cfml-vm/tests/scalar_len.rs`

Local validation:

```sh
cargo run -- tests/runner.cfm
cargo test -p cfml-vm --test scalar_len
cargo test --workspace
```
