### PR TITLE
Add cross-engine test for the `component` reserved-keyword parse gap

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -209,6 +209,12 @@ try { include "core/test_forin_member_loop_var.cfm"; } catch (any e) { writeOutp
 //     for everything except the `local` scope. Wrapped in try/catch so the
 //     throw fails its assertions without aborting the run.
 try { include "core/test_undefined_var_autovivify.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undefined_var_autovivify.cfm | " & e.message & chr(10)); }
+//   - cfinvoke_component_attr: `component` is a soft keyword on Lucee/ACF/BoxLang
+//     but a hard reserved keyword on RustCFML, so `cfinvoke component=...` (and a
+//     bare `component = x`) fail to PARSE. Wheels' Global.cfc::$cfinvoke() uses
+//     this exact shape, so wheels.Global degrades to a non-object and the whole
+//     framework boots-but-serves-empty. Parse failure contained in a fixture.
+try { include "tags/test_cfinvoke_component_attr.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfinvoke_component_attr.cfm | " & e.message & chr(10)); }
 
 printSummary();
 </cfscript>

--- a/tests/tags/CfInvokeComponentAttrFixture.cfc
+++ b/tests/tags/CfInvokeComponentAttrFixture.cfc
@@ -1,0 +1,24 @@
+component {
+
+	// Statement-form cfinvoke that uses the `component` attribute — the exact
+	// shape in Wheels' Global.cfc::$cfinvoke(). `component` is a SOFT keyword on
+	// Lucee/ACF/BoxLang, so it is a legal attribute name here and this PARSES;
+	// the cfinvoke invokes InvokeTarget.getValue(). RustCFML treats `component`
+	// as the HARD reserved CFC keyword, so this fails to PARSE ("Expected LBrace,
+	// found Equal"), degrading the WHOLE component to a non-object at
+	// instantiation. Kept in a fixture so the parse failure is contained (the
+	// test instantiates it at runtime) and does not abort the run.
+	//
+	// The assertion is about PARSE-ability (the RustCFML gap), not the exact
+	// returnVariable semantics of statement-form cfinvoke (which vary), so the
+	// return is guarded: if the invoke captured a value we return it, otherwise
+	// we return the same sentinel — either way a parsing engine yields INVOKED_OK.
+	function callViaCfinvoke() {
+		cfinvoke
+		component = "InvokeTarget"
+		method = "getValue"
+		returnVariable = "local.rv";
+		return structKeyExists(local, "rv") ? local.rv : "INVOKED_OK";
+	}
+
+}

--- a/tests/tags/InvokeTarget.cfc
+++ b/tests/tags/InvokeTarget.cfc
@@ -1,0 +1,5 @@
+component {
+	function getValue() {
+		return "INVOKED_OK";
+	}
+}

--- a/tests/tags/test_cfinvoke_component_attr.cfm
+++ b/tests/tags/test_cfinvoke_component_attr.cfm
@@ -1,0 +1,66 @@
+<cfscript>
+suiteBegin("Tags: cfinvoke with a `component` attribute (script statement form)");
+
+// ============================================================
+// Background
+// ============================================================
+// `component` is a SOFT keyword on Lucee 5/6/7, Adobe ColdFusion 2018-2025,
+// and BoxLang: it introduces a CFC when it begins a declaration, but it is
+// otherwise a normal identifier — usable as a variable name AND as the
+// `component` attribute of <cfinvoke> / the cfscript `cfinvoke` statement:
+//
+//     cfinvoke component="MyService" method="doThing" returnVariable="r";
+//
+// RustCFML treats `component` as a HARD reserved keyword. Any place the token
+// `component` is followed by `=` — a bare `component = x` assignment, or a
+// `component = ...` attribute in a script-statement tag — fails to PARSE with
+// "Expected LBrace, found Equal" (the parser commits to a `component { ... }`
+// declaration and then hits the `=`). The function-CALL form
+// `cfinvoke(component=...)` parses fine; only the statement form with a
+// `component` attribute fails.
+//
+// Why it matters for Wheels: public/... Global.cfc::$cfinvoke() is written as
+//
+//     cfinvoke
+//     component = "#arguments.component#"
+//     method = "#arguments.method#"
+//     returnVariable = "#arguments.returnVariable#"
+//     argumentCollection = "#arguments.invokeArguments#";
+//
+// so wheels.Global fails to parse. Because RustCFML degrades an unparseable
+// component to a non-object SILENTLY (no thrown error),
+// createObject("component","wheels.Global") returns a non-object, the Wheels
+// DI Injector's getInstance("global") hands that non-object to application.wo,
+// and every framework lifecycle call on application.wo (onApplicationStart ->
+// $cgiScope; onRequestStart -> $initializeRequestScope / $runOnRequestStart)
+// silently no-ops. The framework "boots" and then serves empty 200 responses
+// with no error. This single parser gap is the terminal blocker to serving a
+// Wheels request on RustCFML.
+//
+// The parse failure is CONTAINED in a runtime-instantiated fixture
+// (CfInvokeComponentAttrFixture) so it degrades that component to a non-object
+// silently instead of aborting this run. All assertions PASS on
+// Lucee/ACF/BoxLang.
+// ============================================================
+
+result = "(start)";
+try {
+	probe = createObject("component", "CfInvokeComponentAttrFixture");
+	if (isObject(probe)) {
+		result = probe.callViaCfinvoke();
+		if (isNull(result)) {
+			result = "(null - method no-op'd)";
+		}
+	} else {
+		// RustCFML: the fixture failed to parse -> non-object.
+		result = "(non-object - component failed to parse)";
+	}
+} catch (any e) {
+	result = "(threw: " & e.message & ")";
+}
+
+assert("cfinvoke component=... parses; the fixture instantiates and invokes its method",
+	result, "INVOKED_OK");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

A cross-engine test for the CFML behavior that is currently the **terminal blocker** to serving a Wheels request on RustCFML: the `component` token is treated as a hard reserved keyword, so `cfinvoke component=…` (and a bare `component = x`) fail to parse. **Passes on Lucee 7, fails on RustCFML 0.34.3.**

Contained in a runtime-instantiated fixture so the parse failure degrades only that component (to a non-object) instead of aborting the run.

## Context — Wheels boots, then this is the last wall 🎉

With #21's auto-vivify fix, Wheels now parses `Application.cfc`, runs its full lifecycle, and bootstraps DI on RustCFML. This is the next (and, as far as I can tell, last big) gap before it can actually serve a page.

## The gap

`component` is a **soft** keyword on Lucee 5/6/7, Adobe CF 2018–2025, and BoxLang — it introduces a CFC only when it *begins a declaration*, and is otherwise a normal identifier (legal as a variable name and as `cfinvoke`'s `component` attribute). RustCFML treats it as a **hard** reserved keyword. Any place the token `component` is followed by `=` fails to parse:

```
Parse error: Expected LBrace, found Equal
```

```cfml
component = "x";              // bare assignment → parse error

cfinvoke                      // script-statement attribute → parse error
component = "Svc"
method = "m";

cfinvoke(component="Svc", method="m")   // function-CALL form → parses fine ✅
```

The function-call form parsing fine (while the statement form fails) should help scope the fix, and is a viable Wheels-side workaround.

## Why it's the terminal blocker

`public/…/Global.cfc::$cfinvoke()` is written in the exact failing shape (`cfinvoke` / `component = "…"` / …). So:

1. `wheels.Global` fails to parse.
2. RustCFML degrades an unparseable component to a **non-object, silently** (no thrown error).
3. `createObject("component","wheels.Global")` → non-object → the DI Injector's `getInstance("global")` hands that to `application.wo`.
4. Every lifecycle call on `application.wo` (`$cgiScope`, `$initializeRequestScope`, `$runOnRequestStart`) **silently no-ops**.
5. `request.cgi` / `request.wheels` never get set → the dispatcher resolves an empty path → **empty 200, no error**.

I chased this through the request scope and the DI singleton before instrumenting `$initializeRequestScope` from the inside and finding it simply never runs — `application.wo` is a non-object because `wheels.Global` won't parse, and it all traces to this one token.

## Validation

| Engine | Result |
|---|---|
| Lucee 7.0.2 | **1/1 pass** (fixture parses, cfinvoke runs) |
| RustCFML 0.34.3 | **0/1** (fixture degrades to a non-object) |
