### PR TITLE
Add cross-engine tests for component declaration-header attribute parsing

### DIFF
--- a/tests/core/DeclAttrBase.cfc
+++ b/tests/core/DeclAttrBase.cfc
@@ -1,0 +1,7 @@
+// Plain base component for the declaration-header attribute fixtures: the
+// `extends=...` targets below point here. Attribute-less header — already parses.
+component {
+	public string function whoAmI() {
+		return "base";
+	}
+}

--- a/tests/core/ExtendsAfterAttrFixture.cfc
+++ b/tests/core/ExtendsAfterAttrFixture.cfc
@@ -1,0 +1,14 @@
+// Gap A fixture: `extends` appears AFTER another attribute (`output="false"`).
+// On Lucee/Adobe CF/BoxLang component attributes are order-independent, so this
+// parses and instantiates exactly like ExtendsFirstFixture. On RustCFML 0.36.0
+// the parser only accepts `extends` as the FIRST attribute; placed later it
+// fails to parse and the component degrades to a non-object.
+//
+// This is the dominant header shape in the Wheels framework — every CFC in the
+// boot cascade is written `component output="false" ... extends="wheels.Global" {`
+// (Controller, Model, Dispatch, Migrator, Plugins, Public, Test).
+component output="false" extends="DeclAttrBase" {
+	public string function ping() {
+		return "pong";
+	}
+}

--- a/tests/core/ExtendsFirstFixture.cfc
+++ b/tests/core/ExtendsFirstFixture.cfc
@@ -1,0 +1,9 @@
+// Control fixture: `extends` as the FIRST component attribute, followed by
+// another attribute. RustCFML already parses this shape — it is the regression
+// guard that proves the fixture wiring (base lookup, createObject) is sound, so
+// a failure on the sibling ExtendsAfterAttrFixture isolates to attribute ORDER.
+component extends="DeclAttrBase" output="false" {
+	public string function ping() {
+		return "pong";
+	}
+}

--- a/tests/core/QuotedBoolFixture.cfc
+++ b/tests/core/QuotedBoolFixture.cfc
@@ -1,0 +1,8 @@
+// Control fixture: boolean attribute value written as a QUOTED string. RustCFML
+// already parses this — pairs with UnquotedBoolFixture to isolate the gap to the
+// unquoted boolean keyword in the value position (not the `output` attribute).
+component output="false" {
+	public string function ping() {
+		return "pong";
+	}
+}

--- a/tests/core/UnquotedBoolFixture.cfc
+++ b/tests/core/UnquotedBoolFixture.cfc
@@ -1,0 +1,15 @@
+// Gap B fixture: an UNQUOTED boolean keyword as a component attribute value
+// (`output=false`). On Lucee/Adobe CF/BoxLang an unquoted boolean (or bare
+// identifier) is a legal attribute value, so this parses and instantiates. On
+// RustCFML 0.36.0 the value `false` lexes as a Boolean-literal token and the
+// component-attribute parser rejects it ("Expected LBrace, found False"); the
+// component degrades to a non-object.
+//
+// Wheels uses this house style across its database adapters:
+// `component extends="wheels.databaseAdapters.Base" output=false {`
+// (Base + the MySQL/PostgreSQL/MSSQL/Oracle/SQLite/H2/CockroachDB models).
+component output=false {
+	public string function ping() {
+		return "pong";
+	}
+}

--- a/tests/core/test_component_declaration_attributes.cfm
+++ b/tests/core/test_component_declaration_attributes.cfm
@@ -1,0 +1,62 @@
+<cfscript>
+suiteBegin("Core: component declaration-header attribute parsing");
+
+// ============================================================
+// Background
+// ============================================================
+// CFML component declarations carry zero or more metadata attributes in the
+// header before the body brace, e.g. `component output="false" extends="Foo" {`.
+// On Lucee 5/6/7, Adobe ColdFusion 2018-2025, and BoxLang these attributes are
+// ORDER-INDEPENDENT and their values may be written quoted OR unquoted (a bare
+// boolean keyword / identifier is a legal attribute value).
+//
+// RustCFML 0.36.0 made `component` a soft keyword and accepts a single leading
+// metadata attribute, but two header shapes that the framework relies on still
+// fail to parse — and because an unparseable component degrades to a non-object
+// (silently, no throw), the failure is invisible until you ask `isObject()`:
+//
+//   A. `extends` is only accepted as the FIRST attribute. Placed after another
+//      attribute it fails: `Parse error: Expected LBrace, found Extends`.
+//        component extends="Base" output="false" {}   -> parses (control)
+//        component output="false" extends="Base" {}   -> FAILS  (gap A)
+//      This is the dominant Wheels header shape — the entire boot cascade is
+//      `component output="false" ... extends="wheels.Global" {`.
+//
+//   B. An UNQUOTED boolean attribute value is rejected. The value `false` lexes
+//      as a Boolean-literal token the attribute parser will not accept:
+//        component output="false" {}   -> parses (control)
+//        component output=false {}     -> FAILS  (gap B: Expected LBrace, found False)
+//      Wheels writes its database adapters this way:
+//        component extends="wheels.databaseAdapters.Base" output=false {}
+//
+// The failing headers live in runtime-instantiated FIXTURE CFCs (not inline)
+// because a parse error escapes try/catch and would abort the whole runner; via
+// createObject the unparseable fixture degrades to a non-object instead.
+// ============================================================
+
+// Load a fixture and return its ping(); a sentinel if the header failed to parse.
+// On every JVM engine the fixture parses and ping() returns "pong". When the
+// header fails to parse on RustCFML, createObject yields a non-object, so we
+// surface "NOT-A-COMPONENT" and the assertion shows the gap.
+function loadPing(required string name) {
+	var o = createObject("component", arguments.name);
+	return isObject(o) ? o.ping() : "NOT-A-COMPONENT";
+}
+
+// --- controls: header shapes RustCFML already accepts (regression guards) ----
+
+assert("control: `extends` as the FIRST attribute parses", loadPing("ExtendsFirstFixture"), "pong");
+assert("control: a quoted boolean attribute value parses", loadPing("QuotedBoolFixture"), "pong");
+
+// --- gap A: `extends` after another attribute --------------------------------
+
+assert("`extends` after another attribute parses (output=... extends=...)",
+	loadPing("ExtendsAfterAttrFixture"), "pong");
+
+// --- gap B: unquoted boolean attribute value ---------------------------------
+
+assert("an unquoted boolean attribute value parses (output=false)",
+	loadPing("UnquotedBoolFixture"), "pong");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -234,6 +234,15 @@ try { include "core/test_component_soft_keyword.cfm"; } catch (any e) { writeOut
 //     also accepts the ACF-style cf-prefixed `cfinvoke` spelling, but Lucee
 //     rejects it, so the cross-engine test uses the cf-less `invoke`.)
 try { include "tags/test_cfinvoke_statement.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfinvoke_statement.cfm | " & e.message & chr(10)); }
+//   - component_declaration_attributes: follow-on to component_soft_keyword.
+//     Component-header metadata attributes are order-independent and may be
+//     written quoted or unquoted on Lucee/ACF/BoxLang. Two shapes the Wheels
+//     boot cascade relies on still fail to parse on RustCFML: (A) `extends`
+//     placed AFTER another attribute (component output="false" extends="..."),
+//     and (B) an unquoted boolean attribute value (component output=false).
+//     Failing headers live in fixtures (parse errors escape try/catch); via
+//     createObject they degrade to a non-object, so the assertions show the gap.
+try { include "core/test_component_declaration_attributes.cfm"; } catch (any e) { writeOutput("ERROR | core/test_component_declaration_attributes.cfm | " & e.message & chr(10)); }
 
 printSummary();
 </cfscript>


### PR DESCRIPTION
Follow-on to the v0.36.0 *Soft `component` keyword* work. While booting the Wheels framework on 0.36.0 I hit two more component-declaration **header** shapes that Lucee 5/6/7, Adobe CF 2018-2025, and BoxLang all accept but RustCFML rejects at parse time. Both gate the framework boot, and both are invisible without `isObject()` because an unparseable component degrades to a non-object silently (no throw).

This PR adds **one new cross-engine suite** (`tests/core/test_component_declaration_attributes.cfm` + 5 small fixtures) covering them.

## The two gaps

**A. `extends` is only accepted as the *first* attribute.** Placed after another attribute it fails to parse:

```cfml
component extends="Base" output="false" {}   // parses (control)
component output="false" extends="Base" {}   // FAIL: Expected LBrace, found Extends
```

This is the dominant header shape in Wheels — the entire boot cascade is written `component output="false" ... extends="wheels.Global" {`: `Controller.cfc`, `Model.cfc`, `Dispatch.cfc`, `Migrator.cfc`, `Plugins.cfc`, `Public.cfc`, `Test.cfc`, plus `databaseAdapters/Base.cfc`.

**B. An unquoted boolean attribute value is rejected.** The value `false`/`true` lexes as a Boolean-literal token the attribute parser won't accept:

```cfml
component output="false" {}   // parses (control)
component output=false {}     // FAIL: Expected LBrace, found False
```

Wheels writes all of its database adapters this way: `component extends="wheels.databaseAdapters.Base" output=false {` (`Base` + the MySQL / PostgreSQL / MSSQL / Oracle / SQLite / H2 / CockroachDB models).

## Verification

| Engine | Result |
|--------|--------|
| Lucee 7.0.2 | **4/4 pass** |
| RustCFML 0.36.0 | 2/4 — both controls pass; gaps A and B fail |

The failing headers live in runtime-instantiated **fixtures** (a parse error escapes `try/catch` and would abort the runner); via `createObject` the unparseable fixture degrades to a non-object, so the assertions surface the gap and the full runner still reaches `printSummary()`. Full-suite run on 0.36.0: 3092/3097, with the two intended new reds in this suite (the other reds are the pre-existing custom-tag-lifecycle suite, untouched here).

---

## Other gaps found while booting Wheels on 0.36 (not in this PR — just signal)

Sharing these so you have the full roadmap; happy to send self-contained cross-engine tests for any you'd like. All pass on Lucee/ACF/BoxLang and fail on 0.36.0.

- **`interface extends="..."`** — same `extends`-attribute theme, but on an interface declaration. `interface extends="Base" {}` → `Expected LBrace, found Equal` (col 18). Attribute-less `interface {}` parses; `interface displayname="x" {}` parses. Used in `vendor/wheels/interfaces/` (MiddlewareInterface, ServiceProviderInterface, AuthStrategy, AuthenticatorInterface).
- **Dotted FQN type as a function-param type** — `function f( required a.b.C x ){}` → `Expected RParen, found Dot`. A single-token type (`string`, `Foo`) parses; only the dotted form breaks. Used throughout the wheelstest (TestBox-derived) runners/reporters: `required wheels.wheelstest.system.TestResult results`.
- **Compound assignment in a `for` increment** — `for (i=1; i<=10; i+=2){}` → `Expected RParen, found PlusEqual`. Standalone `i += 2;` parses and runs fine — only the for-increment position rejects it. Used in `vendor/wheels/model/bulk.cfc`.
- **Script function with a post-`()` attribute** — `function f() output=true { return 1; }` → `Expected RBrace, found Integer(1)` (the body `{` is parsed as a struct literal). `remote function f(){...}` is fine; only the trailing `attr=value` after `()` breaks. Used in the wheelstest BaseSpec.

And one runtime observation (not a parse gap, less certain — no clean standalone repro yet): the next rung after the parse gaps is `injector.map("global")` resolving to the built-in `map(callback)` struct/array member function instead of the Injector CFC's own `map()` method, so it throws on a non-closure arg. On JVM engines a built-in member function does not shadow a same-named CFC instance method. Mentioning only as a heads-up.

(Separately: the new script-statement `cfinvoke component=... method=...;` form added in 0.36 works great — that was the original blocker. The function-call form `cfinvoke(component="x", method="m")` parses but doesn't read the `component` named arg at runtime → `Component '' not found`. Not a Wheels blocker since the framework uses the statement form.)
