### PR TITLE
Prefer component methods over struct helpers

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -8386,6 +8386,13 @@ impl CfmlVirtualMachine {
                 _ => None,
             },
             CfmlValue::Struct(s) => match method_lower.as_str() {
+                _ if (s.contains_key("__variables") || s.contains_key("__name"))
+                    && s.iter().any(|(key, value)| {
+                        key.eq_ignore_ascii_case(method) && matches!(value, CfmlValue::Function(_))
+                    }) =>
+                {
+                    None
+                }
                 "count" | "len" | "size" => Some("structCount"),
                 "keyexists" => Some("structKeyExists"),
                 "keylist" => Some("structKeyList"),

--- a/crates/cfml-vm/tests/component_method_precedence.rs
+++ b/crates/cfml-vm/tests/component_method_precedence.rs
@@ -1,0 +1,76 @@
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlMapping, CfmlVirtualMachine};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+#[test]
+fn component_method_names_take_precedence_over_struct_member_helpers() {
+    let mut files = HashMap::new();
+    files.insert(
+        "index.cfm".to_string(),
+        r##"
+<cfset service = CreateObject("component", "/lib/service") />
+<cfoutput>#service.delete(id="abc")#|#service.count()#</cfoutput>
+"##
+        .as_bytes()
+        .to_vec(),
+    );
+    files.insert(
+        "lib/service.cfc".to_string(),
+        r#"
+<cfcomponent>
+    <cffunction name="delete">
+        <cfargument name="id" required="true" />
+        <cfreturn "deleted:" & arguments.id />
+    </cffunction>
+
+    <cffunction name="count">
+        <cfreturn "component-count" />
+    </cffunction>
+</cfcomponent>
+"#
+        .as_bytes()
+        .to_vec(),
+    );
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    vm.mappings = vec![CfmlMapping {
+        name: "/lib/".to_string(),
+        path: format!("{}/lib", VROOT),
+    }];
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+
+    vm.execute().unwrap();
+    assert_eq!(
+        "deleted:abc|component-count",
+        vm.get_output().split_whitespace().collect::<String>()
+    );
+}

--- a/tests/oop/MemberPrecedenceService.cfc
+++ b/tests/oop/MemberPrecedenceService.cfc
@@ -1,0 +1,9 @@
+component {
+    function delete(required string id) {
+        return "deleted:" & arguments.id;
+    }
+
+    function count() {
+        return "component-count";
+    }
+}

--- a/tests/oop/test_component_method_precedence.cfm
+++ b/tests/oop/test_component_method_precedence.cfm
@@ -1,0 +1,10 @@
+<cfscript>
+suiteBegin("OOP: component method precedence");
+
+service = createObject("component", "oop.MemberPrecedenceService");
+
+assert("component delete method wins over struct helper", service.delete(id="abc"), "deleted:abc");
+assert("component count method wins over struct helper", service.count(), "component-count");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -106,6 +106,7 @@ try { include "oop/test_property_attributes.cfm"; } catch (any e) { writeOutput(
 try { include "oop/test_struct_method_dispatch.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_struct_method_dispatch.cfm | " & e.message & chr(10)); }
 try { include "oop/test_external_prop.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_external_prop.cfm | " & e.message & chr(10)); }
 try { include "oop/test_repeated_instantiation.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_repeated_instantiation.cfm | " & e.message & chr(10)); }
+try { include "oop/test_component_method_precedence.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_method_precedence.cfm | " & e.message & chr(10)); }
 
 // --- Tags ---
 try { include "tags/test_tags_basic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_basic.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner regression for component methods named like struct member helpers.
- Dispatches to the component method before falling back to struct helper behavior.
- Covers delete() and count() method names with a Rust VM regression test.

## CFML repro
- tests/oop/test_component_method_precedence.cfm

## Tests
- cargo test -p cfml-vm --test component_method_precedence
- cargo run -- tests/runner.cfm