### PR TITLE
Add CFML test for keyword member loop targets

### DIFF
--- a/tests/core/test_forin_keyword_member_access.cfm
+++ b/tests/core/test_forin_keyword_member_access.cfm
@@ -1,0 +1,13 @@
+<cfscript>
+suiteBegin("For-in keyword member access");
+
+local = {};
+items = ["ok"];
+for (var local.package in items) {
+    keywordLoopResult = local.package;
+}
+
+assert("script for-in allows keyword property in dotted variable", keywordLoopResult, "ok");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -238,6 +238,10 @@ try { include "core/test_component_soft_keyword.cfm"; } catch (any e) { writeOut
 //     also accepts the ACF-style cf-prefixed `cfinvoke` spelling, but Lucee
 //     rejects it, so the cross-engine test uses the cf-less `invoke`.)
 try { include "tags/test_cfinvoke_statement.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfinvoke_statement.cfm | " & e.message & chr(10)); }
+// Moopa route metadata can use keyword property names in dotted loop targets
+// (for example local.package). Lucee accepts this; RustCFML currently fails
+// to parse the loop target, so keep this fatal repro last.
+try { include "core/test_forin_keyword_member_access.cfm"; } catch (any e) { writeOutput("ERROR | core/test_forin_keyword_member_access.cfm | " & e.message & chr(10)); }
 
 printSummary();
 </cfscript>


### PR DESCRIPTION
## Summary
- Adds a CFML runner test for Lucee-compatible dotted loop targets whose final member name is a keyword.
- Moopa route metadata can use names such as `local.package`; Lucee allows this as ordinary member access.

## Expected Behaviour
A script `for ... in` loop should allow assigning each item into a dotted variable target like `local.package`, even though `package` is a keyword-like identifier.

## Current RustCFML Behaviour
Running the runner on current `main` reaches the new final repro and fails while parsing the loop target:

```text
Parse error in tests/core/test_forin_keyword_member_access.cfm [line 6, col 24]: Expected Semicolon, found In
```

## Test
- `cargo run -- tests/runner.cfm`
