### PR TITLE
Bind component method named arguments

### DIFF
--- a/crates/cfml-codegen/src/compiler.rs
+++ b/crates/cfml-codegen/src/compiler.rs
@@ -239,6 +239,7 @@ pub enum BytecodeOp {
     //   - Some(vec!["local", "_taffy", "factory"]) for local._taffy.factory.method()
     //   - None — no write-back needed
     CallMethod(String, usize, Option<Vec<String>>),
+    CallMethodNamed(String, Vec<String>, usize, Option<Vec<String>>),
 
     // For-in support
     GetKeys,  // Pop value: if struct, push array of keys; if array, leave as-is
@@ -2531,6 +2532,24 @@ impl CfmlCompiler {
                 // this.items.append(x) → write_back = Some(("this", Some("items")))
                 // dog.method(x)        → write_back = Some(("dog", None))
                 let write_back = Self::method_call_write_back(&call.object);
+                let has_named = call
+                    .arguments
+                    .iter()
+                    .any(|arg| matches!(arg, Expression::NamedArgument(_)));
+                let compile_args =
+                    |compiler: &mut Self, instructions: &mut Vec<BytecodeOp>| -> Vec<String> {
+                        let mut names = Vec::with_capacity(call.arguments.len());
+                        for arg in &call.arguments {
+                            if let Expression::NamedArgument(named) = arg {
+                                names.push(named.name.clone());
+                                compiler.compile_expression(&named.value, instructions);
+                            } else {
+                                names.push(String::new());
+                                compiler.compile_expression(arg, instructions);
+                            }
+                        }
+                        names
+                    };
 
                 // For null-safe method calls, use TryLoadLocal for simple identifiers
                 if call.null_safe {
@@ -2548,24 +2567,38 @@ impl CfmlCompiler {
                     let jump_end = instructions.len();
                     instructions.push(BytecodeOp::Jump(0));
                     instructions[jump_idx] = BytecodeOp::JumpIfNotNull(instructions.len());
-                    for arg in &call.arguments {
-                        self.compile_expression(arg, instructions);
+                    let names = compile_args(self, instructions);
+                    if has_named {
+                        instructions.push(BytecodeOp::CallMethodNamed(
+                            call.method.clone(),
+                            names,
+                            call.arguments.len(),
+                            write_back.clone(),
+                        ));
+                    } else {
+                        instructions.push(BytecodeOp::CallMethod(
+                            call.method.clone(),
+                            call.arguments.len(),
+                            write_back.clone(),
+                        ));
                     }
-                    instructions.push(BytecodeOp::CallMethod(
-                        call.method.clone(),
-                        call.arguments.len(),
-                        write_back.clone(),
-                    ));
                     instructions[jump_end] = BytecodeOp::Jump(instructions.len());
                 } else {
-                    for arg in &call.arguments {
-                        self.compile_expression(arg, instructions);
+                    let names = compile_args(self, instructions);
+                    if has_named {
+                        instructions.push(BytecodeOp::CallMethodNamed(
+                            call.method.clone(),
+                            names,
+                            call.arguments.len(),
+                            write_back,
+                        ));
+                    } else {
+                        instructions.push(BytecodeOp::CallMethod(
+                            call.method.clone(),
+                            call.arguments.len(),
+                            write_back,
+                        ));
                     }
-                    instructions.push(BytecodeOp::CallMethod(
-                        call.method.clone(),
-                        call.arguments.len(),
-                        write_back,
-                    ));
                 }
             }
             Expression::Array(arr) => {

--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -3182,7 +3182,12 @@ impl CfmlVirtualMachine {
                     }
                 }
 
-                BytecodeOp::CallMethod(method_name, arg_count, write_back) => {
+                BytecodeOp::CallMethod(method_name, arg_count, write_back)
+                | BytecodeOp::CallMethodNamed(method_name, _, arg_count, write_back) => {
+                    let method_arg_names = match &func.instructions[ip - 1] {
+                        BytecodeOp::CallMethodNamed(_, names, _, _) => Some(names.as_slice()),
+                        _ => None,
+                    };
                     let mut extra_args: Vec<CfmlValue> =
                         (0..*arg_count).filter_map(|_| stack.pop()).collect();
                     extra_args.reverse();
@@ -3225,7 +3230,12 @@ impl CfmlVirtualMachine {
                                         } else {
                                             None
                                         };
-                                    let args: Vec<CfmlValue> = extra_args.drain(..).collect();
+                                    let raw_args: Vec<CfmlValue> = extra_args.drain(..).collect();
+                                    let args = Self::reorder_named_args_for_function(
+                                        &prop,
+                                        method_arg_names,
+                                        raw_args,
+                                    );
                                     let mut method_locals = IndexMap::new();
                                     // Merge captured scope first (closure vars from defining scope)
                                     if let Some(ref shared_env) = f.captured_scope {
@@ -3275,13 +3285,24 @@ impl CfmlVirtualMachine {
                                         &object,
                                         &method_name,
                                         &mut extra_args,
+                                        method_arg_names,
                                     )
                                 }
                             } else {
-                                self.call_member_function(&object, &method_name, &mut extra_args)
+                                self.call_member_function(
+                                    &object,
+                                    &method_name,
+                                    &mut extra_args,
+                                    method_arg_names,
+                                )
                             }
                         } else {
-                            self.call_member_function(&object, &method_name, &mut extra_args)
+                            self.call_member_function(
+                                &object,
+                                &method_name,
+                                &mut extra_args,
+                                method_arg_names,
+                            )
                         };
                     self.try_stack = saved_try_stack_method;
                     let result = match method_result {
@@ -8023,6 +8044,7 @@ impl CfmlVirtualMachine {
         object: &CfmlValue,
         method: &str,
         extra_args: &mut Vec<CfmlValue>,
+        arg_names: Option<&[String]>,
     ) -> CfmlResult {
         let method_lower = method.to_lowercase();
 
@@ -8762,7 +8784,8 @@ impl CfmlVirtualMachine {
         };
         if let CfmlValue::Function(ref _fdata) = &prop {
             let func_ref = prop.clone();
-            let args: Vec<CfmlValue> = extra_args.drain(..).collect();
+            let raw_args: Vec<CfmlValue> = extra_args.drain(..).collect();
+            let args = Self::reorder_named_args_for_function(&prop, arg_names, raw_args);
             // Bind 'this' / __variables ONLY when the receiver is an actual CFC.
             // For plain struct-stored closures (e.g. `enc = { string: fn }`), the
             // closure should keep whatever `this` it captured at definition (or
@@ -8882,6 +8905,59 @@ impl CfmlVirtualMachine {
         }
 
         Ok(CfmlValue::Null)
+    }
+
+    fn reorder_named_args_for_function(
+        func_ref: &CfmlValue,
+        arg_names: Option<&[String]>,
+        arg_values: Vec<CfmlValue>,
+    ) -> Vec<CfmlValue> {
+        let Some(arg_names) = arg_names else {
+            return arg_values;
+        };
+        let CfmlValue::Function(func) = func_ref else {
+            return arg_values;
+        };
+
+        let mut expanded_names = Vec::new();
+        let mut expanded_values = Vec::new();
+        for (i, name) in arg_names.iter().enumerate() {
+            let value = arg_values.get(i).cloned().unwrap_or(CfmlValue::Null);
+            if name.eq_ignore_ascii_case("argumentcollection") {
+                if let CfmlValue::Struct(s) = value {
+                    for (k, v) in s.iter() {
+                        expanded_names.push(k.clone());
+                        expanded_values.push(v.clone());
+                    }
+                    continue;
+                }
+            }
+            expanded_names.push(name.clone());
+            expanded_values.push(value);
+        }
+
+        let mut positional = vec![CfmlValue::Null; func.params.len().max(expanded_names.len())];
+        for (i, name) in expanded_names.iter().enumerate() {
+            let value = expanded_values.get(i).cloned().unwrap_or(CfmlValue::Null);
+            if name.is_empty() {
+                if i < positional.len() {
+                    positional[i] = value;
+                }
+                continue;
+            }
+            match func
+                .params
+                .iter()
+                .position(|param| param.name.eq_ignore_ascii_case(name))
+            {
+                Some(param_index) if param_index < positional.len() => {
+                    positional[param_index] = value;
+                }
+                Some(_) => {}
+                None => positional.push(value),
+            }
+        }
+        positional
     }
 
     /// Check if a variable name (possibly dotted like "request.data.name") is defined
@@ -12113,7 +12189,7 @@ fn stack_effect(op: &BytecodeOp) -> (usize, usize) {
         BytecodeOp::TryStart(_) | BytecodeOp::TryEnd => (0, 0),
         BytecodeOp::Throw | BytecodeOp::Rethrow => (0, 1),
         // Method call: pops obj + args, pushes 1
-        BytecodeOp::CallMethod(_, n, _) => (1, n + 1),
+        BytecodeOp::CallMethod(_, n, _) | BytecodeOp::CallMethodNamed(_, _, n, _) => (1, n + 1),
         BytecodeOp::CallRustSuperCtor(n) => (1, *n),
         // Include
         BytecodeOp::Include(_) => (0, 0),

--- a/crates/cfml-vm/tests/component_method_named_args.rs
+++ b/crates/cfml-vm/tests/component_method_named_args.rs
@@ -1,0 +1,87 @@
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlMapping, CfmlVirtualMachine};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+fn run_page(source: &str) -> String {
+    let mut files = HashMap::new();
+    files.insert("index.cfm".to_string(), source.as_bytes().to_vec());
+    files.insert(
+        "lib/widget.cfc".to_string(),
+        r#"
+<cfcomponent>
+    <cffunction name="combine">
+        <cfargument name="first" />
+        <cfargument name="second" />
+        <cfargument name="third" />
+        <cfreturn arguments.first & arguments.second & arguments.third />
+    </cffunction>
+</cfcomponent>
+"#
+        .as_bytes()
+        .to_vec(),
+    );
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    vm.mappings = vec![CfmlMapping {
+        name: "/lib/".to_string(),
+        path: format!("{}/lib", VROOT),
+    }];
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+
+    vm.execute().unwrap();
+    vm.get_output().trim().to_string()
+}
+
+#[test]
+fn component_methods_bind_named_arguments_by_parameter_name() {
+    let output = run_page(
+        r##"
+<cfset widget = CreateObject("component", "/lib/widget") />
+<cfoutput>#widget.combine(third="C", first="A", second="B")#</cfoutput>
+"##,
+    );
+
+    assert_eq!("ABC", output);
+}
+
+#[test]
+fn component_methods_expand_named_argument_collection() {
+    let output = run_page(
+        r##"
+<cfset widget = CreateObject("component", "/lib/widget") />
+<cfset args = { first = "A", second = "B", third = "C" } />
+<cfoutput>#widget.combine(argumentCollection=args)#</cfoutput>
+"##,
+    );
+
+    assert_eq!("ABC", output);
+}

--- a/tests/oop/NamedArgWidget.cfc
+++ b/tests/oop/NamedArgWidget.cfc
@@ -1,0 +1,5 @@
+component {
+    function combine(first, second, third) {
+        return arguments.first & arguments.second & arguments.third;
+    }
+}

--- a/tests/oop/test_component_method_named_args.cfm
+++ b/tests/oop/test_component_method_named_args.cfm
@@ -1,0 +1,11 @@
+<cfscript>
+suiteBegin("OOP: component method named arguments");
+
+widget = createObject("component", "oop.NamedArgWidget");
+args = { first = "A", second = "B", third = "C" };
+
+assert("named arguments bind by parameter name", widget.combine(third="C", first="A", second="B"), "ABC");
+assert("argumentCollection expands by parameter name", widget.combine(argumentCollection=args), "ABC");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -106,6 +106,7 @@ try { include "oop/test_property_attributes.cfm"; } catch (any e) { writeOutput(
 try { include "oop/test_struct_method_dispatch.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_struct_method_dispatch.cfm | " & e.message & chr(10)); }
 try { include "oop/test_external_prop.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_external_prop.cfm | " & e.message & chr(10)); }
 try { include "oop/test_repeated_instantiation.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_repeated_instantiation.cfm | " & e.message & chr(10)); }
+try { include "oop/test_component_method_named_args.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_method_named_args.cfm | " & e.message & chr(10)); }
 
 // --- Tags ---
 try { include "tags/test_tags_basic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_basic.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner regression for component method named arguments and argumentCollection.
- Binds component method calls by parameter name instead of call-site ordering.
- Covers both direct named arguments and argumentCollection with a Rust VM regression test.

## CFML repro
- tests/oop/test_component_method_named_args.cfm

## Tests
- cargo test -p cfml-vm --test component_method_named_args
- cargo run -- tests/runner.cfm