### PR TITLE
Add CFML test for ordered struct literals

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -45,6 +45,7 @@ try { include "types/test_array_append_grow.cfm"; } catch (any e) { writeOutput(
 try { include "types/test_array_reference_semantics.cfm"; } catch (any e) { writeOutput("ERROR | types/test_array_reference_semantics.cfm | " & e.message & chr(10)); }
 try { include "types/test_struct.cfm"; } catch (any e) { writeOutput("ERROR | types/test_struct.cfm | " & e.message & chr(10)); }
 try { include "types/test_struct_reference_semantics.cfm"; } catch (any e) { writeOutput("ERROR | types/test_struct_reference_semantics.cfm | " & e.message & chr(10)); }
+try { include "types/test_ordered_struct_literals.cfm"; } catch (any e) { writeOutput("ERROR | types/test_ordered_struct_literals.cfm | " & e.message & chr(10)); }
 try { include "types/test_nested_writeback.cfm"; } catch (any e) { writeOutput("ERROR | types/test_nested_writeback.cfm | " & e.message & chr(10)); }
 try { include "types/test_query.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query.cfm | " & e.message & chr(10)); }
 try { include "types/test_query_column.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_column.cfm | " & e.message & chr(10)); }

--- a/tests/types/test_ordered_struct_literals.cfm
+++ b/tests/types/test_ordered_struct_literals.cfm
@@ -1,0 +1,13 @@
+<cfscript>
+suiteBegin("Ordered struct literals");
+
+indexes = [
+    "idx_one": { "type": "btree", "fields": "name" },
+    "idx_two": { "type": "btree", "fields": "created_at" }
+];
+
+assertTrue("bracketed key-value literal builds struct", structKeyExists(indexes, "idx_one"));
+assert("bracketed key-value literal preserves member access", indexes.idx_two.fields, "created_at");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary
- Adds a CFML runner test for Lucee-style bracketed key-value struct literals.
- The repro comes from Moopa table/index metadata, where literal keys like `"idx_one": { ... }` are used inside bracketed struct literals.

## Current RustCFML behavior
Running the new test on current `main` fails while parsing the colon after the quoted key:

```text
Parse error in tests/types/test_ordered_struct_literals.cfm [line 5, col 14]: Expected RBracket, found Colon
```

## Test
- `cargo run -- tests/types/test_ordered_struct_literals.cfm`