### PR TITLE
Add CFML test for soft-keyword function names

### DIFF
--- a/tests/oop/MetadataSoftKeywordRoute.cfc
+++ b/tests/oop/MetadataSoftKeywordRoute.cfc
@@ -1,0 +1,5 @@
+<cfcomponent key="route-key" open_to="security">
+    <cffunction name="new">
+        <cfreturn { ok = true } />
+    </cffunction>
+</cfcomponent>

--- a/tests/oop/test_soft_keyword_function_name.cfm
+++ b/tests/oop/test_soft_keyword_function_name.cfm
@@ -1,0 +1,16 @@
+<cfscript>
+suiteBegin("Soft-keyword function names");
+
+route = createObject("component", "oop.MetadataSoftKeywordRoute");
+md = getMetaData(route);
+
+functionNames = [];
+for (fn in md.functions) {
+    arrayAppend(functionNames, fn.name);
+}
+
+assertTrue("component metadata preserves soft-keyword function name", arrayFind(functionNames, "new") > 0);
+assertTrue("soft-keyword function is callable", route.new().ok);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -107,6 +107,7 @@ try { include "oop/test_inheritance.cfm"; } catch (any e) { writeOutput("ERROR |
 try { include "oop/test_inherited_helpers.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inherited_helpers.cfm | " & e.message & chr(10)); }
 try { include "oop/test_interfaces.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_interfaces.cfm | " & e.message & chr(10)); }
 try { include "oop/test_metadata.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_metadata.cfm | " & e.message & chr(10)); }
+try { include "oop/test_soft_keyword_function_name.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_soft_keyword_function_name.cfm | " & e.message & chr(10)); }
 try { include "oop/test_property_attributes.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_property_attributes.cfm | " & e.message & chr(10)); }
 try { include "oop/test_struct_method_dispatch.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_struct_method_dispatch.cfm | " & e.message & chr(10)); }
 try { include "oop/test_external_prop.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_external_prop.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary
- Adds a CFML runner test for Lucee-compatible component function names that use soft-keyword identifiers.
- Moopa can define route-style component methods named `new`, and Lucee preserves/calls those methods normally.

## Expected Behaviour
A `<cffunction name="new">` method should appear in `getMetadata(component).functions` as `new` and should be callable as `component.new()`.

## Current RustCFML Behaviour
Running the runner on current `main` reaches the new test but the method is neither present in metadata nor callable:

```text
FAIL | Soft-keyword function names | 0/2 passed (2 failed)
```

## Test
- `cargo run -- tests/runner.cfm`
