### PR TITLE
Support cfloop collection item index

### DIFF
--- a/crates/cfml-compiler/src/tag_parser.rs
+++ b/crates/cfml-compiler/src/tag_parser.rs
@@ -397,7 +397,7 @@ fn parse_cf_tag(chars: &[char], start: usize, len: usize, imports: &mut std::col
             ("} else {\n".to_string(), tag_end - start)
         }
         "cfloop" => {
-            parse_cfloop_tag(&attrs, tag_end - start)
+            parse_cfloop_tag(&attrs, chars, tag_end, len, imports, tag_end - start)
         }
         "cfscript" => {
             // Everything between <cfscript> and </cfscript> is raw script
@@ -1812,6 +1812,10 @@ fn scan_cfargument_tags(chars: &[char], start: usize, len: usize) -> Vec<String>
 
 fn parse_cfloop_tag(
     attrs: &std::collections::HashMap<String, String>,
+    chars: &[char],
+    tag_end: usize,
+    len: usize,
+    imports: &mut std::collections::HashMap<String, String>,
     consumed: usize,
 ) -> (String, usize) {
     // Different loop types based on attributes
@@ -1875,15 +1879,49 @@ fn parse_cfloop_tag(
         }
     } else if let Some(collection) = attrs.get("collection") {
         let collection = strip_hashes(collection);
-        let item = attrs.get("item").cloned().unwrap_or("item".to_string());
-        let key = attrs.get("key");
+        let item = attrs.get("item").map(|v| strip_hashes(v));
+        let key = attrs
+            .get("key")
+            .or_else(|| attrs.get("index"))
+            .map(|v| strip_hashes(v));
         if let Some(key) = key {
+            if let Some(item) = item {
+                if let Some(body_start) = find_closing_tag(chars, tag_end, len, "cfloop") {
+                    let body_source: String = chars[tag_end..body_start].iter().collect();
+                    let body_script = tags_to_script_impl(&body_source, imports);
+                    let close_end = find_tag_end(chars, body_start, len);
+                    (
+                        format!(
+                            "for (var {} in structKeyArray({})) {{ var {} = {}[{}];\n{}\n{}[{}] = {};\n}}\n",
+                            key, collection, item, collection, key, body_script, collection, key, item
+                        ),
+                        close_end - (tag_end - consumed),
+                    )
+                } else {
+                    (
+                        format!(
+                            "for (var {} in structKeyArray({})) {{ var {} = {}[{}];\n",
+                            key, collection, item, collection, key
+                        ),
+                        consumed,
+                    )
+                }
+            } else {
+                (
+                    format!("for (var {} in structKeyArray({})) {{\n", key, collection),
+                    consumed,
+                )
+            }
+        } else if let Some(item) = item {
             (
-                format!("for (var {} in structKeyArray({})) {{ var {} = {}[{}];\n", key, collection, item, collection, key),
+                format!("for (var {} in structKeyArray({})) {{\n", item, collection),
                 consumed,
             )
         } else {
-            (format!("for (var {} in {}) {{\n", item, collection), consumed)
+            (
+                "throw(\"cfloop collection requires an item, index, or key attribute.\");\n".to_string(),
+                consumed,
+            )
         }
     } else {
         // Infinite loop? Just use while(true)
@@ -2566,5 +2604,22 @@ mod tests {
         let input = r#"<cfloop from="1" to="10" index="i">body</cfloop>"#;
         let result = tags_to_script(input);
         assert!(result.contains("for (var i = 1; i <= 10; i = i + 1)"));
+    }
+
+    #[test]
+    fn test_cfloop_collection_sets_item_and_index() {
+        let input =
+            r##"<cfloop collection="#tables#" item="table" index="table_key">body</cfloop>"##;
+        let result = tags_to_script(input);
+        assert!(result.contains("for (var table_key in structKeyArray(tables))"));
+        assert!(result.contains("var table = tables[table_key];"));
+        assert!(result.contains("tables[table_key] = table;"));
+    }
+
+    #[test]
+    fn test_cfloop_collection_item_only_iterates_keys() {
+        let input = r##"<cfloop collection="#tables#" item="table_name">body</cfloop>"##;
+        let result = tags_to_script(input);
+        assert!(result.contains("for (var table_name in structKeyArray(tables))"));
     }
 }

--- a/crates/cfml-vm/tests/cfloop_collection.rs
+++ b/crates/cfml-vm/tests/cfloop_collection.rs
@@ -1,0 +1,88 @@
+//! Regression coverage for Lucee-style cfloop collection item/index behavior.
+
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::CfmlVirtualMachine;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+fn run_page(source: &str) -> String {
+    let mut files = HashMap::new();
+    files.insert("index.cfm".to_string(), source.as_bytes().to_vec());
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+
+    vm.execute().unwrap();
+    vm.get_output()
+}
+
+#[test]
+fn collection_loop_with_item_and_index_exposes_value_and_key() {
+    let output = run_page(
+        r##"
+<cfset tables = {
+    route = {
+        fields = {
+            profiles = {}
+        }
+    }
+} />
+<cfloop collection="#tables#" item="table" index="tableName">
+    <cfset table.visited = tableName />
+</cfloop>
+<cfoutput>#tables.route.visited ?: "missing"#</cfoutput>
+"##,
+    );
+
+    assert_eq!("route", output.trim());
+}
+
+#[test]
+fn collection_loop_item_mutation_writes_back_to_collection() {
+    let output = run_page(
+        r##"
+<cfset schema = {
+    route = {
+        fields = {
+            profiles = {}
+        }
+    }
+} />
+<cfloop collection="#schema.route.fields#" item="field" index="fieldName">
+    <cfset field.generated = fieldName />
+</cfloop>
+<cfoutput>#schema.route.fields.profiles.generated ?: "missing"#</cfoutput>
+"##,
+    );
+
+    assert_eq!("profiles", output.trim());
+}

--- a/tests/core/test_cfloop_collection_item_index.cfm
+++ b/tests/core/test_cfloop_collection_item_index.cfm
@@ -1,0 +1,33 @@
+<cfscript>
+suiteBegin("CFLoop collection item and index");
+
+tables = {
+    route = {
+        fields = {
+            profiles = {}
+        }
+    }
+};
+</cfscript>
+<cfloop collection="#tables#" item="table" index="tableName">
+    <cfset table.visited = tableName />
+</cfloop>
+<cfscript>
+assert("collection cfloop exposes item value and key index", tables.route.visited ?: "missing", "route");
+
+schema = {
+    route = {
+        fields = {
+            profiles = {}
+        }
+    }
+};
+</cfscript>
+<cfloop collection="#schema.route.fields#" item="field" index="fieldName">
+    <cfset field.generated = fieldName />
+</cfloop>
+<cfscript>
+assert("collection cfloop item mutation writes back", schema.route.fields.profiles.generated ?: "missing", "profiles");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -18,6 +18,7 @@ try { include "core/test_struct_method_sequential.cfm"; } catch (any e) { writeO
 try { include "core/test_include_scope_capture.cfm"; } catch (any e) { writeOutput("ERROR | core/test_include_scope_capture.cfm | " & e.message & chr(10)); }
 try { include "core/test_operators.cfm"; } catch (any e) { writeOutput("ERROR | core/test_operators.cfm | " & e.message & chr(10)); }
 try { include "core/test_control_flow.cfm"; } catch (any e) { writeOutput("ERROR | core/test_control_flow.cfm | " & e.message & chr(10)); }
+try { include "core/test_cfloop_collection_item_index.cfm"; } catch (any e) { writeOutput("ERROR | core/test_cfloop_collection_item_index.cfm | " & e.message & chr(10)); }
 try { include "core/test_error_handling.cfm"; } catch (any e) { writeOutput("ERROR | core/test_error_handling.cfm | " & e.message & chr(10)); }
 try { include "core/test_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_functions.cfm | " & e.message & chr(10)); }
 try { include "core/test_arrow_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_arrow_functions.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner regression for collection loops using both item and index.
- Makes collection loops expose the item value and key/index consistently with Lucee behavior.
- Covers the behavior with a Rust VM regression test.

## CFML repro
- tests/core/test_cfloop_collection_item_index.cfm

## Tests
- cargo test -p cfml-vm --test cfloop_collection