### PR TITLE
Preserve nested argument references

### DIFF
--- a/crates/cfml-codegen/src/compiler.rs
+++ b/crates/cfml-codegen/src/compiler.rs
@@ -190,6 +190,7 @@ pub enum BytecodeOp {
     /// TRUE arm (back to body); falling through means the loop has finished.
     ForLoopStep(String, i64, CmpOp, i64, usize),
     Call(usize),
+    CallWithArgSources(usize, Vec<Option<Vec<String>>>),
     Return,
 
     // Collections
@@ -269,6 +270,7 @@ pub enum BytecodeOp {
     // Named function call: like Call but carries argument names for name-to-param mapping
     // (names, arg_count) — names[i] corresponds to the i-th arg on the stack
     CallNamed(Vec<String>, usize),
+    CallNamedWithArgSources(Vec<String>, usize, Vec<Option<Vec<String>>>),
 
     // Explicit super(args) constructor call for a CFC whose parent is a Rust class.
     // Pops arg_count values, looks up the constructor registered under
@@ -371,6 +373,42 @@ impl CfmlCompiler {
         } else {
             None
         }
+    }
+
+    fn argument_write_back_path(expr: &Expression) -> Option<Vec<String>> {
+        fn collect_path(expr: &Expression, path: &mut Vec<String>) -> bool {
+            match expr {
+                Expression::Identifier(ident) => {
+                    path.push(ident.name.clone());
+                    true
+                }
+                Expression::This(_) | Expression::Super(_) => {
+                    path.push("this".to_string());
+                    true
+                }
+                Expression::MemberAccess(access) => {
+                    if collect_path(&access.object, path) {
+                        path.push(access.member.clone());
+                        true
+                    } else {
+                        false
+                    }
+                }
+                Expression::NamedArgument(named) => collect_path(&named.value, path),
+                _ => false,
+            }
+        }
+
+        let mut path = Vec::new();
+        if collect_path(expr, &mut path) {
+            Some(path)
+        } else {
+            None
+        }
+    }
+
+    fn argument_write_back_paths(args: &[Expression]) -> Vec<Option<Vec<String>>> {
+        args.iter().map(Self::argument_write_back_path).collect()
     }
 
     pub fn compile(mut self, ast: Program) -> BytecodeProgram {
@@ -2413,7 +2451,12 @@ impl CfmlCompiler {
                             self.compile_expression(arg, instructions);
                         }
                     }
-                    instructions.push(BytecodeOp::CallNamed(names, call.arguments.len()));
+                    let arg_sources = Self::argument_write_back_paths(&call.arguments);
+                    instructions.push(BytecodeOp::CallNamedWithArgSources(
+                        names,
+                        call.arguments.len(),
+                        arg_sources,
+                    ));
                 } else {
                     // Push function reference first
                     if let Expression::Identifier(ident) = &*call.name {
@@ -2425,7 +2468,11 @@ impl CfmlCompiler {
                     for arg in &call.arguments {
                         self.compile_expression(arg, instructions);
                     }
-                    instructions.push(BytecodeOp::Call(call.arguments.len()));
+                    let arg_sources = Self::argument_write_back_paths(&call.arguments);
+                    instructions.push(BytecodeOp::CallWithArgSources(
+                        call.arguments.len(),
+                        arg_sources,
+                    ));
                 }
             }
             Expression::MethodCall(call) => {

--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -1997,11 +1997,14 @@ impl CfmlVirtualMachine {
                     }
                 }
 
-                BytecodeOp::Call(arg_count) => {
+                BytecodeOp::Call(arg_count) | BytecodeOp::CallWithArgSources(arg_count, _) => {
                     // Identify which local variables are being passed as args
                     // (for pass-by-reference writeback of complex types)
                     // ip was already incremented past this Call op, so use ip-1
-                    let arg_sources = find_arg_sources(&func.instructions, ip - 1, *arg_count);
+                    let arg_sources = match &func.instructions[ip - 1] {
+                        BytecodeOp::CallWithArgSources(_, sources) => sources.clone(),
+                        _ => find_arg_source_paths(&func.instructions, ip - 1, *arg_count),
+                    };
 
                     let mut args = Vec::with_capacity(*arg_count);
                     for _ in 0..*arg_count {
@@ -2082,9 +2085,13 @@ impl CfmlVirtualMachine {
                                     for (idx_str, modified_val) in ref_wb {
                                         if let Ok(param_idx) = idx_str.parse::<usize>() {
                                             if param_idx < arg_sources.len() {
-                                                if let Some(ref source_var) = arg_sources[param_idx]
+                                                if let Some(ref source_path) = arg_sources[param_idx]
                                                 {
-                                                    locals.insert(source_var.clone(), modified_val);
+                                                    self.write_arg_ref_back(
+                                                        source_path,
+                                                        modified_val,
+                                                        &mut locals,
+                                                    );
                                                 }
                                             }
                                         }
@@ -2118,11 +2125,14 @@ impl CfmlVirtualMachine {
                     }
                 }
 
-                BytecodeOp::CallNamed(names, arg_count) => {
+                BytecodeOp::CallNamed(names, arg_count)
+                | BytecodeOp::CallNamedWithArgSources(names, arg_count, _) => {
                     // Identify arg sources for pass-by-reference writeback
                     // ip was already incremented past this op, so use ip-1
-                    let named_arg_sources =
-                        find_arg_sources(&func.instructions, ip - 1, *arg_count);
+                    let named_arg_sources = match &func.instructions[ip - 1] {
+                        BytecodeOp::CallNamedWithArgSources(_, _, sources) => sources.clone(),
+                        _ => find_arg_source_paths(&func.instructions, ip - 1, *arg_count),
+                    };
 
                     let mut named_values = Vec::with_capacity(*arg_count);
                     for _ in 0..*arg_count {
@@ -2250,12 +2260,13 @@ impl CfmlVirtualMachine {
                                                     };
                                                     if matches && call_idx < named_arg_sources.len()
                                                     {
-                                                        if let Some(ref source_var) =
+                                                        if let Some(ref source_path) =
                                                             named_arg_sources[call_idx]
                                                         {
-                                                            locals.insert(
-                                                                source_var.clone(),
+                                                            self.write_arg_ref_back(
+                                                                source_path,
                                                                 modified_val.clone(),
+                                                                &mut locals,
                                                             );
                                                         }
                                                         break;
@@ -2449,6 +2460,7 @@ impl CfmlVirtualMachine {
                     let index = stack.pop().unwrap_or(CfmlValue::Null);
                     let mut collection = stack.pop().unwrap_or(CfmlValue::Null);
                     let value = stack.pop().unwrap_or(CfmlValue::Null);
+                    let old_collection = collection.clone();
                     match &mut collection {
                         CfmlValue::Array(arr) => {
                             let idx = match &index {
@@ -2490,6 +2502,11 @@ impl CfmlVirtualMachine {
                             Arc::make_mut(s).insert(key, value);
                         }
                         _ => {}
+                    }
+                    for (old_struct, new_struct) in Self::collect_struct_alias_replacements(&old_collection, &collection) {
+                        if !Arc::ptr_eq(&old_struct, &new_struct) {
+                            self.replace_struct_aliases(&old_struct, &new_struct, &mut locals);
+                        }
                     }
                     stack.push(collection);
                 }
@@ -2660,6 +2677,7 @@ impl CfmlVirtualMachine {
                 BytecodeOp::SetProperty(name) => {
                     if let Some(value) = stack.pop() {
                         if let Some(mut obj) = stack.pop() {
+                            let old_obj = obj.clone();
                             // CFC with a Rust-backed parent: route writes the
                             // native side recognises before touching the CFC
                             // struct, so Rust state stays first-class. The
@@ -2716,6 +2734,11 @@ impl CfmlVirtualMachine {
                                 }
                             }
                             obj.set(name.clone(), value);
+                            for (old_struct, new_struct) in Self::collect_struct_alias_replacements(&old_obj, &obj) {
+                                if !Arc::ptr_eq(&old_struct, &new_struct) {
+                                    self.replace_struct_aliases(&old_struct, &new_struct, &mut locals);
+                                }
+                            }
                             stack.push(obj);
                         }
                     }
@@ -7583,6 +7606,211 @@ impl CfmlVirtualMachine {
         }
     }
 
+    fn get_path_value(root: &CfmlValue, path: &[String]) -> Option<CfmlValue> {
+        if path.is_empty() {
+            return Some(root.clone());
+        }
+
+        match root {
+            CfmlValue::Struct(s) => {
+                let key = &path[0];
+                let next = s
+                    .get(key)
+                    .or_else(|| s.get(&key.to_uppercase()))
+                    .or_else(|| s.get(&key.to_lowercase()))
+                    .or_else(|| {
+                        let key_lower = key.to_lowercase();
+                        s.iter()
+                            .find(|(candidate, _)| candidate.to_lowercase() == key_lower)
+                            .map(|(_, value)| value)
+                    })?;
+                Self::get_path_value(next, &path[1..])
+            }
+            CfmlValue::Array(a) | CfmlValue::QueryColumn(a) => {
+                let index = path[0].parse::<usize>().ok()?.saturating_sub(1);
+                let next = a.get(index)?;
+                Self::get_path_value(next, &path[1..])
+            }
+            _ => None,
+        }
+    }
+
+    fn collect_struct_alias_replacements(
+        old_value: &CfmlValue,
+        new_value: &CfmlValue,
+    ) -> Vec<(
+        Arc<IndexMap<String, CfmlValue>>,
+        Arc<IndexMap<String, CfmlValue>>,
+    )> {
+        let mut replacements = Vec::new();
+        let mut visited = std::collections::HashSet::new();
+        Self::collect_struct_alias_replacements_inner(
+            old_value,
+            new_value,
+            &mut replacements,
+            &mut visited,
+        );
+        replacements
+    }
+
+    fn collect_struct_alias_replacements_inner(
+        old_value: &CfmlValue,
+        new_value: &CfmlValue,
+        replacements: &mut Vec<(
+            Arc<IndexMap<String, CfmlValue>>,
+            Arc<IndexMap<String, CfmlValue>>,
+        )>,
+        visited: &mut std::collections::HashSet<(usize, usize)>,
+    ) {
+        match (old_value, new_value) {
+            (CfmlValue::Struct(old_struct), CfmlValue::Struct(new_struct)) => {
+                let pair = (Arc::as_ptr(old_struct) as usize, Arc::as_ptr(new_struct) as usize);
+                if !visited.insert(pair) {
+                    return;
+                }
+                replacements.push((old_struct.clone(), new_struct.clone()));
+
+                for (key, old_child) in old_struct.iter() {
+                    if let Some(new_child) = new_struct.get(key) {
+                        Self::collect_struct_alias_replacements_inner(
+                            old_child,
+                            new_child,
+                            replacements,
+                            visited,
+                        );
+                    }
+                }
+            }
+            (CfmlValue::Array(old_array), CfmlValue::Array(new_array))
+            | (CfmlValue::QueryColumn(old_array), CfmlValue::QueryColumn(new_array)) => {
+                for (old_child, new_child) in old_array.iter().zip(new_array.iter()) {
+                    Self::collect_struct_alias_replacements_inner(
+                        old_child,
+                        new_child,
+                        replacements,
+                        visited,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn replace_struct_aliases(
+        &mut self,
+        old_struct: &Arc<IndexMap<String, CfmlValue>>,
+        new_struct: &Arc<IndexMap<String, CfmlValue>>,
+        locals: &mut IndexMap<String, CfmlValue>,
+    ) {
+        let mut visited = std::collections::HashSet::new();
+        for value in locals.values_mut() {
+            Self::replace_struct_aliases_in_value(value, old_struct, new_struct, &mut visited);
+        }
+        for value in self.globals.values_mut() {
+            Self::replace_struct_aliases_in_value(value, old_struct, new_struct, &mut visited);
+        }
+        for value in self.request_scope.values_mut() {
+            Self::replace_struct_aliases_in_value(value, old_struct, new_struct, &mut visited);
+        }
+        if let Some(ref app_scope) = self.application_scope {
+            if let Ok(mut scope) = app_scope.lock() {
+                for value in scope.values_mut() {
+                    Self::replace_struct_aliases_in_value(
+                        value,
+                        old_struct,
+                        new_struct,
+                        &mut visited,
+                    );
+                }
+            }
+        }
+    }
+
+    fn replace_struct_aliases_in_value(
+        value: &mut CfmlValue,
+        old_struct: &Arc<IndexMap<String, CfmlValue>>,
+        new_struct: &Arc<IndexMap<String, CfmlValue>>,
+        visited: &mut std::collections::HashSet<usize>,
+    ) -> bool {
+        match value {
+            CfmlValue::Struct(s) => {
+                if Arc::ptr_eq(s, old_struct) {
+                    *value = CfmlValue::Struct(new_struct.clone());
+                    return true;
+                }
+
+                let ptr = Arc::as_ptr(s) as usize;
+                if !visited.insert(ptr) {
+                    return false;
+                }
+
+                let mut changed_children = Vec::new();
+                for (key, child) in s.iter() {
+                    let mut child_value = child.clone();
+                    if Self::replace_struct_aliases_in_value(
+                        &mut child_value,
+                        old_struct,
+                        new_struct,
+                        visited,
+                    ) {
+                        changed_children.push((key.clone(), child_value));
+                    }
+                }
+
+                if changed_children.is_empty() {
+                    return false;
+                }
+
+                let map = Arc::make_mut(s);
+                for (key, child_value) in changed_children {
+                    map.insert(key, child_value);
+                }
+                true
+            }
+            CfmlValue::Array(a) | CfmlValue::QueryColumn(a) => {
+                let ptr = Arc::as_ptr(a) as usize;
+                if !visited.insert(ptr) {
+                    return false;
+                }
+
+                let mut changed_children = Vec::new();
+                for (index, child) in a.iter().enumerate() {
+                    let mut child_value = child.clone();
+                    if Self::replace_struct_aliases_in_value(
+                        &mut child_value,
+                        old_struct,
+                        new_struct,
+                        visited,
+                    ) {
+                        changed_children.push((index, child_value));
+                    }
+                }
+
+                if changed_children.is_empty() {
+                    return false;
+                }
+
+                let array = Arc::make_mut(a);
+                for (index, child_value) in changed_children {
+                    array[index] = child_value;
+                }
+                true
+            }
+            CfmlValue::Query(q) => {
+                let mut changed = false;
+                for row in &mut q.rows {
+                    for child in row.values_mut() {
+                        changed = Self::replace_struct_aliases_in_value(
+                            child, old_struct, new_struct, visited,
+                        ) || changed;
+                    }
+                }
+                changed
+            }
+            _ => false,
+        }
+    }
+
     /// Load a variable by name, checking locals, globals, and special scopes (application, request, local/variables).
     fn scope_aware_load(
         &self,
@@ -7732,6 +7960,47 @@ impl CfmlVirtualMachine {
             self.globals.insert(name.to_string(), val);
         } else {
             locals.insert(name.to_string(), val);
+        }
+    }
+
+    fn write_arg_ref_back(
+        &mut self,
+        source_path: &[String],
+        modified_val: CfmlValue,
+        locals: &mut IndexMap<String, CfmlValue>,
+    ) {
+        if source_path.is_empty() {
+            return;
+        }
+
+        let root_name = &source_path[0];
+        if source_path.len() == 1 {
+            let alias_replacements = self
+                .scope_aware_load(root_name, locals)
+                .map(|old| Self::collect_struct_alias_replacements(&old, &modified_val))
+                .unwrap_or_default();
+            self.scope_aware_store(root_name, modified_val, locals);
+            for (old_struct, new_struct) in alias_replacements {
+                if !Arc::ptr_eq(&old_struct, &new_struct) {
+                    self.replace_struct_aliases(&old_struct, &new_struct, locals);
+                }
+            }
+            return;
+        }
+
+        if let Some(mut root_obj) = self.scope_aware_load(root_name, locals) {
+            let old_value = Self::get_path_value(&root_obj, &source_path[1..]);
+            let alias_replacements = old_value
+                .as_ref()
+                .map(|old| Self::collect_struct_alias_replacements(old, &modified_val))
+                .unwrap_or_default();
+            Self::deep_set(&mut root_obj, &source_path[1..], modified_val);
+            self.scope_aware_store(root_name, root_obj, locals);
+            for (old_struct, new_struct) in alias_replacements {
+                if !Arc::ptr_eq(&old_struct, &new_struct) {
+                    self.replace_struct_aliases(&old_struct, &new_struct, locals);
+                }
+            }
         }
     }
 
@@ -11655,8 +11924,8 @@ fn stack_effect(op: &BytecodeOp) -> (usize, usize) {
         BytecodeOp::ForLoopStep(_, _, _, _, _) => (0, 0),
         BytecodeOp::Return => (0, 1),
         // Call: pops func + N args, pushes 1 result
-        BytecodeOp::Call(n) => (1, n + 1),
-        BytecodeOp::CallNamed(_, n) => (1, n + 1),
+        BytecodeOp::Call(n) | BytecodeOp::CallWithArgSources(n, _) => (1, n + 1),
+        BytecodeOp::CallNamed(_, n) | BytecodeOp::CallNamedWithArgSources(_, n, _) => (1, n + 1),
         BytecodeOp::CallSpread => (1, 3), // func, array, count — approximate
         // Collections
         BytecodeOp::BuildArray(n) => (1, *n),
@@ -11734,6 +12003,17 @@ fn find_arg_sources(ops: &[BytecodeOp], call_ip: usize, arg_count: usize) -> Vec
         depth += pops as i32;
     }
     sources
+}
+
+fn find_arg_source_paths(
+    ops: &[BytecodeOp],
+    call_ip: usize,
+    arg_count: usize,
+) -> Vec<Option<Vec<String>>> {
+    find_arg_sources(ops, call_ip, arg_count)
+        .into_iter()
+        .map(|source| source.map(|name| vec![name]))
+        .collect()
 }
 
 // ---- precisionEvaluate: recursive-descent parser operating on rust_decimal::Decimal ----

--- a/crates/cfml-vm/tests/argument_reference.rs
+++ b/crates/cfml-vm/tests/argument_reference.rs
@@ -1,0 +1,127 @@
+//! Regression coverage for complex arguments passed through property paths.
+
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::dynamic::CfmlValue;
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::CfmlVirtualMachine;
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+fn run_page(source: &str, application_scope: Option<IndexMap<String, CfmlValue>>) -> String {
+    let mut files = HashMap::new();
+    files.insert("index.cfm".to_string(), source.as_bytes().to_vec());
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    vm.application_scope = application_scope.map(|scope| Arc::new(Mutex::new(scope)));
+
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+
+    vm.execute().unwrap();
+    vm.get_output()
+}
+
+#[test]
+fn nested_struct_argument_mutation_writes_back_to_caller_path() {
+    let output = run_page(
+        r##"
+<cffunction name="mutate">
+    <cfargument name="target" />
+    <cfset arguments.target.foo = "bar" />
+</cffunction>
+<cfset holder = { child = {} } />
+<cfset mutate(holder.child) />
+<cfoutput>#holder.child.foo ?: "missing"#</cfoutput>
+"##,
+        None,
+    );
+
+    assert_eq!("bar", output.trim());
+}
+
+#[test]
+fn application_scope_argument_mutation_writes_back_to_nested_scope_path() {
+    let output = run_page(
+        r##"
+<cffunction name="mutate">
+    <cfargument name="target" />
+    <cfset arguments.target.foo = "bar" />
+</cffunction>
+<cfset application.service = {} />
+<cfset mutate(application.service) />
+<cfoutput>#application.service.foo ?: "missing"#</cfoutput>
+"##,
+        Some(IndexMap::new()),
+    );
+
+    assert_eq!("bar", output.trim());
+}
+
+#[test]
+fn assigned_struct_reference_observes_later_nested_mutation() {
+    let output = run_page(
+        r##"
+<cfset original = { child = { value = "before" } } />
+<cfset alias = original.child />
+<cfset original.child.value = "after" />
+<cfoutput>#alias.value#</cfoutput>
+"##,
+        None,
+    );
+
+    assert_eq!("after", output.trim());
+}
+
+#[test]
+fn nested_aliases_survive_complex_argument_writeback() {
+    let output = run_page(
+        r##"
+<cffunction name="enrich">
+    <cfargument name="schema" />
+    <cfset arguments.schema.route.fields.profiles.generated = "yes" />
+</cffunction>
+
+<cfset input = {
+    route = {
+        fields = {
+            profiles = {}
+        }
+    }
+} />
+<cfset out = {} />
+<cfset out.route = input.route />
+<cfset enrich(input) />
+<cfoutput>#input.route.fields.profiles.generated ?: "missing"#|#out.route.fields.profiles.generated ?: "missing"#</cfoutput>
+"##,
+        None,
+    );
+
+    assert_eq!("yes|yes", output.trim());
+}

--- a/tests/core/test_argument_reference_nested.cfm
+++ b/tests/core/test_argument_reference_nested.cfm
@@ -1,0 +1,39 @@
+<cfscript>
+suiteBegin("Nested argument references");
+
+function mutateNestedTarget(required any target) {
+    arguments.target.foo = "bar";
+}
+
+holder = { child = {} };
+mutateNestedTarget(holder.child);
+assert("nested struct argument writes back to caller path", holder.child.foo ?: "missing", "bar");
+
+application.service = {};
+mutateNestedTarget(application.service);
+assert("application scope argument writes back to nested scope path", application.service.foo ?: "missing", "bar");
+
+original = { child = { value = "before" } };
+alias = original.child;
+original.child.value = "after";
+assert("assigned struct reference observes later nested mutation", alias.value, "after");
+
+function enrichSchema(required any schema) {
+    arguments.schema.route.fields.profiles.generated = "yes";
+}
+
+input = {
+    route = {
+        fields = {
+            profiles = {}
+        }
+    }
+};
+out = {};
+out.route = input.route;
+enrichSchema(input);
+assert("deep argument writeback updates original", input.route.fields.profiles.generated ?: "missing", "yes");
+assert("deep argument writeback updates alias", out.route.fields.profiles.generated ?: "missing", "yes");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -22,6 +22,7 @@ try { include "core/test_error_handling.cfm"; } catch (any e) { writeOutput("ERR
 try { include "core/test_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_functions.cfm | " & e.message & chr(10)); }
 try { include "core/test_arrow_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_arrow_functions.cfm | " & e.message & chr(10)); }
 try { include "core/test_arguments_writeback.cfm"; } catch (any e) { writeOutput("ERROR | core/test_arguments_writeback.cfm | " & e.message & chr(10)); }
+try { include "core/test_argument_reference_nested.cfm"; } catch (any e) { writeOutput("ERROR | core/test_argument_reference_nested.cfm | " & e.message & chr(10)); }
 try { include "core/test_language_features.cfm"; } catch (any e) { writeOutput("ERROR | core/test_language_features.cfm | " & e.message & chr(10)); }
 try { include "core/test_scopes.cfm"; } catch (any e) { writeOutput("ERROR | core/test_scopes.cfm | " & e.message & chr(10)); }
 try { include "core/test_server_scope.cfm"; } catch (any e) { writeOutput("ERROR | core/test_server_scope.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner regression for nested argument references.
- Preserves writeback when an argument aliases a nested caller path.
- Covers the same behavior with a Rust VM regression test.

## CFML repro
- tests/core/test_argument_reference_nested.cfm

## Tests
- cargo test -p cfml-vm --test argument_reference