### PR TITLE
Fix custom tag lifecycle phases

### DIFF
--- a/crates/cfml-compiler/src/tag_parser.rs
+++ b/crates/cfml-compiler/src/tag_parser.rs
@@ -271,8 +271,9 @@ fn parse_import_tag(chars: &[char], start: usize, len: usize, imports: &mut std:
         );
         (result, close_end - start)
     } else {
-        // Self-closing
-        let result = format!("__cfcustomtag({}, {});\n", path_expr, attrs_expr);
+        // XML-style self-closing custom tags still run the end phase.
+        let run_end = is_self_closing_tag(chars, tag_end);
+        let result = format!("__cfcustomtag({}, {}, {});\n", path_expr, attrs_expr, run_end);
         (result, tag_end - start)
     }
 }
@@ -1120,8 +1121,9 @@ fn parse_cf_tag(chars: &[char], start: usize, len: usize, imports: &mut std::col
                 );
                 (result, close_end - start)
             } else {
-                // Self-closing
-                let result = format!("__cfcustomtag({}, {});\n", path_expr, attrs_expr);
+                // XML-style self-closing custom tags still run the end phase.
+                let run_end = is_self_closing_tag(chars, tag_end);
+                let result = format!("__cfcustomtag({}, {}, {});\n", path_expr, attrs_expr, run_end);
                 (result, tag_end - start)
             }
         }
@@ -1386,8 +1388,9 @@ fn parse_cf_tag(chars: &[char], start: usize, len: usize, imports: &mut std::col
                     );
                     (result, close_end - start)
                 } else {
-                    // Self-closing
-                    let result = format!("__cfcustomtag({}, {});\n", path_expr, attrs_expr);
+                    // XML-style self-closing custom tags still run the end phase.
+                    let run_end = is_self_closing_tag(chars, tag_end);
+                    let result = format!("__cfcustomtag({}, {}, {});\n", path_expr, attrs_expr, run_end);
                     (result, tag_end - start)
                 }
             } else {
@@ -1417,6 +1420,18 @@ fn find_tag_end(chars: &[char], start: usize, len: usize) -> usize {
         i += 1;
     }
     len
+}
+
+fn is_self_closing_tag(chars: &[char], tag_end: usize) -> bool {
+    let mut i = tag_end.saturating_sub(1);
+    while i > 0 {
+        i -= 1;
+        if chars[i].is_whitespace() {
+            continue;
+        }
+        return chars[i] == '/';
+    }
+    false
 }
 
 fn parse_tag_attributes(

--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -697,6 +697,7 @@ struct TryHandler {
 struct CustomTagState {
     template_path: String,
     attributes: CfmlValue,
+    start_locals: IndexMap<String, CfmlValue>,
 }
 
 impl CfmlVirtualMachine {
@@ -7631,6 +7632,7 @@ impl CfmlVirtualMachine {
                         .get(1)
                         .cloned()
                         .unwrap_or(CfmlValue::strukt(IndexMap::new()));
+                    let run_end_phase = args.get(2).map(|v| v.is_true()).unwrap_or(false);
 
                     let resolved = self.resolve_custom_tag_path(&path_spec)?;
                     let mut this_tag = IndexMap::new();
@@ -7638,7 +7640,7 @@ impl CfmlVirtualMachine {
                         "executionmode".to_string(),
                         CfmlValue::String("start".to_string()),
                     );
-                    this_tag.insert("hasendtag".to_string(), CfmlValue::Bool(false));
+                    this_tag.insert("hasendtag".to_string(), CfmlValue::Bool(run_end_phase));
                     this_tag.insert(
                         "generatedcontent".to_string(),
                         CfmlValue::String(String::new()),
@@ -7646,7 +7648,7 @@ impl CfmlVirtualMachine {
 
                     let caller_snapshot = parent_locals.clone();
                     let mut tag_locals = IndexMap::new();
-                    tag_locals.insert("attributes".to_string(), attrs_val);
+                    tag_locals.insert("attributes".to_string(), attrs_val.clone());
                     tag_locals.insert(
                         "caller".to_string(),
                         CfmlValue::strukt(caller_snapshot.clone()),
@@ -7655,22 +7657,69 @@ impl CfmlVirtualMachine {
 
                     self.execute_custom_tag_template(&resolved, &tag_locals)?;
 
-                    // Caller write-back: read modified caller from captured_locals
-                    if let Some(ref captured) = self.captured_locals {
-                        if let Some(CfmlValue::Struct(modified_caller)) = captured.get("caller") {
-                            let mut wb = IndexMap::new();
-                            for (k, v) in modified_caller.iter() {
-                                if let Some(orig) = caller_snapshot.get(&k) {
-                                    if !Self::values_equal_shallow(&v, orig) {
-                                        wb.insert(k.clone(), v.clone());
-                                    }
-                                } else {
-                                    wb.insert(k.clone(), v.clone());
+                    let start_locals = self.captured_locals.clone().unwrap_or_default();
+
+                    if run_end_phase {
+                        let caller_for_end = if let Some(CfmlValue::Struct(modified_caller)) =
+                            start_locals.get("caller")
+                        {
+                            modified_caller.snapshot()
+                        } else {
+                            caller_snapshot.clone()
+                        };
+
+                        let mut this_tag = IndexMap::new();
+                        this_tag.insert(
+                            "executionmode".to_string(),
+                            CfmlValue::String("end".to_string()),
+                        );
+                        this_tag.insert("hasendtag".to_string(), CfmlValue::Bool(true));
+                        this_tag.insert(
+                            "generatedcontent".to_string(),
+                            CfmlValue::String(String::new()),
+                        );
+
+                        let mut end_locals = start_locals;
+                        if !end_locals
+                            .keys()
+                            .any(|key| key.eq_ignore_ascii_case("attributes"))
+                        {
+                            end_locals.insert("attributes".to_string(), attrs_val);
+                        }
+                        end_locals.insert("caller".to_string(), CfmlValue::strukt(caller_for_end));
+                        end_locals.insert("thistag".to_string(), CfmlValue::strukt(this_tag));
+
+                        let outer_output = std::mem::take(&mut self.output_buffer);
+                        self.execute_custom_tag_template(&resolved, &end_locals)?;
+                        let end_output = std::mem::take(&mut self.output_buffer);
+                        self.output_buffer = outer_output;
+
+                        if let Some(ref captured) = self.captured_locals {
+                            if let Some(CfmlValue::Struct(tag_info)) = captured
+                                .iter()
+                                .rev()
+                                .find(|(key, _)| key.eq_ignore_ascii_case("thistag"))
+                                .map(|(_, value)| value)
+                            {
+                                if let Some(CfmlValue::String(content)) = tag_info
+                                    .iter()
+                                    .rev()
+                                    .find(|(key, _)| key.eq_ignore_ascii_case("generatedcontent"))
+                                    .map(|(_, value)| value)
+                                {
+                                    self.output_buffer.push_str(&content);
                                 }
                             }
-                            if !wb.is_empty() {
-                                self.closure_parent_writeback = Some(wb);
-                            }
+                        }
+                        self.output_buffer.push_str(&end_output);
+                    }
+
+                    // Caller write-back: read modified caller from captured_locals.
+                    if let Some(ref captured) = self.captured_locals {
+                        if let Some(wb) =
+                            Self::caller_writeback_from_captured(captured, &caller_snapshot)
+                        {
+                            self.closure_parent_writeback = Some(wb);
                         }
                     }
                     return Ok(CfmlValue::Null);
@@ -7707,22 +7756,14 @@ impl CfmlVirtualMachine {
 
                     self.execute_custom_tag_template(&resolved, &tag_locals)?;
 
+                    let start_locals = self.captured_locals.clone().unwrap_or_default();
+
                     // Caller write-back from start execution
                     if let Some(ref captured) = self.captured_locals {
-                        if let Some(CfmlValue::Struct(modified_caller)) = captured.get("caller") {
-                            let mut wb = IndexMap::new();
-                            for (k, v) in modified_caller.iter() {
-                                if let Some(orig) = caller_snapshot.get(&k) {
-                                    if !Self::values_equal_shallow(&v, orig) {
-                                        wb.insert(k.clone(), v.clone());
-                                    }
-                                } else {
-                                    wb.insert(k.clone(), v.clone());
-                                }
-                            }
-                            if !wb.is_empty() {
-                                self.closure_parent_writeback = Some(wb);
-                            }
+                        if let Some(wb) =
+                            Self::caller_writeback_from_captured(captured, &caller_snapshot)
+                        {
+                            self.closure_parent_writeback = Some(wb);
                         }
                     }
 
@@ -7730,6 +7771,7 @@ impl CfmlVirtualMachine {
                     self.custom_tag_stack.push(CustomTagState {
                         template_path: resolved,
                         attributes: attrs_val,
+                        start_locals,
                     });
 
                     // Push output buffer to capture body content (like savecontent)
@@ -7763,44 +7805,57 @@ impl CfmlVirtualMachine {
                         CfmlValue::String(body_content),
                     );
 
+                    let CustomTagState {
+                        template_path,
+                        attributes,
+                        start_locals,
+                    } = state;
+
                     let caller_snapshot = parent_locals.clone();
-                    let mut tag_locals = IndexMap::new();
-                    tag_locals.insert("attributes".to_string(), state.attributes);
+                    let mut tag_locals = start_locals;
+                    if !tag_locals
+                        .keys()
+                        .any(|key| key.eq_ignore_ascii_case("attributes"))
+                    {
+                        tag_locals.insert("attributes".to_string(), attributes);
+                    }
                     tag_locals.insert(
                         "caller".to_string(),
                         CfmlValue::strukt(caller_snapshot.clone()),
                     );
                     tag_locals.insert("thistag".to_string(), CfmlValue::strukt(this_tag));
 
-                    self.execute_custom_tag_template(&state.template_path, &tag_locals)?;
+                    let outer_output = std::mem::take(&mut self.output_buffer);
+                    self.execute_custom_tag_template(&template_path, &tag_locals)?;
+                    let end_output = std::mem::take(&mut self.output_buffer);
+                    self.output_buffer = outer_output;
 
                     // Read back generatedContent and append to output
                     if let Some(ref captured) = self.captured_locals {
-                        if let Some(CfmlValue::Struct(tag_info)) = captured.get("thistag") {
-                            if let Some(CfmlValue::String(content)) =
-                                tag_info.get("generatedcontent")
+                        if let Some(CfmlValue::Struct(tag_info)) = captured
+                            .iter()
+                            .rev()
+                            .find(|(key, _)| key.eq_ignore_ascii_case("thistag"))
+                            .map(|(_, value)| value)
+                        {
+                            if let Some(CfmlValue::String(content)) = tag_info
+                                .iter()
+                                .rev()
+                                .find(|(key, _)| key.eq_ignore_ascii_case("generatedcontent"))
+                                .map(|(_, value)| value)
                             {
                                 self.output_buffer.push_str(&content);
                             }
                         }
                     }
+                    self.output_buffer.push_str(&end_output);
 
                     // Caller write-back from end execution
                     if let Some(ref captured) = self.captured_locals {
-                        if let Some(CfmlValue::Struct(modified_caller)) = captured.get("caller") {
-                            let mut wb = IndexMap::new();
-                            for (k, v) in modified_caller.iter() {
-                                if let Some(orig) = caller_snapshot.get(&k) {
-                                    if !Self::values_equal_shallow(&v, orig) {
-                                        wb.insert(k.clone(), v.clone());
-                                    }
-                                } else {
-                                    wb.insert(k.clone(), v.clone());
-                                }
-                            }
-                            if !wb.is_empty() {
-                                self.closure_parent_writeback = Some(wb);
-                            }
+                        if let Some(wb) =
+                            Self::caller_writeback_from_captured(captured, &caller_snapshot)
+                        {
+                            self.closure_parent_writeback = Some(wb);
                         }
                     }
 
@@ -8983,6 +9038,32 @@ impl CfmlVirtualMachine {
     /// scopes (which could cause infinite recursion with shared environments).
     fn values_equal_shallow(a: &CfmlValue, b: &CfmlValue) -> bool {
         Self::values_equal_shallow_depth(a, b, 0)
+    }
+
+    fn caller_writeback_from_captured(
+        captured: &IndexMap<String, CfmlValue>,
+        caller_snapshot: &IndexMap<String, CfmlValue>,
+    ) -> Option<IndexMap<String, CfmlValue>> {
+        let Some(CfmlValue::Struct(modified_caller)) = captured.get("caller") else {
+            return None;
+        };
+
+        let mut writeback = IndexMap::new();
+        for (key, value) in modified_caller.iter() {
+            if let Some(original) = caller_snapshot.get(&key) {
+                if !Self::values_equal_shallow(&value, original) {
+                    writeback.insert(key.clone(), value.clone());
+                }
+            } else {
+                writeback.insert(key.clone(), value.clone());
+            }
+        }
+
+        if writeback.is_empty() {
+            None
+        } else {
+            Some(writeback)
+        }
     }
 
     fn values_equal_shallow_depth(a: &CfmlValue, b: &CfmlValue, depth: usize) -> bool {

--- a/crates/cfml-vm/tests/custom_tag.rs
+++ b/crates/cfml-vm/tests/custom_tag.rs
@@ -1,0 +1,155 @@
+//! Custom tag lifecycle behavior.
+
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::dynamic::CfmlValue;
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::CfmlVirtualMachine;
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+fn run_page(files: HashMap<String, Vec<u8>>) -> String {
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    vm.custom_tag_paths = vec![format!("{}/tags", VROOT)];
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+    vm.globals
+        .entry("url".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("cgi".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("form".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+
+    vm.execute().unwrap();
+    vm.get_output()
+}
+
+fn fixture(entries: &[(&str, &str)]) -> HashMap<String, Vec<u8>> {
+    entries
+        .iter()
+        .map(|(path, source)| (path.to_string(), source.as_bytes().to_vec()))
+        .collect()
+}
+
+#[test]
+fn self_closing_custom_tag_runs_end_phase_with_start_locals() {
+    let files = fixture(&[
+        (
+            "index.cfm",
+            include_str!("../../../tests/lifecycle/custom_tag/self_closing_end_phase/index.cfm"),
+        ),
+        (
+            "tags/capture.cfm",
+            include_str!(
+                "../../../tests/lifecycle/custom_tag/self_closing_end_phase/tags/capture.cfm"
+            ),
+        ),
+    ]);
+
+    assert_eq!("ok", run_page(files).trim());
+}
+
+#[test]
+fn self_closing_custom_tag_reports_has_end_tag() {
+    let files = fixture(&[
+        (
+            "index.cfm",
+            include_str!("../../../tests/lifecycle/custom_tag/self_closing_has_end_tag/index.cfm"),
+        ),
+        (
+            "tags/requires_end.cfm",
+            include_str!(
+                "../../../tests/lifecycle/custom_tag/self_closing_has_end_tag/tags/requires_end.cfm"
+            ),
+        ),
+    ]);
+
+    assert_eq!("true", run_page(files).trim());
+}
+
+#[test]
+fn body_custom_tag_end_phase_keeps_start_locals() {
+    let files = fixture(&[
+        (
+            "index.cfm",
+            include_str!("../../../tests/lifecycle/custom_tag/body_end_start_locals/index.cfm"),
+        ),
+        (
+            "tags/wrap.cfm",
+            include_str!(
+                "../../../tests/lifecycle/custom_tag/body_end_start_locals/tags/wrap.cfm"
+            ),
+        ),
+    ]);
+
+    assert_eq!("start:body", run_page(files).trim());
+}
+
+#[test]
+fn body_custom_tag_generated_content_precedes_end_phase_output() {
+    let files = fixture(&[
+        (
+            "index.cfm",
+            include_str!("../../../tests/lifecycle/custom_tag/generated_content_order/index.cfm"),
+        ),
+        (
+            "tags/layout.cfm",
+            include_str!(
+                "../../../tests/lifecycle/custom_tag/generated_content_order/tags/layout.cfm"
+            ),
+        ),
+    ]);
+
+    let output = run_page(files);
+    let body_start = output.find("<body>").unwrap();
+    let body_content = output.find("body").unwrap();
+    let body_end = output.find("</body>").unwrap();
+
+    assert!(body_start < body_content);
+    assert!(body_content < body_end);
+}
+
+#[test]
+fn custom_tag_template_has_local_scope() {
+    let files = fixture(&[
+        (
+            "index.cfm",
+            include_str!("../../../tests/lifecycle/custom_tag/local_scope/index.cfm"),
+        ),
+        (
+            "tags/localtest.cfm",
+            include_str!("../../../tests/lifecycle/custom_tag/local_scope/tags/localtest.cfm"),
+        ),
+    ]);
+
+    assert_eq!("ok", run_page(files).trim());
+}

--- a/tests/lifecycle/custom_tag/body_end_start_locals/index.cfm
+++ b/tests/lifecycle/custom_tag/body_end_start_locals/index.cfm
@@ -1,0 +1,1 @@
+<cf_wrap returnContentVariable="result">body</cf_wrap><cfoutput>#result#</cfoutput>

--- a/tests/lifecycle/custom_tag/body_end_start_locals/tags/wrap.cfm
+++ b/tests/lifecycle/custom_tag/body_end_start_locals/tags/wrap.cfm
@@ -1,0 +1,8 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfset prefix = "start:" />
+</cfif>
+
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.returnContentVariable] = prefix & thisTag.generatedContent />
+    <cfset thisTag.generatedContent = "" />
+</cfif>

--- a/tests/lifecycle/custom_tag/generated_content_order/index.cfm
+++ b/tests/lifecycle/custom_tag/generated_content_order/index.cfm
@@ -1,0 +1,1 @@
+<cf_layout><cfoutput>body</cfoutput></cf_layout>

--- a/tests/lifecycle/custom_tag/generated_content_order/tags/layout.cfm
+++ b/tests/lifecycle/custom_tag/generated_content_order/tags/layout.cfm
@@ -1,0 +1,5 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfoutput><html><body></cfoutput>
+<cfelse>
+    <cfoutput></body></html></cfoutput>
+</cfif>

--- a/tests/lifecycle/custom_tag/local_scope/index.cfm
+++ b/tests/lifecycle/custom_tag/local_scope/index.cfm
@@ -1,0 +1,1 @@
+<cf_localtest returnContentVariable="result" /><cfoutput>#result#</cfoutput>

--- a/tests/lifecycle/custom_tag/local_scope/tags/localtest.cfm
+++ b/tests/lifecycle/custom_tag/local_scope/tags/localtest.cfm
@@ -1,0 +1,4 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfset local.payload = {message = "ok"} />
+    <cfset caller[attributes.returnContentVariable] = local.payload.message />
+</cfif>

--- a/tests/lifecycle/custom_tag/self_closing_end_phase/index.cfm
+++ b/tests/lifecycle/custom_tag/self_closing_end_phase/index.cfm
@@ -1,0 +1,1 @@
+<cf_capture value="ok" returnContentVariable="result" /><cfoutput>#result#</cfoutput>

--- a/tests/lifecycle/custom_tag/self_closing_end_phase/tags/capture.cfm
+++ b/tests/lifecycle/custom_tag/self_closing_end_phase/tags/capture.cfm
@@ -1,0 +1,7 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfset savedValue = attributes.value />
+</cfif>
+
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.returnContentVariable] = savedValue />
+</cfif>

--- a/tests/lifecycle/custom_tag/self_closing_has_end_tag/index.cfm
+++ b/tests/lifecycle/custom_tag/self_closing_has_end_tag/index.cfm
@@ -1,0 +1,1 @@
+<cf_requires_end returnContentVariable="result" /><cfoutput>#result#</cfoutput>

--- a/tests/lifecycle/custom_tag/self_closing_has_end_tag/tags/requires_end.cfm
+++ b/tests/lifecycle/custom_tag/self_closing_has_end_tag/tags/requires_end.cfm
@@ -1,0 +1,7 @@
+<cfif not thisTag.HasEndTag>
+    <cfabort showerror="Must have an end tag..." />
+</cfif>
+
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.returnContentVariable] = thisTag.HasEndTag />
+</cfif>


### PR DESCRIPTION
## Summary
- Adds CFML fixtures covering custom tag start/end behavior, generatedContent ordering, caller write-back, local scope, and XML-style self-closing tags.
- Makes XML-style self-closing custom tags run the end phase and report `thisTag.hasEndTag = true`.
- Carries start-phase locals into the end phase for body custom tags, while preserving generatedContent placement and caller write-back behavior.

## CFML repro
- `tests/lifecycle/custom_tag/self_closing_end_phase/index.cfm`
- `tests/lifecycle/custom_tag/self_closing_has_end_tag/index.cfm`
- `tests/lifecycle/custom_tag/body_end_start_locals/index.cfm`
- `tests/lifecycle/custom_tag/generated_content_order/index.cfm`
- `tests/lifecycle/custom_tag/local_scope/index.cfm`

## Tests
- `cargo test -p cfml-vm --test custom_tag`