### PR TITLE
Implement applicationStop lifecycle reset

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -520,6 +520,10 @@ pub struct CfmlVirtualMachine {
     pub request_scope: IndexMap<String, CfmlValue>,
     /// Application scope — shared across requests (Arc<Mutex> for thread safety)
     pub application_scope: Option<Arc<Mutex<IndexMap<String, CfmlValue>>>>,
+    /// Name of the application currently attached to application_scope.
+    current_application_name: Option<String>,
+    /// Set when applicationStop() has cleared the attached application during this request.
+    application_stopped: bool,
     /// Server-level state — persists across requests in --serve mode
     pub server_state: Option<ServerState>,
     /// HTTP response headers set by cfheader
@@ -720,6 +724,8 @@ impl CfmlVirtualMachine {
             closure_parent_writeback: None,
             request_scope: IndexMap::new(),
             application_scope: None,
+            current_application_name: None,
+            application_stopped: false,
             server_state: None,
             response_headers: Vec::new(),
             response_status: None,
@@ -4330,6 +4336,7 @@ impl CfmlVirtualMachine {
                 | "sessioninvalidate"
                 | "sessionrotate"
                 | "sessiongetmetadata"
+                | "applicationstop"
                 | "getauthuser"
                 | "isuserinrole"
                 | "isuserloggedin"
@@ -6601,6 +6608,10 @@ impl CfmlVirtualMachine {
                     }
                     self.transaction_conn = None;
                     self.transaction_datasource = None;
+                    return Ok(CfmlValue::Null);
+                }
+                "applicationstop" => {
+                    self.stop_current_application();
                     return Ok(CfmlValue::Null);
                 }
                 "__cflog" => {
@@ -11437,8 +11448,32 @@ impl CfmlVirtualMachine {
         source
     }
 
+    fn stop_current_application(&mut self) {
+        if let Some(app_name) = self.current_application_name.clone() {
+            if let Some(ref server_state) = self.server_state {
+                server_state.applications.modify(&app_name, &mut |app| {
+                    app.variables.clear();
+                    app.started = false;
+                    app.cached_functions.clear();
+                    app.cached_functions_original_offset = 0;
+                });
+            }
+        }
+
+        if let Some(ref app_scope) = self.application_scope {
+            if let Ok(mut scope) = app_scope.lock() {
+                scope.clear();
+            }
+        }
+
+        self.application_stopped = true;
+    }
+
     /// Execute with Application.cfc lifecycle
     pub fn execute_with_lifecycle(&mut self) -> CfmlResult {
+        self.application_stopped = false;
+        self.current_application_name = None;
+
         // 1. Find Application.cfc
         let app_cfc_path = self.find_application_cfc();
 
@@ -11593,6 +11628,7 @@ impl CfmlVirtualMachine {
             }
             let app_snapshot = server_state.applications.get(&app_name).unwrap();
             let scope = Arc::new(Mutex::new(app_snapshot.variables.clone()));
+            self.current_application_name = Some(app_name.clone());
             self.application_scope = Some(scope.clone());
 
             // 5. onApplicationStart (if not yet started)
@@ -11839,22 +11875,24 @@ impl CfmlVirtualMachine {
         // and any function values that the application scope captured during the
         // request (e.g. `application._taffy.factory.getBean`) end up with body
         // indices beyond the restored program length.
-        if let Some(ref server_state) = self.server_state.clone() {
-            if let Some(ref app_scope) = self.application_scope {
-                if let Ok(scope) = app_scope.lock() {
-                    let scope_snapshot = scope.clone();
-                    let program_functions = self.program.functions.clone();
-                    server_state.applications.modify(&app_name, &mut |app| {
-                        app.variables = scope_snapshot.clone();
-                        // Refresh cache from current program. Use the
-                        // original offset captured the first time
-                        // onApplicationStart ran; that anchor stays
-                        // constant for the lifetime of the application.
-                        let offset = app.cached_functions_original_offset;
-                        if offset > 0 && program_functions.len() > offset {
-                            app.cached_functions = program_functions[offset..].to_vec();
-                        }
-                    });
+        if !self.application_stopped {
+            if let Some(ref server_state) = self.server_state.clone() {
+                if let Some(ref app_scope) = self.application_scope {
+                    if let Ok(scope) = app_scope.lock() {
+                        let scope_snapshot = scope.clone();
+                        let program_functions = self.program.functions.clone();
+                        server_state.applications.modify(&app_name, &mut |app| {
+                            app.variables = scope_snapshot.clone();
+                            // Refresh cache from current program. Use the
+                            // original offset captured the first time
+                            // onApplicationStart ran; that anchor stays
+                            // constant for the lifetime of the application.
+                            let offset = app.cached_functions_original_offset;
+                            if offset > 0 && program_functions.len() > offset {
+                                app.cached_functions = program_functions[offset..].to_vec();
+                            }
+                        });
+                    }
                 }
             }
         }

--- a/crates/cfml-vm/tests/application_stop.rs
+++ b/crates/cfml-vm/tests/application_stop.rs
@@ -1,0 +1,115 @@
+//! End-to-end coverage for `applicationStop()`.
+//!
+//! The function has to mutate the VM's shared application store, so this test
+//! drives real lifecycle execution instead of testing the stdlib shim.
+
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::dynamic::CfmlValue;
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlVirtualMachine, ServerState};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+const APP_NAME: &str = "application-stop-test";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+fn run_request(server_state: &ServerState, vfs: Arc<dyn Vfs>, page: &str) {
+    let page_path = format!("{}/{}", VROOT, page);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+    vm.globals
+        .entry("url".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("cgi".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("form".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+
+    vm.server_state = Some(server_state.clone());
+
+    vm.execute_with_lifecycle().unwrap();
+}
+
+#[test]
+fn application_stop_clears_shared_application_state() {
+    let mut files: HashMap<String, Vec<u8>> = HashMap::new();
+    files.insert(
+        "Application.cfc".to_string(),
+        include_str!("../../../tests/lifecycle/application_stop/Application.cfc")
+            .as_bytes()
+            .to_vec(),
+    );
+    files.insert(
+        "index.cfm".to_string(),
+        include_str!("../../../tests/lifecycle/application_stop/index.cfm")
+            .as_bytes()
+            .to_vec(),
+    );
+    files.insert(
+        "stop.cfm".to_string(),
+        include_str!("../../../tests/lifecycle/application_stop/stop.cfm")
+            .as_bytes()
+            .to_vec(),
+    );
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let server_state = ServerState::with_production(false);
+
+    run_request(&server_state, vfs.clone(), "index.cfm");
+    let started_app = server_state.applications.get(APP_NAME).unwrap();
+    assert!(started_app.started);
+    assert!(started_app
+        .variables
+        .keys()
+        .any(|key| key.eq_ignore_ascii_case("seed")));
+
+    run_request(&server_state, vfs.clone(), "stop.cfm");
+    let stopped_app = server_state.applications.get(APP_NAME).unwrap();
+    assert!(
+        !stopped_app.started,
+        "applicationStop() must mark the application unstarted"
+    );
+    assert!(
+        stopped_app.variables.is_empty(),
+        "applicationStop() must clear application scope variables"
+    );
+    assert!(
+        stopped_app.cached_functions.is_empty(),
+        "applicationStop() must discard cached lifecycle functions"
+    );
+    assert_eq!(0, stopped_app.cached_functions_original_offset);
+
+    run_request(&server_state, vfs, "index.cfm");
+    let restarted_app = server_state.applications.get(APP_NAME).unwrap();
+    assert!(restarted_app.started);
+    assert!(restarted_app
+        .variables
+        .keys()
+        .any(|key| key.eq_ignore_ascii_case("seed")));
+}

--- a/tests/lifecycle/application_stop/Application.cfc
+++ b/tests/lifecycle/application_stop/Application.cfc
@@ -1,0 +1,12 @@
+component {
+    this.name = "application-stop-test";
+
+    function onApplicationStart() {
+        application.startedByLifecycle = true;
+        application.seed = createUUID();
+    }
+
+    function onRequest(targetPage) {
+        include "#targetPage#";
+    }
+}

--- a/tests/lifecycle/application_stop/index.cfm
+++ b/tests/lifecycle/application_stop/index.cfm
@@ -1,0 +1,1 @@
+<cfoutput>#application.seed#</cfoutput>

--- a/tests/lifecycle/application_stop/stop.cfm
+++ b/tests/lifecycle/application_stop/stop.cfm
@@ -1,0 +1,3 @@
+<cfset application.stopMarker = true>
+<cfset applicationStop()>
+<cfoutput>stopped</cfoutput>


### PR DESCRIPTION
## Summary
- Adds a lifecycle CFML fixture for applicationStop() across requests.
- Implements applicationStop() so it clears shared application scope, marks the app unstarted, and drops cached lifecycle functions.
- Prevents the end-of-request application writeback from restoring the stopped state.

## CFML repro
- tests/lifecycle/application_stop/Application.cfc
- tests/lifecycle/application_stop/index.cfm
- tests/lifecycle/application_stop/stop.cfm

## Tests
- cargo test -p cfml-vm --test application_stop