### PR TITLE
Add CFML test for preserveSingleQuotes

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -84,6 +84,7 @@ try { include "stdlib/test_bitmask_functions.cfm"; } catch (any e) { writeOutput
 try { include "stdlib/test_xml_dom_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_xml_dom_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_misc_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_misc_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_len_scalar_coercion.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_len_scalar_coercion.cfm | " & e.message & chr(10)); }
+try { include "stdlib/test_preserve_single_quotes.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_preserve_single_quotes.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_valuelist_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_valuelist_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_callstack.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_callstack.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_precisionevaluate.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_precisionevaluate.cfm | " & e.message & chr(10)); }

--- a/tests/stdlib/test_preserve_single_quotes.cfm
+++ b/tests/stdlib/test_preserve_single_quotes.cfm
@@ -1,0 +1,8 @@
+<cfscript>
+suiteBegin("PreserveSingleQuotes");
+
+fragment = "person.id::text AS id,'label',person.label";
+assert("preserveSingleQuotes returns original SQL fragment", preserveSingleQuotes(fragment), fragment);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary
- Adds a CFML runner test for Lucee-compatible `preserveSingleQuotes()` behaviour.
- Moopa uses this helper around SQL fragments that contain quoted literals and PostgreSQL casts.

## Expected Behaviour
`preserveSingleQuotes(value)` should return the original string unchanged while marking embedded single quotes as preserved for query handling, matching Lucee compatibility expectations.

## Current RustCFML Behaviour
Running the runner on current `main` reports the missing builtin:

```text
ERROR | stdlib/test_preserve_single_quotes.cfm | Variable 'preserveSingleQuotes' is undefined
```

## Test
- `cargo run -- tests/runner.cfm`
