### PR TITLE
Add CFML test for dotted function names

### DIFF
--- a/tests/oop/MetadataDottedFunctionRoute.cfc
+++ b/tests/oop/MetadataDottedFunctionRoute.cfc
@@ -1,0 +1,5 @@
+<cfcomponent key="route-key" open_to="security">
+    <cffunction name="uploadFileToServerWithProgress.profile_picture_id">
+        <cfreturn "ok" />
+    </cffunction>
+</cfcomponent>

--- a/tests/oop/test_dotted_function_names.cfm
+++ b/tests/oop/test_dotted_function_names.cfm
@@ -1,0 +1,19 @@
+<cfscript>
+suiteBegin("Dotted function names");
+
+route = createObject("component", "oop.MetadataDottedFunctionRoute");
+md = getMetaData(route);
+
+functionNames = [];
+for (fn in md.functions) {
+    arrayAppend(functionNames, fn.name);
+}
+
+assertTrue(
+    "component metadata preserves dotted function name",
+    arrayFind(functionNames, "uploadFileToServerWithProgress.profile_picture_id") > 0
+);
+assert("dotted function is callable", route["uploadFileToServerWithProgress.profile_picture_id"](), "ok");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -107,6 +107,7 @@ try { include "oop/test_inheritance.cfm"; } catch (any e) { writeOutput("ERROR |
 try { include "oop/test_inherited_helpers.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inherited_helpers.cfm | " & e.message & chr(10)); }
 try { include "oop/test_interfaces.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_interfaces.cfm | " & e.message & chr(10)); }
 try { include "oop/test_metadata.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_metadata.cfm | " & e.message & chr(10)); }
+try { include "oop/test_dotted_function_names.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_dotted_function_names.cfm | " & e.message & chr(10)); }
 try { include "oop/test_property_attributes.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_property_attributes.cfm | " & e.message & chr(10)); }
 try { include "oop/test_struct_method_dispatch.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_struct_method_dispatch.cfm | " & e.message & chr(10)); }
 try { include "oop/test_external_prop.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_external_prop.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner test for Lucee-compatible component function names that contain dots.
- Moopa uses generated endpoint/function names such as `uploadFileToServerWithProgress.profile_picture_id` for field-specific upload handlers.

## Expected Behaviour
A component method declared with a dotted `cffunction name` should appear in component metadata with its full name and remain callable by bracket lookup.

## Current RustCFML Behaviour
Running the runner on current `main` reaches the new test and fails when calling the dotted function by name:

```text
ERROR | oop/test_dotted_function_names.cfm | Variable is not a function or function '<unknown>' is not defined
```

## Test
- `cargo run -- tests/runner.cfm`
