### PR TITLE
Add cross-engine test for undefined-variable auto-vivification

### DIFF
--- a/tests/core/test_undefined_var_autovivify.cfm
+++ b/tests/core/test_undefined_var_autovivify.cfm
@@ -1,0 +1,102 @@
+<cfscript>
+suiteBegin("Core: auto-vivify an undefined variable on member-path assignment");
+
+// ============================================================
+// Background
+// ============================================================
+// On Lucee 5/6/7, Adobe ColdFusion 2018-2025, and BoxLang, assigning to a
+// MEMBER PATH of a variable that does not yet exist auto-creates that
+// variable as a struct ("auto-vivification"):
+//
+//     initArgs.path = "wheels";     // initArgs was never declared
+//     writeOutput(initArgs.path);   // -> "wheels"
+//
+// The engine implicitly performs `initArgs = {}` on the first subscript
+// write.
+//
+// CFWheels/Wheels relies on this in public/Application.cfc.onApplicationStart:
+//
+//     application.wo = application.wheelsdi.getInstance("global");
+//     initArgs.path     = "wheels";              // <-- UNDECLARED `initArgs`
+//     initArgs.filename = "onapplicationstart";
+//     application.wheelsdi.getInstance(name="wheels.events.onapplicationstart",
+//                                      initArguments=initArgs).$init(this);
+//
+// RustCFML auto-vivifies the `local` scope (see test_local_at_template_scope)
+// but NOT an arbitrary undeclared variable: `initArgs.path = "wheels"` throws
+// `Variable 'initArgs' is undefined`, which aborts onApplicationStart and
+// leaves the application un-bootstrapped. The work-around is an explicit
+// `var initArgs = {}` first -- but every JVM engine makes that implicit.
+//
+// All assertions below PASS on Lucee/ACF/BoxLang. Each risky write is
+// wrapped in try/catch so a RustCFML "undefined" throw fails the assertion
+// gracefully instead of aborting the run.
+// ============================================================
+
+// ------------------------------------------------------------
+// (1) Single-level: undefined var, one member assigned.
+//     rcfmlAutoViv1.path = "wheels" should create rcfmlAutoViv1 = {path:"wheels"}.
+// ------------------------------------------------------------
+singleResult = "(threw)";
+singleErr    = "";
+try {
+    rcfmlAutoViv1.path = "wheels";
+    singleResult = rcfmlAutoViv1.path;
+} catch (any e) {
+    singleErr = e.message;
+}
+assert("undefined var auto-vivifies on member assign: x.path == 'wheels'",
+    singleResult, "wheels");
+assertTrue("no exception thrown auto-vivifying an undefined var (got: [" & singleErr & "])",
+    len(singleErr) == 0);
+
+// ------------------------------------------------------------
+// (2) The exact Wheels shape: two member writes onto one undeclared var,
+//     then read both back (mirrors initArgs.path / initArgs.filename).
+// ------------------------------------------------------------
+pathVal = "(threw)";
+fileVal = "(threw)";
+twoErr  = "";
+try {
+    rcfmlAutoViv2.path     = "wheels";
+    rcfmlAutoViv2.filename = "onapplicationstart";
+    pathVal = rcfmlAutoViv2.path;
+    fileVal = rcfmlAutoViv2.filename;
+} catch (any e) {
+    twoErr = e.message;
+}
+assert("Wheels initArgs shape: .path",     pathVal, "wheels");
+assert("Wheels initArgs shape: .filename", fileVal, "onapplicationstart");
+
+// ------------------------------------------------------------
+// (3) The auto-vivified variable is a real struct.
+// ------------------------------------------------------------
+isStructResult = false;
+try {
+    rcfmlAutoViv3.k = 1;
+    isStructResult = isStruct(rcfmlAutoViv3);
+} catch (any e) {
+}
+assertTrue("auto-vivified variable is a struct", isStructResult);
+
+// ------------------------------------------------------------
+// (4) Inside a function body -- onApplicationStart IS a function, so this
+//     is the precise context Wheels hits. An undeclared var member-assign
+//     must behave identically here.
+// ------------------------------------------------------------
+function autoVivInFunction() {
+    var out = "(threw)";
+    try {
+        fnLocalUndeclared.a = "1";
+        fnLocalUndeclared.b = "2";
+        out = fnLocalUndeclared.a & fnLocalUndeclared.b;
+    } catch (any e) {
+        out = "(threw)";
+    }
+    return out;
+}
+assert("auto-vivify works for an undeclared var inside a function body",
+    autoVivInFunction(), "12");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -200,5 +200,15 @@ try { include "tags/test_tags_script_syntax_body.cfm"; } catch (any e) { writeOu
 try { include "functions/test_expandpath_trailing_slash.cfm"; } catch (any e) { writeOutput("ERROR | functions/test_expandpath_trailing_slash.cfm | " & e.message & chr(10)); }
 try { include "core/test_forin_member_loop_var.cfm"; } catch (any e) { writeOutput("ERROR | core/test_forin_member_loop_var.cfm | " & e.message & chr(10)); }
 
+// --- v0.34.3 round: Wheels now parses, constructs, and boots its full app
+//     lifecycle + DI on RustCFML. This is the remaining language gap found
+//     on the way to serving a request. ---
+//   - undefined_var_autovivify: assigning to a member path of an UNDECLARED
+//     variable (initArgs.path = "wheels" in Application.cfc.onApplicationStart)
+//     must auto-create it as a struct. RustCFML throws "Variable is undefined"
+//     for everything except the `local` scope. Wrapped in try/catch so the
+//     throw fails its assertions without aborting the run.
+try { include "core/test_undefined_var_autovivify.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undefined_var_autovivify.cfm | " & e.message & chr(10)); }
+
 printSummary();
 </cfscript>


### PR DESCRIPTION
## Summary

A cross-engine test for a CFML behavior Wheels depends on that **passes on Lucee 7 but currently fails on RustCFML 0.34.3**: auto-vivification of an undeclared variable on member-path assignment.

Registered with the existing Wheels-compat cluster at the end of `tests/runner.cfm`. Each risky write is wrapped in `try/catch`, so the suite fails its assertions without aborting the run (cluster ordering stays non-load-bearing).

## Context — Wheels now boots its full lifecycle on RustCFML 🎉

As of v0.34.3, Wheels parses, constructs, and runs its **entire application lifecycle** (`onApplicationStart` / `onRequestStart` / `onRequest`) plus its DI container on RustCFML — the for-in member-path and `expandPath` trailing-slash fixes (from #7) cleared the earlier blockers. This test pins the next language gap found on the path to serving a request.

## The gap

Assigning to a **member path of a variable that does not yet exist** must auto-create that variable as a struct:

```cfml
initArgs.path = "wheels";     // initArgs was never declared
writeOutput(initArgs.path);   // -> "wheels"
```

Lucee 5/6/7, Adobe CF 2018–2025, and BoxLang all do this implicitly (`initArgs = {}` on first subscript write). RustCFML auto-vivifies the `local` scope (see `test_local_at_template_scope`) but throws `Variable '<name>' is undefined` for any **other** undeclared variable.

Wheels hits this in `public/Application.cfc.onApplicationStart`:

```cfml
application.wo = application.wheelsdi.getInstance("global");
initArgs.path     = "wheels";              // <-- undeclared initArgs
initArgs.filename = "onapplicationstart";
application.wheelsdi.getInstance(name="wheels.events.onapplicationstart",
                                 initArguments=initArgs).$init(this);
```

which throws and aborts `onApplicationStart`. The work-around is an explicit `var initArgs = {}` first — but every JVM engine makes that implicit.

## Validation

| Engine | Result |
|---|---|
| Lucee 7.0.2 | **6/6 pass** |
| RustCFML 0.34.3 | **0/6** (each assertion fails on the `Variable is undefined` throw) |
