### PR TITLE
Fix string member regex argument order

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -8438,7 +8438,8 @@ impl CfmlVirtualMachine {
             // object (which the member was called on) becomes the second arg.
             if matches!(object, CfmlValue::String(_)) && args.len() >= 2 {
                 match name {
-                    "find" | "findNoCase" | "insert" => {
+                    "find" | "findNoCase" | "insert" | "reFind" | "reFindNoCase"
+                    | "reMatch" | "reMatchNoCase" => {
                         args.swap(0, 1);
                     }
                     _ => {}

--- a/crates/cfml-vm/tests/string_member_regex.rs
+++ b/crates/cfml-vm/tests/string_member_regex.rs
@@ -1,0 +1,55 @@
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::CfmlVirtualMachine;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+#[test]
+fn string_member_regex_functions_pass_pattern_before_receiver() {
+    let mut files = HashMap::new();
+    files.insert(
+        "index.cfm".to_string(),
+        r##"
+<cfset route = "/sysadmin/routes/[route_id]" />
+<cfoutput>#route.reFind("\[\w+\]")#|#arrayToList(route.reMatch("\[\w+\]"))#</cfoutput>
+"##
+        .as_bytes()
+        .to_vec(),
+    );
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+
+    vm.execute().unwrap();
+    assert_eq!(
+        "18|[route_id]",
+        vm.get_output().split_whitespace().collect::<String>()
+    );
+}

--- a/tests/members/test_string_member_regex.cfm
+++ b/tests/members/test_string_member_regex.cfm
@@ -1,0 +1,9 @@
+<cfscript>
+suiteBegin("String member regex functions");
+
+route = "/sysadmin/routes/[route_id]";
+assert("string.reFind passes pattern before receiver", route.reFind("\[\w+\]"), 18);
+assert("string.reMatch passes pattern before receiver", arrayToList(route.reMatch("\[\w+\]")), "[route_id]");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -87,6 +87,7 @@ try { include "functions/test_function_references.cfm"; } catch (any e) { writeO
 
 // --- Member Functions ---
 try { include "members/test_string_members.cfm"; } catch (any e) { writeOutput("ERROR | members/test_string_members.cfm | " & e.message & chr(10)); }
+try { include "members/test_string_member_regex.cfm"; } catch (any e) { writeOutput("ERROR | members/test_string_member_regex.cfm | " & e.message & chr(10)); }
 try { include "members/test_array_members.cfm"; } catch (any e) { writeOutput("ERROR | members/test_array_members.cfm | " & e.message & chr(10)); }
 try { include "members/test_struct_members.cfm"; } catch (any e) { writeOutput("ERROR | members/test_struct_members.cfm | " & e.message & chr(10)); }
 try { include "members/test_number_members.cfm"; } catch (any e) { writeOutput("ERROR | members/test_number_members.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner regression for string regex member functions.
- Passes regex member-function arguments in the order expected by the underlying string functions.
- Covers the behavior with a Rust VM regression test.

## CFML repro
- tests/members/test_string_member_regex.cfm

## Tests
- cargo test -p cfml-vm --test string_member_regex