### PR TITLE
Bound application function cache to reachable functions

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -5,7 +5,7 @@ use cfml_common::dynamic::CfmlValue;
 use cfml_common::vfs::{RealFs, Vfs};
 use cfml_common::vm::{CfmlError, CfmlErrorType, CfmlResult};
 use indexmap::IndexMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::SystemTime;
 
@@ -42,8 +42,12 @@ pub struct ApplicationState {
     /// Bytecode functions added during onApplicationStart (factory, resources, etc.).
     /// Only the delta (functions added after load_application_cfc) is cached.
     pub cached_functions: Vec<std::sync::Arc<cfml_codegen::compiler::BytecodeFunction>>,
-    /// The program.functions.len() at which cached_functions were originally inserted.
-    /// Used to compute index offsets when restoring on subsequent requests.
+    /// Original program indices for `cached_functions`.
+    /// Restoring app-scope CFCs has to remap each sparse original index to the
+    /// compact position where the cached functions are appended for a request.
+    pub cached_function_indices: Vec<usize>,
+    /// Legacy contiguous-cache anchor. Used only for application states created
+    /// before `cached_function_indices` existed in this process.
     pub cached_functions_original_offset: usize,
     /// Value of `this.sessionStorage` from Application.cfc — name of the cache to use
     /// for session storage. Overrides the server-wide `.cfconfig.json` setting.
@@ -9552,6 +9556,181 @@ impl CfmlVirtualMachine {
         }
     }
 
+    fn application_scope_function_indices(scope: &IndexMap<String, CfmlValue>) -> Vec<usize> {
+        let mut indices = Vec::new();
+        let mut seen_indices = HashSet::new();
+        let mut visited = HashSet::new();
+        for value in scope.values() {
+            Self::collect_function_indices(value, &mut indices, &mut seen_indices, &mut visited);
+        }
+        indices.sort_unstable();
+        indices
+    }
+
+    fn collect_function_indices(
+        value: &CfmlValue,
+        indices: &mut Vec<usize>,
+        seen_indices: &mut HashSet<usize>,
+        visited: &mut HashSet<(u8, usize)>,
+    ) {
+        match value {
+            CfmlValue::Function(function) => {
+                Self::collect_function_indices_from_function(
+                    function,
+                    indices,
+                    seen_indices,
+                    visited,
+                );
+            }
+            CfmlValue::Struct(values) => {
+                let ptr = values.backing_ptr();
+                if !visited.insert((1, ptr)) {
+                    return;
+                }
+                for (_, value) in values.iter() {
+                    Self::collect_function_indices(&value, indices, seen_indices, visited);
+                }
+            }
+            CfmlValue::Array(values) => {
+                let ptr = values.backing_ptr();
+                if !visited.insert((2, ptr)) {
+                    return;
+                }
+                for value in values.iter() {
+                    Self::collect_function_indices(&value, indices, seen_indices, visited);
+                }
+            }
+            CfmlValue::QueryColumn(values) => {
+                let ptr = Arc::as_ptr(values) as usize;
+                if !visited.insert((4, ptr)) {
+                    return;
+                }
+                for value in values.iter() {
+                    Self::collect_function_indices(value, indices, seen_indices, visited);
+                }
+            }
+            CfmlValue::Component(component) => {
+                for value in component.properties.values() {
+                    Self::collect_function_indices(value, indices, seen_indices, visited);
+                }
+                for function in component.methods.values() {
+                    Self::collect_function_indices_from_function(
+                        function,
+                        indices,
+                        seen_indices,
+                        visited,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_function_indices_from_function(
+        function: &cfml_common::dynamic::CfmlFunction,
+        indices: &mut Vec<usize>,
+        seen_indices: &mut HashSet<usize>,
+        visited: &mut HashSet<(u8, usize)>,
+    ) {
+        if let cfml_common::dynamic::CfmlClosureBody::Expression(ref body) = function.body {
+            if let CfmlValue::Int(idx) = body.as_ref() {
+                let idx = *idx as usize;
+                if seen_indices.insert(idx) {
+                    indices.push(idx);
+                }
+            }
+        }
+        if let Some(shared_scope) = &function.captured_scope {
+            let ptr = Arc::as_ptr(shared_scope) as usize;
+            if !visited.insert((3, ptr)) {
+                return;
+            }
+            if let Ok(scope) = shared_scope.read() {
+                for value in scope.values() {
+                    Self::collect_function_indices(value, indices, seen_indices, visited);
+                }
+            }
+        }
+    }
+
+    fn remap_func_indices(
+        val: &mut CfmlValue,
+        index_map: &HashMap<usize, usize>,
+        visited: &mut HashSet<(u8, usize)>,
+    ) {
+        match val {
+            CfmlValue::Function(function) => {
+                if let cfml_common::dynamic::CfmlClosureBody::Expression(ref mut body) =
+                    function.body
+                {
+                    if let CfmlValue::Int(ref mut idx) = body.as_mut() {
+                        if let Some(new_idx) = index_map.get(&(*idx as usize)) {
+                            *idx = *new_idx as i64;
+                        }
+                    }
+                }
+                if let Some(shared_scope) = &function.captured_scope {
+                    let ptr = Arc::as_ptr(shared_scope) as usize;
+                    if !visited.insert((3, ptr)) {
+                        return;
+                    }
+                    if let Ok(mut scope) = shared_scope.write() {
+                        let keys: Vec<String> = scope.keys().cloned().collect();
+                        for key in keys {
+                            if let Some(value) = scope.get_mut(&key) {
+                                Self::remap_func_indices(value, index_map, visited);
+                            }
+                        }
+                    }
+                }
+            }
+            CfmlValue::Struct(values) => {
+                let ptr = values.backing_ptr();
+                if !visited.insert((1, ptr)) {
+                    return;
+                }
+                values.with_write(|m| {
+                    for value in m.values_mut() {
+                        Self::remap_func_indices(value, index_map, visited);
+                    }
+                });
+            }
+            CfmlValue::Array(values) => {
+                let ptr = values.backing_ptr();
+                if !visited.insert((2, ptr)) {
+                    return;
+                }
+                values.with_write(|items| {
+                    for value in items.iter_mut() {
+                        Self::remap_func_indices(value, index_map, visited);
+                    }
+                });
+            }
+            CfmlValue::QueryColumn(values) => {
+                let ptr = Arc::as_ptr(values) as usize;
+                if !visited.insert((4, ptr)) {
+                    return;
+                }
+                for value in Arc::make_mut(values).iter_mut() {
+                    Self::remap_func_indices(value, index_map, visited);
+                }
+            }
+            CfmlValue::Component(component) => {
+                for value in component.properties.values_mut() {
+                    Self::remap_func_indices(value, index_map, visited);
+                }
+                for function in component.methods.values_mut() {
+                    let mut value = CfmlValue::Function(Box::new(function.clone()));
+                    Self::remap_func_indices(&mut value, index_map, visited);
+                    if let CfmlValue::Function(updated) = value {
+                        *function = *updated;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Get default datasource from application scope or request scope
     fn get_default_datasource(&self, parent_locals: &IndexMap<String, CfmlValue>) -> String {
         // Check application scope for datasource config
@@ -11585,6 +11764,7 @@ impl CfmlVirtualMachine {
                     started: false,
                     config: config.clone(),
                     cached_functions: Vec::new(),
+                    cached_function_indices: Vec::new(),
                     cached_functions_original_offset: 0,
                     session_storage: app_session_storage.clone(),
                     app_caches: app_caches.clone(),
@@ -11621,13 +11801,12 @@ impl CfmlVirtualMachine {
                             if let Some(ref server_state) = self.server_state.clone() {
                                 let new_funcs: Vec<_> =
                                     self.program.functions[funcs_before..].to_vec();
-                                server_state.applications.modify(
-                                    &app_name,
-                                    &mut |app| {
-                                        app.cached_functions = new_funcs.clone();
-                                        app.cached_functions_original_offset = funcs_before;
-                                    },
-                                );
+                                server_state.applications.modify(&app_name, &mut |app| {
+                                    app.cached_functions = new_funcs.clone();
+                                    app.cached_function_indices =
+                                        (funcs_before..funcs_after).collect();
+                                    app.cached_functions_original_offset = funcs_before;
+                                });
                             }
                         }
                     }
@@ -11650,6 +11829,7 @@ impl CfmlVirtualMachine {
                 // already has the page's functions + Application.cfc functions
                 // from load_application_cfc).
                 let cached = app_snapshot.cached_functions.clone();
+                let cached_indices = app_snapshot.cached_function_indices.clone();
                 let original_offset = app_snapshot.cached_functions_original_offset;
                 if !cached.is_empty() {
                     let new_offset = self.program.functions.len();
@@ -11657,7 +11837,24 @@ impl CfmlVirtualMachine {
 
                     // If functions ended up at a different offset than originally,
                     // fix up function indices in the application scope values.
-                    if new_offset != original_offset {
+                    if !cached_indices.is_empty() {
+                        let index_map: HashMap<usize, usize> = cached_indices
+                            .iter()
+                            .enumerate()
+                            .map(|(position, original_idx)| (*original_idx, new_offset + position))
+                            .collect();
+                        if let Some(ref app_scope) = self.application_scope {
+                            if let Ok(mut scope) = app_scope.lock() {
+                                let keys: Vec<String> = scope.keys().cloned().collect();
+                                let mut visited = HashSet::new();
+                                for key in keys {
+                                    if let Some(val) = scope.get_mut(&key) {
+                                        Self::remap_func_indices(val, &index_map, &mut visited);
+                                    }
+                                }
+                            }
+                        }
+                    } else if new_offset != original_offset {
                         let index_delta = new_offset as i64 - original_offset as i64;
                         if let Some(ref app_scope) = self.application_scope {
                             if let Ok(mut scope) = app_scope.lock() {
@@ -11846,13 +12043,35 @@ impl CfmlVirtualMachine {
                     let program_functions = self.program.functions.clone();
                     server_state.applications.modify(&app_name, &mut |app| {
                         app.variables = scope_snapshot.clone();
-                        // Refresh cache from current program. Use the
-                        // original offset captured the first time
-                        // onApplicationStart ran; that anchor stays
-                        // constant for the lifetime of the application.
+                        // Refresh the function cache to the bytecode functions
+                        // still reachable from application scope. This keeps
+                        // long-lived CFCs/factories callable across requests
+                        // without retaining stale functions from app-scope
+                        // values that were overwritten during this request.
                         let offset = app.cached_functions_original_offset;
-                        if offset > 0 && program_functions.len() > offset {
-                            app.cached_functions = program_functions[offset..].to_vec();
+                        let function_indices = Self::application_scope_function_indices(
+                            &scope_snapshot,
+                        )
+                        .into_iter()
+                        .filter(|idx| offset == 0 || *idx >= offset)
+                        .collect::<Vec<_>>();
+                        if !function_indices.is_empty() {
+                            if offset == 0 {
+                                app.cached_functions_original_offset = function_indices[0];
+                            }
+                            app.cached_function_indices = function_indices
+                                .into_iter()
+                                .filter(|idx| *idx < program_functions.len())
+                                .collect();
+                            app.cached_functions = app
+                                .cached_function_indices
+                                .iter()
+                                .map(|idx| program_functions[*idx].clone())
+                                .collect();
+                        } else {
+                            app.cached_functions_original_offset = 0;
+                            app.cached_function_indices.clear();
+                            app.cached_functions.clear();
                         }
                     });
                 }

--- a/crates/cfml-vm/tests/application_function_cache.rs
+++ b/crates/cfml-vm/tests/application_function_cache.rs
@@ -1,0 +1,186 @@
+//! Regression coverage for Application.cfc cached bytecode functions.
+//!
+//! Application scope can hold long-lived CFC instances. The VM caches the
+//! bytecode functions reachable from that scope so those instances remain
+//! callable on later requests. When a request overwrites an app-scope CFC, the
+//! cache must drop the old function bodies instead of retaining both old and
+//! new copies forever.
+
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::dynamic::CfmlValue;
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlVirtualMachine, ServerState};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+const APP_NAME: &str = "application-function-cache-test";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+fn run_request(server_state: &ServerState, vfs: Arc<dyn Vfs>) {
+    run_request_with_expected_output(server_state, vfs, "ok");
+}
+
+fn run_request_with_expected_output(
+    server_state: &ServerState,
+    vfs: Arc<dyn Vfs>,
+    expected_output: &str,
+) {
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+    vm.globals
+        .entry("url".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("cgi".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("form".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+
+    vm.server_state = Some(server_state.clone());
+
+    vm.execute_with_lifecycle().unwrap();
+    assert_eq!(expected_output, vm.output_buffer.trim());
+}
+
+fn cached_function_count(server_state: &ServerState) -> usize {
+    server_state
+        .applications
+        .get(APP_NAME)
+        .expect("application state should exist")
+        .cached_functions
+        .len()
+}
+
+fn overwrite_fixture() -> HashMap<String, Vec<u8>> {
+    let mut files = HashMap::new();
+    files.insert(
+        "Application.cfc".to_string(),
+        include_str!("../../../tests/lifecycle/application_function_cache/overwrite/Application.cfc")
+            .as_bytes()
+            .to_vec(),
+    );
+    files.insert(
+        "Factory.cfc".to_string(),
+        include_str!("../../../tests/lifecycle/application_function_cache/overwrite/Factory.cfc")
+            .as_bytes()
+            .to_vec(),
+    );
+    files.insert(
+        "index.cfm".to_string(),
+        include_str!("../../../tests/lifecycle/application_function_cache/overwrite/index.cfm")
+            .as_bytes()
+            .to_vec(),
+    );
+    files
+}
+
+fn sparse_fixture() -> HashMap<String, Vec<u8>> {
+    let mut files = HashMap::new();
+    files.insert(
+        "Application.cfc".to_string(),
+        include_str!("../../../tests/lifecycle/application_function_cache/sparse/Application.cfc")
+            .as_bytes()
+            .to_vec(),
+    );
+    files.insert(
+        "Factory.cfc".to_string(),
+        include_str!("../../../tests/lifecycle/application_function_cache/sparse/Factory.cfc")
+            .as_bytes()
+            .to_vec(),
+    );
+    files.insert(
+        "RequestFactory.cfc".to_string(),
+        include_str!(
+            "../../../tests/lifecycle/application_function_cache/sparse/RequestFactory.cfc"
+        )
+        .as_bytes()
+        .to_vec(),
+    );
+    files.insert(
+        "index.cfm".to_string(),
+        include_str!("../../../tests/lifecycle/application_function_cache/sparse/index.cfm")
+            .as_bytes()
+            .to_vec(),
+    );
+    files
+}
+
+#[test]
+fn overwritten_application_scope_cfc_does_not_grow_function_cache() {
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(overwrite_fixture(), VROOT.to_string()));
+    let server_state = ServerState::with_production(false);
+
+    run_request(&server_state, vfs.clone());
+    let first_count = cached_function_count(&server_state);
+    assert!(
+        first_count > 0,
+        "test fixture must cache at least one app-scope CFC function"
+    );
+
+    run_request(&server_state, vfs.clone());
+    assert_eq!(
+        first_count,
+        cached_function_count(&server_state),
+        "cached functions should not grow after the first repeated request"
+    );
+
+    run_request(&server_state, vfs);
+    assert_eq!(
+        first_count,
+        cached_function_count(&server_state),
+        "cached functions should remain stable across repeated overwrites"
+    );
+}
+
+#[test]
+fn persistent_and_overwritten_application_cfc_functions_are_cached_sparsely() {
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(sparse_fixture(), VROOT.to_string()));
+    let server_state = ServerState::with_production(false);
+
+    run_request_with_expected_output(&server_state, vfs.clone(), "okok");
+    let first_count = cached_function_count(&server_state);
+    assert!(
+        first_count > 1,
+        "test fixture must cache persistent and per-request app-scope CFC functions"
+    );
+
+    run_request_with_expected_output(&server_state, vfs.clone(), "okok");
+    assert_eq!(
+        first_count,
+        cached_function_count(&server_state),
+        "sparse cache must not retain stale functions between persistent and overwritten CFCs"
+    );
+
+    run_request_with_expected_output(&server_state, vfs, "okok");
+    assert_eq!(
+        first_count,
+        cached_function_count(&server_state),
+        "sparse cache should remain stable across repeated mixed app-scope CFCs"
+    );
+}

--- a/crates/cfml-worker/src/do_application_store.rs
+++ b/crates/cfml-worker/src/do_application_store.rs
@@ -96,6 +96,7 @@ impl DoApplicationStore {
                 started: snap.started,
                 config: indexmap::IndexMap::new(),
                 cached_functions: Vec::new(),
+                cached_function_indices: Vec::new(),
                 cached_functions_original_offset: 0,
                 session_storage: None,
                 app_caches: indexmap::IndexMap::new(),

--- a/crates/cfml-worker/src/kv_stores.rs
+++ b/crates/cfml-worker/src/kv_stores.rs
@@ -218,6 +218,7 @@ impl KvBackedApplicationStore {
                         started: false,
                         config: indexmap::IndexMap::new(),
                         cached_functions: Vec::new(),
+                        cached_function_indices: Vec::new(),
                         cached_functions_original_offset: 0,
                         session_storage: None,
                         app_caches: indexmap::IndexMap::new(),

--- a/tests/lifecycle/application_function_cache/overwrite/Application.cfc
+++ b/tests/lifecycle/application_function_cache/overwrite/Application.cfc
@@ -1,0 +1,11 @@
+component {
+    this.name = "application-function-cache-test";
+
+    function onRequestStart(targetPage) {
+        application.factory = createObject("component", "Factory");
+    }
+
+    function onRequest(targetPage) {
+        include "#targetPage#";
+    }
+}

--- a/tests/lifecycle/application_function_cache/overwrite/Factory.cfc
+++ b/tests/lifecycle/application_function_cache/overwrite/Factory.cfc
@@ -1,0 +1,5 @@
+component {
+    function getValue() {
+        return "ok";
+    }
+}

--- a/tests/lifecycle/application_function_cache/overwrite/index.cfm
+++ b/tests/lifecycle/application_function_cache/overwrite/index.cfm
@@ -1,0 +1,1 @@
+<cfoutput>#application.factory.getValue()#</cfoutput>

--- a/tests/lifecycle/application_function_cache/sparse/Application.cfc
+++ b/tests/lifecycle/application_function_cache/sparse/Application.cfc
@@ -1,0 +1,15 @@
+component {
+    this.name = "application-function-cache-test";
+
+    function onApplicationStart() {
+        application.persistentFactory = createObject("component", "Factory");
+    }
+
+    function onRequestStart(targetPage) {
+        application.requestFactory = createObject("component", "RequestFactory");
+    }
+
+    function onRequest(targetPage) {
+        include "#targetPage#";
+    }
+}

--- a/tests/lifecycle/application_function_cache/sparse/Factory.cfc
+++ b/tests/lifecycle/application_function_cache/sparse/Factory.cfc
@@ -1,0 +1,5 @@
+component {
+    function getValue() {
+        return "ok";
+    }
+}

--- a/tests/lifecycle/application_function_cache/sparse/RequestFactory.cfc
+++ b/tests/lifecycle/application_function_cache/sparse/RequestFactory.cfc
@@ -1,0 +1,5 @@
+component {
+    function getValue() {
+        return "ok";
+    }
+}

--- a/tests/lifecycle/application_function_cache/sparse/index.cfm
+++ b/tests/lifecycle/application_function_cache/sparse/index.cfm
@@ -1,0 +1,1 @@
+<cfoutput>#application.persistentFactory.getValue()##application.requestFactory.getValue()#</cfoutput>


### PR DESCRIPTION
## Summary
- Adds CFML lifecycle fixtures for application-scope CFCs that are overwritten each request and mixed persistent/per-request CFCs.
- Tracks the exact app-scope function indices reachable from application scope rather than caching one broad contiguous suffix.
- Remaps cached function indices when restoring cached app-scope CFCs into a new request program, with cycle guards while traversing nested scope values.

## CFML repro
- `tests/lifecycle/application_function_cache/overwrite/Application.cfc`
- `tests/lifecycle/application_function_cache/overwrite/index.cfm`
- `tests/lifecycle/application_function_cache/sparse/Application.cfc`
- `tests/lifecycle/application_function_cache/sparse/index.cfm`

## Tests
- `cargo test -p cfml-vm --test application_function_cache`
- `cargo check -p cfml-worker`