### PR TITLE
Resolve cfdirectory paths through mappings

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -3897,6 +3897,17 @@ impl CfmlVirtualMachine {
                 return Ok(CfmlValue::Null);
             }
 
+            if matches!(name_lower.as_str(), "cfdirectory" | "__cfdirectory") {
+                if let Some(CfmlValue::Struct(opts)) = args.first() {
+                    let action = Self::struct_get_ci(opts, "action")
+                        .map(|v| v.as_string().to_lowercase())
+                        .unwrap_or_else(|| "list".to_string());
+                    if action == "list" {
+                        return self.cfdirectory_list_from_opts(opts);
+                    }
+                }
+            }
+
             // queryAppend: mutates the first query in-place, returns boolean.
             if name_lower == "queryappend" {
                 if let (Some(CfmlValue::Query(q1)), Some(CfmlValue::Query(q2))) =
@@ -10325,13 +10336,7 @@ impl CfmlVirtualMachine {
                         .map(|(_, v)| v.as_string().to_lowercase())
                         .unwrap_or_else(|| "list".to_string());
                     match action.as_str() {
-                        "list" => {
-                            let dir = opts.iter()
-                                .find(|(k, _)| k.to_lowercase() == "directory")
-                                .map(|(_, v)| v.as_string())
-                                .unwrap_or_default();
-                            Some(self.sandbox_directory_list(&dir, false, "query"))
-                        }
+                        "list" => Some(self.cfdirectory_list_from_opts(opts)),
                         _ => Some(Err(CfmlError::runtime(format!(
                             "cfdirectory action='{}': filesystem writes are disabled in sandbox mode", action
                         )))),
@@ -10400,6 +10405,105 @@ impl CfmlVirtualMachine {
                     .collect(),
             ))
         }
+    }
+
+    fn cfdirectory_list_from_opts(&self, opts: &IndexMap<String, CfmlValue>) -> CfmlResult {
+        let dir = Self::struct_get_ci(opts, "directory")
+            .map(|v| v.as_string())
+            .unwrap_or_default();
+        let filter = Self::struct_get_ci(opts, "filter")
+            .map(|v| v.as_string())
+            .unwrap_or_else(|| "*".to_string());
+        let recurse = Self::struct_get_ci(opts, "recurse")
+            .map(|v| v.is_true())
+            .unwrap_or(false);
+        match self.resolve_directory_path_with_mappings(&dir) {
+            Some(resolved) => self.sandbox_cfdirectory_list(&resolved, recurse, &filter),
+            None => Err(CfmlError::runtime(format!(
+                "cfdirectory: directory not found: {}",
+                dir
+            ))),
+        }
+    }
+
+    fn struct_get_ci<'a>(
+        s: &'a IndexMap<String, CfmlValue>,
+        key: &str,
+    ) -> Option<&'a CfmlValue> {
+        s.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .map(|(_, v)| v)
+    }
+
+    fn sandbox_cfdirectory_list(&self, path: &str, recurse: bool, filter: &str) -> CfmlResult {
+        let mut entries = Vec::new();
+        self.sandbox_collect_entries(path, recurse, &mut entries)?;
+        entries.retain(|(name, _, _)| Self::matches_directory_filter(name, filter));
+
+        let mut names = Vec::new();
+        let mut dirs = Vec::new();
+        let mut sizes = Vec::new();
+        let mut types = Vec::new();
+        let mut dates = Vec::new();
+        for (name, full_path, is_dir) in &entries {
+            names.push(CfmlValue::String(name.clone()));
+            let directory = std::path::Path::new(full_path)
+                .parent()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| path.to_string());
+            dirs.push(CfmlValue::String(directory));
+            sizes.push(CfmlValue::Int(0));
+            types.push(CfmlValue::String(if *is_dir {
+                "Dir".to_string()
+            } else {
+                "File".to_string()
+            }));
+            dates.push(CfmlValue::String(String::new()));
+        }
+
+        let mut columns = IndexMap::new();
+        columns.insert("name".to_string(), CfmlValue::array(names));
+        columns.insert("directory".to_string(), CfmlValue::array(dirs));
+        columns.insert("size".to_string(), CfmlValue::array(sizes));
+        columns.insert("type".to_string(), CfmlValue::array(types));
+        columns.insert("datelastmodified".to_string(), CfmlValue::array(dates));
+        let mut q = IndexMap::new();
+        q.insert("__type".to_string(), CfmlValue::String("query".to_string()));
+        q.insert("__columns".to_string(), CfmlValue::strukt(columns));
+        q.insert(
+            "recordcount".to_string(),
+            CfmlValue::Int(entries.len() as i64),
+        );
+        Ok(CfmlValue::strukt(q))
+    }
+
+    fn resolve_directory_path_with_mappings(&self, path: &str) -> Option<String> {
+        if self.vfs.exists(path) {
+            return Some(path.to_string());
+        }
+        if path.starts_with('/') {
+            return self.resolve_include_with_mappings(path);
+        }
+        if let Some(ref base) = self.base_template_path {
+            let base_dir = std::path::Path::new(base)
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("."));
+            let candidate = base_dir.join(path).to_string_lossy().to_string();
+            if self.vfs.exists(&candidate) {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    fn matches_directory_filter(name: &str, pattern: &str) -> bool {
+        if pattern == "*" || pattern.is_empty() {
+            return true;
+        }
+        if let Some(ext) = pattern.strip_prefix("*.") {
+            return name.to_lowercase().ends_with(&format!(".{}", ext.to_lowercase()));
+        }
+        name.eq_ignore_ascii_case(pattern)
     }
 
     fn sandbox_collect_entries(

--- a/crates/cfml-vm/tests/cfdirectory_mapping.rs
+++ b/crates/cfml-vm/tests/cfdirectory_mapping.rs
@@ -1,0 +1,80 @@
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlMapping, CfmlVirtualMachine};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+fn run_page(source: &str) -> String {
+    let mut files = HashMap::new();
+    files.insert("index.cfm".to_string(), source.as_bytes().to_vec());
+    files.insert(
+        "lib/tables/person.cfc".to_string(),
+        b"<cfcomponent></cfcomponent>".to_vec(),
+    );
+    files.insert(
+        "lib/tables/nested/address.cfc".to_string(),
+        b"<cfcomponent></cfcomponent>".to_vec(),
+    );
+    files.insert("lib/tables/readme.txt".to_string(), b"ignore".to_vec());
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    vm.mappings = vec![CfmlMapping {
+        name: "/lib/".to_string(),
+        path: format!("{}/lib", VROOT),
+    }];
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+
+    vm.execute().unwrap();
+    vm.get_output().trim().to_string()
+}
+
+#[test]
+fn cfdirectory_resolves_leading_slash_mapping_path() {
+    let output = run_page(
+        r##"
+<cfdirectory action="list" directory="/lib/tables" name="q" filter="*.cfc" recurse="true">
+<cfoutput>#q.recordCount#</cfoutput>
+"##,
+    );
+
+    assert_eq!("2", output);
+}
+
+#[test]
+fn cfdirectory_keeps_existing_absolute_filesystem_path() {
+    let output = run_page(
+        r##"
+<cfdirectory action="list" directory="/app/lib/tables" name="q" filter="*.cfc">
+<cfoutput>#q.recordCount#</cfoutput>
+"##,
+    );
+
+    assert_eq!("1", output);
+}

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -117,6 +117,7 @@ try { include "tags/test_tags_cfmail.cfm"; } catch (any e) { writeOutput("ERROR 
 try { include "tags/test_tags_cfcache.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfcache.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfstoredproc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfstoredproc.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfqueryparam_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfqueryparam_attribute_collection.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_mapping_path.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfimport.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfimport.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfthread.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfthread.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfscript_statements.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfscript_statements.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_cfdirectory_mapping_path.cfm
+++ b/tests/tags/test_cfdirectory_mapping_path.cfm
@@ -1,0 +1,12 @@
+<cfscript>
+suiteBegin("cfdirectory mapping paths");
+
+directory action="list"
+    directory="/oop/native_cfcs"
+    name="mappedCfcFiles"
+    filter="*.cfc";
+
+assert("mapped directory resolves via Application.cfc mapping", mappedCfcFiles.recordCount, 3);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary
- Adds a CFML runner regression for cfdirectory using an Application.cfc mapping path.
- Resolves leading-slash mapped directories before falling back to filesystem paths.
- Covers mapped and absolute-path behavior with a Rust VM regression test.

## CFML repro
- tests/tags/test_cfdirectory_mapping_path.cfm

## Tests
- cargo test -p cfml-vm --test cfdirectory_mapping
- cargo run -- tests/runner.cfm