### PR TITLE
Add CFML test for query column scalar coercion

### DIFF
--- a/tests/types/test_query_column.cfm
+++ b/tests/types/test_query_column.cfm
@@ -40,6 +40,14 @@ assert("for-in yields first row only", collected, "Alice,");
 assert("valueList iterates rows", valueList(q.name), "Alice,Bob");
 assert("quotedValueList iterates rows", quotedValueList(q.name), "'Alice','Bob'");
 
+// --- QueryColumn scalar proxy should coerce to the first row value ---
+qScalar = queryNew("times,iterations,name", "integer,integer,varchar", [
+    { times = 3, iterations = 120000, name = "index.cfc" }
+]);
+assert("query column coerces to number for builtin argument", repeatString("x", qScalar.times), "xxx");
+assert("query column scalar compares against first row", qScalar.name EQ "INDEX.CFC", true);
+assert("query column scalar reversed compare uses first row", "index.cfc" NEQ qScalar.name, false);
+
 // --- elvis: q.col stringifies to first row ---
 val = q.name ?: "fallback";
 assert("elvis yields proxy (stringified)", val & "", "Alice");


### PR DESCRIPTION
## Summary
- Adds CFML runner assertions for Lucee-compatible scalar coercion of query column proxies.
- Moopa can pass single-row query columns into scalar contexts such as builtin arguments and comparisons.

## Expected Behaviour
A query column proxy used in a scalar context should coerce to the first row value, including numeric builtin arguments and equality comparisons.

## Current RustCFML Behaviour
Running the runner on current `main` fails the new assertions:

```text
FAIL | Type: QueryColumn proxy | 12/15 passed (3 failed)
FAIL: query column coerces to number for builtin argument | expected: [xxx] | got: []
FAIL: query column scalar compares against first row | expected: [true] | got: [false]
FAIL: query column scalar reversed compare uses first row | expected: [false] | got: [true]
```

## Test
- `cargo run -- tests/runner.cfm`
