### PR TITLE
Add cross-engine tests for multi-word operators and mapping-based includes

### DIFF
--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -8,4 +8,10 @@ component {
     // Map "tags" for any tag-based test includes
     this.mappings["/tags"] = getDirectoryFromPath(getCurrentTemplatePath()) & "tags/";
 
+    // Distinct mapping name (NOT a real webroot subdirectory) used by
+    // tags/test_mapping_include.cfm to isolate this.mappings-based cfinclude
+    // resolution: a `/wheelsmapprobe/...` include can ONLY be found via this
+    // mapping, never by webroot-relative path resolution. Points at tests/tags/.
+    this.mappings["/wheelsmapprobe"] = getDirectoryFromPath(getCurrentTemplatePath()) & "tags/";
+
 }

--- a/tests/core/MultiWordOperatorFixture.cfc
+++ b/tests/core/MultiWordOperatorFixture.cfc
@@ -1,0 +1,24 @@
+component {
+
+	// Each method uses ONE multi-word CFML comparison operator. Lucee 5/6/7,
+	// Adobe CF 2018-2025, and BoxLang parse and evaluate all of them. RustCFML
+	// fails to PARSE any multi-word operator ("Expected RParen, found <next
+	// token>"), which degrades the WHOLE component to a non-object at
+	// instantiation. (Single-word operators -- IS, EQ, NEQ, GT, LT, GTE, LTE,
+	// CONTAINS, AND, OR, NOT, MOD -- all parse fine on RustCFML; only the
+	// multi-word/verbose forms fail.) Kept in a fixture so the parse failure is
+	// contained and does not abort the run.
+
+	function isNot() {
+		return (1 IS NOT 2) ? "yes" : "no";
+	}
+
+	function doesNotContain() {
+		return ("abc" DOES NOT CONTAIN "z") ? "yes" : "no";
+	}
+
+	function greaterThan() {
+		return (5 GREATER THAN 3) ? "yes" : "no";
+	}
+
+}

--- a/tests/core/test_multiword_operators.cfm
+++ b/tests/core/test_multiword_operators.cfm
@@ -1,0 +1,56 @@
+<cfscript>
+suiteBegin("Operators: multi-word comparison operators");
+
+// ============================================================
+// Background
+// ============================================================
+// CFML offers verbose, multi-word aliases for its comparison operators.
+// Lucee 5/6/7, Adobe ColdFusion 2018-2025, and BoxLang all accept them:
+//
+//     a IS NOT b                 (alias for NEQ / !=)
+//     a DOES NOT CONTAIN b       (negated CONTAINS)
+//     a GREATER THAN b           (alias for GT / >)
+//     a LESS THAN b              (alias for LT / <)
+//     a GREATER THAN OR EQUAL TO b   /   a LESS THAN OR EQUAL TO b
+//     a EQUAL b                  (alias for EQ)
+//     a NOT EQUAL b              (alias for NEQ)
+//
+// RustCFML supports every SINGLE-word operator (IS, EQ, NEQ, GT, LT, GTE,
+// LTE, CONTAINS, AND, OR, NOT, MOD) but fails to PARSE every MULTI-word one:
+//
+//     Parse error: Expected RParen, found Identifier("NOT")   // for IS NOT
+//     Parse error: Expected RParen, found Identifier("DOES")  // for DOES NOT CONTAIN
+//
+// Because a parse failure degrades the WHOLE component to a non-object
+// SILENTLY, a CFC anywhere in a codebase that uses one of these operators
+// becomes unusable. CFWheels/Wheels' Global.cfc uses `IS NOT` (x2) and
+// `DOES NOT CONTAIN` (x1); each is on the boot path, so wheels.Global will
+// not parse until these operators are supported (or the framework rewrites
+// them to single-word forms).
+//
+// This suite exercises the operators through a fixture
+// (MultiWordOperatorFixture) so the parse failure is contained -- it
+// degrades that one component to a non-object instead of aborting the run.
+// Each operator independently triggers the parse failure (verified in
+// isolation); when the component cannot parse, all three assertions report
+// "(non-object ...)". All assertions PASS on Lucee/ACF/BoxLang.
+// ============================================================
+
+ok = false;
+probe = "";
+try {
+	probe = createObject("component", "MultiWordOperatorFixture");
+	ok = isObject(probe);
+} catch (any e) {
+	ok = false;
+}
+
+assert("IS NOT parses and evaluates (1 IS NOT 2 -> true)",
+	ok ? probe.isNot() : "(non-object: component failed to parse)", "yes");
+assert("DOES NOT CONTAIN parses and evaluates ('abc' DOES NOT CONTAIN 'z' -> true)",
+	ok ? probe.doesNotContain() : "(non-object: component failed to parse)", "yes");
+assert("GREATER THAN parses and evaluates (5 GREATER THAN 3 -> true)",
+	ok ? probe.greaterThan() : "(non-object: component failed to parse)", "yes");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -209,6 +209,16 @@ try { include "core/test_forin_member_loop_var.cfm"; } catch (any e) { writeOutp
 //     for everything except the `local` scope. Wrapped in try/catch so the
 //     throw fails its assertions without aborting the run.
 try { include "core/test_undefined_var_autovivify.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undefined_var_autovivify.cfm | " & e.message & chr(10)); }
+//   - multiword_operators: RustCFML rejects multi-word comparison operators
+//     (IS NOT, DOES NOT CONTAIN, GREATER THAN, ...) while accepting all
+//     single-word forms. A CFC using one fails to parse -> non-object.
+//     wheels.Global uses IS NOT and DOES NOT CONTAIN on the boot path.
+//   - mapping_include: RustCFML does not resolve this.mappings for cfinclude
+//     template paths (reads the literal "/tags/..." -> ENOENT). wheels.Global's
+//     pseudo-constructor does `include "/app/global/functions.cfm"`, so it
+//     throws at instantiation -> non-object -> empty dispatch.
+try { include "core/test_multiword_operators.cfm"; } catch (any e) { writeOutput("ERROR | core/test_multiword_operators.cfm | " & e.message & chr(10)); }
+try { include "tags/test_mapping_include.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_mapping_include.cfm | " & e.message & chr(10)); }
 
 printSummary();
 </cfscript>

--- a/tests/tags/MappingIncludeFixture.cfc
+++ b/tests/tags/MappingIncludeFixture.cfc
@@ -1,0 +1,19 @@
+component {
+
+	// Pseudo-constructor (runs at instantiation) includes a this.mappings path.
+	// On Lucee/ACF/BoxLang the "/wheelsmapprobe" mapping resolves, this include
+	// runs, and request.mappedIncludeMarker is set. On RustCFML the mapping is
+	// NOT applied to cfinclude paths -> the literal "/wheelsmapprobe/..." read
+	// fails -> the pseudo-constructor errors -> the component degrades to a
+	// non-object SILENTLY at instantiation. This is the exact mechanism by which
+	// wheels.Global fails: its pseudo-constructor does
+	// `include "/app/global/functions.cfm"`.
+	include "/wheelsmapprobe/mapped_include_target.cfm";
+
+	this.markerFromInclude = StructKeyExists(request, "mappedIncludeMarker") ? request.mappedIncludeMarker : "(unset)";
+
+	function getMarker() {
+		return this.markerFromInclude;
+	}
+
+}

--- a/tests/tags/mapped_include_target.cfm
+++ b/tests/tags/mapped_include_target.cfm
@@ -1,0 +1,6 @@
+<cfscript>
+// Include target for test_mapping_include.cfm. Sets a request marker so the
+// includer can confirm this file was actually resolved (via the /tags mapping)
+// and executed. Lives in tests/tags/, which tests/Application.cfc maps to "/tags".
+request.mappedIncludeMarker = "MAPPED_INCLUDE_OK";
+</cfscript>

--- a/tests/tags/test_mapping_include.cfm
+++ b/tests/tags/test_mapping_include.cfm
@@ -1,0 +1,58 @@
+<cfscript>
+suiteBegin("Includes: this.mappings-based include path resolution");
+
+// ============================================================
+// Background
+// ============================================================
+// A CFML application registers path mappings via `this.mappings` in
+// Application.cfc. On Lucee 5/6/7, Adobe CF 2018-2025, and BoxLang those
+// mappings resolve BOTH component paths (createObject/new) AND template paths
+// used by cfinclude.
+//
+// tests/Application.cfc maps "/wheelsmapprobe" to the tests/tags/ directory.
+// That mapping name is deliberately NOT a real webroot subdirectory, so a
+// `/wheelsmapprobe/...` include can ONLY be resolved via the mapping --
+// webroot-relative resolution cannot find it. (Using a name like "/tags" would
+// be ambiguous: tests/tags/ exists under the webroot, so a leading-slash
+// include would resolve webroot-relative even without consulting the mapping.)
+// This isolates this.mappings resolution as the behavior under test.
+//
+// RustCFML resolves the COMPONENT form of mappings (createObject("component",
+// "wheels.Injector"), new wheels.X all work) but does NOT apply mappings to
+// cfinclude template paths: it reads the LITERAL path from the filesystem root
+// ("Cannot read '/wheelsmapprobe/mapped_include_target.cfm': No such file or
+// directory"). NB: that read-failure is also NOT catchable via try/catch on
+// RustCFML, so this test exercises the include inside a fixture's
+// PSEUDO-CONSTRUCTOR -- there the failure degrades the component to a
+// non-object silently (the same way wheels.Global degrades), which keeps the
+// run going and lets the assertion below fail cleanly rather than aborting.
+//
+// Why it matters for Wheels: public/.../Global.cfc's pseudo-constructor runs
+//
+//     include "/app/global/functions.cfm";
+//
+// relying on the "/app" mapping (app/ is a sibling of the public/ webroot, so
+// it is reachable ONLY via the mapping). On RustCFML that include reads the
+// literal path, throws, and -- because the failing pseudo-constructor degrades
+// wheels.Global to a non-object silently -- the DI Injector's
+// getInstance("global") returns a non-object, application.wo no-ops, and the
+// request renders empty. This is the runtime blocker that remains after the
+// parse-level gaps on the boot path are cleared.
+//
+// This assertion PASSES on Lucee/ACF/BoxLang.
+// ============================================================
+
+ok = false;
+probe = "";
+try {
+	probe = createObject("component", "MappingIncludeFixture");
+	ok = isObject(probe);
+} catch (any e) {
+	ok = false;
+}
+
+assert("include of a this.mappings path (/wheelsmapprobe/...) resolves and runs at instantiation",
+	ok ? probe.getMarker() : "(non-object: pseudo-constructor include failed)", "MAPPED_INCLUDE_OK");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

Two more CFML behaviors Wheels depends on that **pass on Lucee 7 and fail on RustCFML 0.34.3**. Both sit on the `wheels.Global` boot path: with #21 (auto-vivify, merged) and #22 (`component` keyword) addressed, these are the gaps that still stop the framework from serving a request. Each failure is contained (degrades a fixture to a non-object) so the suite run completes.

## 1. Multi-word comparison operators

`tests/core/test_multiword_operators.cfm` (+ `MultiWordOperatorFixture.cfc`)

CFML offers verbose multi-word aliases for its comparison operators. Lucee/ACF/BoxLang accept them. RustCFML accepts every **single-word** operator (`IS`, `EQ`, `NEQ`, `GT`, `LT`, `GTE`, `LTE`, `CONTAINS`, `AND`, `OR`, `NOT`, `MOD`) but fails to **parse** every **multi-word** one:

```cfml
1 IS NOT 2                 // Parse error: Expected RParen, found Identifier("NOT")
"ab" DOES NOT CONTAIN "z"  // Parse error: Expected RParen, found Identifier("DOES")
5 GREATER THAN 3           // (also: LESS THAN, EQUAL, NOT EQUAL, GREATER THAN OR EQUAL TO, …)
```

A CFC using any of these fails to parse and degrades to a non-object. `wheels.Global` uses `IS NOT` (×2) and `DOES NOT CONTAIN` (×1) on the boot path. Each operator independently triggers the failure (verified in isolation); the fixture contains it so the run isn't aborted.

## 2. `this.mappings`-based `cfinclude` resolution

`tests/tags/test_mapping_include.cfm` (+ `MappingIncludeFixture.cfc`, `mapped_include_target.cfm`, and a `/wheelsmapprobe` mapping in `tests/Application.cfc`)

`this.mappings` resolves **both** component paths *and* `cfinclude` template paths on Lucee/ACF/BoxLang. RustCFML resolves the **component** form (`new wheels.X`, `getInstance(...)` all work) but **not** `cfinclude`: it reads the literal path from the filesystem root and throws —

```
Cannot read '/wheelsmapprobe/mapped_include_target.cfm': No such file or directory
```

Two deliberate test-design choices, both explained inline:
- The mapping name (`/wheelsmapprobe`) is **not** a real webroot subdirectory, so the include can only resolve via the mapping — isolating mapping resolution from webroot-relative resolution.
- The read-failure **escapes `try/catch`** on RustCFML, so the include runs inside a fixture's **pseudo-constructor**, where the failure degrades the component to a non-object *silently* (keeping the run going).

This is exactly how `wheels.Global` fails: its pseudo-constructor runs `include "/app/global/functions.cfm"` (and `app/` is a sibling of the `public/` webroot, reachable **only** via the `/app` mapping). That throw degrades `wheels.Global` to a non-object → the DI Injector's `getInstance("global")` returns a non-object → `application.wo` no-ops → the request renders empty.

## The boot ladder (context)

Booting Wheels on RustCFML has turned out to be a ladder of narrow engine gaps, each surfacing the next:

```
auto-vivify (#21, merged) → cfinvoke `component` attr (#22) → IS NOT / DOES NOT CONTAIN → this.mappings cfinclude → …
```

This PR covers rungs 3 and 4.

## Validation

| Engine | Operators | Mapping include |
|---|---|---|
| Lucee 7.0.2 | **3/3 pass** | **1/1 pass** |
| RustCFML 0.34.3 | **0/3** (non-object) | **0/1** (non-object) |

Full suite run completes on both; no aborts.
