### PR TITLE
Resolve leading slash component mappings

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -9132,8 +9132,17 @@ impl CfmlVirtualMachine {
         if self.mappings.is_empty() {
             return None;
         }
-        // Convert dot-path to slash-path: "taffy.core.api" → "/taffy/core/api"
-        let slash_path = format!("/{}", class_name.replace('.', "/"));
+        // Convert dot-path to slash-path: "taffy.core.api" -> "/taffy/core/api".
+        // Leading-slash component names are CFML mapping-relative paths, not
+        // necessarily OS-absolute filesystem paths.
+        let slash_path = if class_name.starts_with('/') {
+            class_name
+                .strip_suffix(".cfc")
+                .unwrap_or(class_name)
+                .to_string()
+        } else {
+            format!("/{}", class_name.replace('.', "/"))
+        };
         let slash_lower = slash_path.to_lowercase();
 
         for mapping in &self.mappings {
@@ -9745,6 +9754,8 @@ impl CfmlVirtualMachine {
                 };
                 if self.vfs.exists(&p) {
                     p
+                } else if let Some(mapped) = self.resolve_path_with_mappings(class_name) {
+                    mapped
                 } else if let Some(ref source) = self.source_file {
                     // Try relative to source file
                     let source_dir = std::path::Path::new(source)

--- a/crates/cfml-vm/tests/component_mapping.rs
+++ b/crates/cfml-vm/tests/component_mapping.rs
@@ -1,0 +1,76 @@
+//! Regression coverage for CFML mapping-relative component paths.
+
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::dynamic::CfmlValue;
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlMapping, CfmlVirtualMachine};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+#[test]
+fn createobject_component_resolves_leading_slash_mapping_path() {
+    let mut files = HashMap::new();
+    files.insert(
+        "index.cfm".to_string(),
+        r##"
+<cfset widget = CreateObject("component", "/lib/widget").init() />
+<cfoutput>#widget.ready ?: "missing"#</cfoutput>
+"##
+        .as_bytes()
+        .to_vec(),
+    );
+    files.insert(
+        "lib/widget.cfc".to_string(),
+        r#"
+<cfcomponent>
+    <cffunction name="init">
+        <cfset this.ready = "ok" />
+        <cfreturn this />
+    </cffunction>
+</cfcomponent>
+"#
+        .as_bytes()
+        .to_vec(),
+    );
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    vm.mappings = vec![CfmlMapping {
+        name: "/lib/".to_string(),
+        path: format!("{}/lib", VROOT),
+    }];
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+    vm.globals
+        .entry("url".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+
+    vm.execute().unwrap();
+    assert_eq!("ok", vm.get_output().trim());
+}

--- a/tests/oop/LeadingSlashMappingWidget.cfc
+++ b/tests/oop/LeadingSlashMappingWidget.cfc
@@ -1,0 +1,6 @@
+component {
+    function init() {
+        this.ready = "ok";
+        return this;
+    }
+}

--- a/tests/oop/test_component_mapping_paths.cfm
+++ b/tests/oop/test_component_mapping_paths.cfm
@@ -1,0 +1,9 @@
+<cfscript>
+suiteBegin("OOP: component mapping paths");
+
+widget = createObject("component", "/oop/LeadingSlashMappingWidget").init();
+
+assert("leading slash component path resolves via mapping", widget.ready, "ok");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -106,6 +106,7 @@ try { include "oop/test_property_attributes.cfm"; } catch (any e) { writeOutput(
 try { include "oop/test_struct_method_dispatch.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_struct_method_dispatch.cfm | " & e.message & chr(10)); }
 try { include "oop/test_external_prop.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_external_prop.cfm | " & e.message & chr(10)); }
 try { include "oop/test_repeated_instantiation.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_repeated_instantiation.cfm | " & e.message & chr(10)); }
+try { include "oop/test_component_mapping_paths.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_mapping_paths.cfm | " & e.message & chr(10)); }
 
 // --- Tags ---
 try { include "tags/test_tags_basic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_basic.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner regression for createObject() with a leading-slash component mapping path.
- Resolves mapped component paths such as /oop/ComponentName consistently with Application.cfc mappings.
- Covers the behavior with a Rust VM regression test.

## CFML repro
- tests/oop/test_component_mapping_paths.cfm

## Tests
- cargo test -p cfml-vm --test component_mapping
- cargo run -- tests/runner.cfm