### PR TITLE
Add CFML test for createUniqueID

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -84,6 +84,7 @@ try { include "stdlib/test_bitmask_functions.cfm"; } catch (any e) { writeOutput
 try { include "stdlib/test_xml_dom_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_xml_dom_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_misc_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_misc_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_len_scalar_coercion.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_len_scalar_coercion.cfm | " & e.message & chr(10)); }
+try { include "stdlib/test_create_unique_id.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_create_unique_id.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_valuelist_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_valuelist_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_callstack.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_callstack.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_precisionevaluate.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_precisionevaluate.cfm | " & e.message & chr(10)); }

--- a/tests/stdlib/test_create_unique_id.cfm
+++ b/tests/stdlib/test_create_unique_id.cfm
@@ -1,0 +1,12 @@
+<cfscript>
+suiteBegin("CreateUniqueID");
+
+firstId = createUniqueID();
+secondId = createUniqueID();
+
+assert("createUniqueID length", len(firstId), 32);
+assertTrue("createUniqueID returns uppercase hex", reFind("^[0-9A-F]{32}$", firstId) == 1);
+assertTrue("createUniqueID returns distinct values", firstId != secondId);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary
- Adds a CFML runner test for Lucee-compatible `createUniqueID()` behaviour.
- Moopa uses this helper when generating short unique identifiers, and Lucee returns a 32-character uppercase hexadecimal value.

## Expected Behaviour
`createUniqueID()` should return a 32-character uppercase hex string, and repeated calls should produce distinct values.

## Current RustCFML Behaviour
Running the runner on current `main` reports the missing builtin:

```text
ERROR | stdlib/test_create_unique_id.cfm | Variable 'createUniqueID' is undefined
```

## Test
- `cargo run -- tests/runner.cfm`
