### PR TITLE
Support negative cfloop steps

### DIFF
--- a/crates/cfml-compiler/src/tag_parser.rs
+++ b/crates/cfml-compiler/src/tag_parser.rs
@@ -1824,10 +1824,15 @@ fn parse_cfloop_tag(
         let from = strip_hashes(from);
         let to = strip_hashes(to);
         let step = strip_hashes(&step);
+        let comparison = if step.trim_start().starts_with('-') {
+            ">="
+        } else {
+            "<="
+        };
         (
             format!(
-                "for (var {} = {}; {} <= {}; {} = {} + {}) {{\n",
-                index, from, index, to, index, index, step
+                "for (var {} = {}; {} {} {}; {} = {} + {}) {{\n",
+                index, from, index, comparison, to, index, index, step
             ),
             consumed,
         )

--- a/crates/cfml-vm/tests/cfloop_negative_step.rs
+++ b/crates/cfml-vm/tests/cfloop_negative_step.rs
@@ -1,0 +1,59 @@
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::CfmlVirtualMachine;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+#[test]
+fn counted_cfloop_supports_negative_step() {
+    let mut files = HashMap::new();
+    files.insert(
+        "index.cfm".to_string(),
+        r##"
+<cfset descending = "" />
+<cfloop from="3" to="1" step="-1" index="i">
+    <cfset descending = descending & i />
+</cfloop>
+<cfset ascending = "" />
+<cfloop from="1" to="3" index="i">
+    <cfset ascending = ascending & i />
+</cfloop>
+<cfoutput>#descending#|#ascending#</cfoutput>
+"##
+        .as_bytes()
+        .to_vec(),
+    );
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+
+    vm.execute().unwrap();
+    assert_eq!("321|123", vm.get_output().trim());
+}

--- a/tests/core/test_cfloop_negative_step.cfm
+++ b/tests/core/test_cfloop_negative_step.cfm
@@ -1,0 +1,19 @@
+<cfscript>
+suiteBegin("CFLoop negative step");
+
+descending = "";
+</cfscript>
+<cfloop from="3" to="1" step="-1" index="i">
+    <cfset descending = descending & i />
+</cfloop>
+<cfscript>
+ascending = "";
+</cfscript>
+<cfloop from="1" to="3" index="i">
+    <cfset ascending = ascending & i />
+</cfloop>
+<cfscript>
+assert("counted cfloop supports negative step", descending & "|" & ascending, "321|123");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -18,6 +18,7 @@ try { include "core/test_struct_method_sequential.cfm"; } catch (any e) { writeO
 try { include "core/test_include_scope_capture.cfm"; } catch (any e) { writeOutput("ERROR | core/test_include_scope_capture.cfm | " & e.message & chr(10)); }
 try { include "core/test_operators.cfm"; } catch (any e) { writeOutput("ERROR | core/test_operators.cfm | " & e.message & chr(10)); }
 try { include "core/test_control_flow.cfm"; } catch (any e) { writeOutput("ERROR | core/test_control_flow.cfm | " & e.message & chr(10)); }
+try { include "core/test_cfloop_negative_step.cfm"; } catch (any e) { writeOutput("ERROR | core/test_cfloop_negative_step.cfm | " & e.message & chr(10)); }
 try { include "core/test_error_handling.cfm"; } catch (any e) { writeOutput("ERROR | core/test_error_handling.cfm | " & e.message & chr(10)); }
 try { include "core/test_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_functions.cfm | " & e.message & chr(10)); }
 try { include "core/test_arrow_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_arrow_functions.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner regression for counted cfloop with a negative step.
- Updates counted loop translation so descending ranges execute correctly.
- Covers the behavior with a Rust VM regression test.

## CFML repro
- tests/core/test_cfloop_negative_step.cfm

## Tests
- cargo test -p cfml-vm --test cfloop_negative_step