### PR TITLE
Fix cfloop array item index

### DIFF
--- a/crates/cfml-compiler/src/tag_parser.rs
+++ b/crates/cfml-compiler/src/tag_parser.rs
@@ -1834,10 +1834,40 @@ fn parse_cfloop_tag(
     } else if let Some(condition) = attrs.get("condition") {
         let condition = strip_hashes(condition);
         (format!("while ({}) {{\n", condition), consumed)
-    } else if let (Some(array), Some(index)) = (attrs.get("array"), attrs.get("index")) {
+    } else if let Some(array) = attrs.get("array") {
         let array = strip_hashes(array);
-        let index = strip_hashes(index);
-        (format!("for (var {} in {}) {{\n", index, array), consumed)
+        if let (Some(item), Some(index)) = (attrs.get("item"), attrs.get("index")) {
+            let item = strip_hashes(item);
+            let index = strip_hashes(index);
+            let array_var = format!("__cfloop_array_{}", consumed);
+            let index_var = format!("__cfloop_index_{}", consumed);
+            (
+                format!(
+                    "var {} = {};\nfor (var {} = 1; {} <= arrayLen({}); {} = {} + 1) {{\n{} = {};\n{} = {}[{}];\n",
+                    array_var,
+                    array,
+                    index_var,
+                    index_var,
+                    array_var,
+                    index_var,
+                    index_var,
+                    index,
+                    index_var,
+                    item,
+                    array_var,
+                    index_var
+                ),
+                consumed,
+            )
+        } else if let Some(item) = attrs.get("item").or_else(|| attrs.get("index")) {
+            let item = strip_hashes(item);
+            (format!("for (var {} in {}) {{\n", item, array), consumed)
+        } else {
+            (
+                "throw(\"cfloop array requires an item or index attribute.\");\n".to_string(),
+                consumed,
+            )
+        }
     } else if let (Some(list), Some(index)) = (attrs.get("list"), attrs.get("index")) {
         // If the list contains #expr#, strip hashes to get the expression.
         // Otherwise treat it as a string literal and quote it.

--- a/crates/cfml-vm/tests/cfloop_array_index.rs
+++ b/crates/cfml-vm/tests/cfloop_array_index.rs
@@ -1,0 +1,59 @@
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::CfmlVirtualMachine;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+#[test]
+fn cfloop_array_with_item_and_index_sets_one_based_position() {
+    let mut files = HashMap::new();
+    files.insert(
+        "index.cfm".to_string(),
+        r##"
+<cfset values = ["alpha", "beta"] />
+<cfset result = "" />
+<cfloop array="#values#" item="value" index="i">
+    <cfset result = result & i & ":" & value & ";" />
+</cfloop>
+<cfoutput>#result#</cfoutput>
+"##
+        .as_bytes()
+        .to_vec(),
+    );
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+
+    vm.execute().unwrap();
+    assert_eq!(
+        "1:alpha;2:beta;",
+        vm.get_output().split_whitespace().collect::<String>()
+    );
+}

--- a/tests/core/test_cfloop_array_item_index.cfm
+++ b/tests/core/test_cfloop_array_item_index.cfm
@@ -1,0 +1,14 @@
+<cfscript>
+suiteBegin("CFLoop array item and index");
+
+values = ["alpha", "beta"];
+arrayLoopResult = "";
+</cfscript>
+<cfloop array="#values#" item="value" index="i">
+    <cfset arrayLoopResult = arrayLoopResult & i & ":" & value & ";" />
+</cfloop>
+<cfscript>
+assert("array cfloop item and one-based index", arrayLoopResult, "1:alpha;2:beta;");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -18,6 +18,7 @@ try { include "core/test_struct_method_sequential.cfm"; } catch (any e) { writeO
 try { include "core/test_include_scope_capture.cfm"; } catch (any e) { writeOutput("ERROR | core/test_include_scope_capture.cfm | " & e.message & chr(10)); }
 try { include "core/test_operators.cfm"; } catch (any e) { writeOutput("ERROR | core/test_operators.cfm | " & e.message & chr(10)); }
 try { include "core/test_control_flow.cfm"; } catch (any e) { writeOutput("ERROR | core/test_control_flow.cfm | " & e.message & chr(10)); }
+try { include "core/test_cfloop_array_item_index.cfm"; } catch (any e) { writeOutput("ERROR | core/test_cfloop_array_item_index.cfm | " & e.message & chr(10)); }
 try { include "core/test_error_handling.cfm"; } catch (any e) { writeOutput("ERROR | core/test_error_handling.cfm | " & e.message & chr(10)); }
 try { include "core/test_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_functions.cfm | " & e.message & chr(10)); }
 try { include "core/test_arrow_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_arrow_functions.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner regression for cfloop over arrays with both item and index.
- Makes the generated loop expose the item value and one-based index correctly.
- Covers the behavior with a Rust VM regression test.

## CFML repro
- tests/core/test_cfloop_array_item_index.cfm

## Tests
- cargo test -p cfml-vm --test cfloop_array_index