### PR TITLE
Add cross-engine tests for reserved-word identifiers and quoted catch types

### DIFF
--- a/tests/core/NewMethodFixture.cfc
+++ b/tests/core/NewMethodFixture.cfc
@@ -1,0 +1,17 @@
+// Fixture: a component with a method literally named `new`. On Lucee/Adobe CF/
+// BoxLang `new` is a SOFT keyword — it introduces the `new Foo()` operator, but
+// is equally legal as a function name, and calling it via `this.new()` works.
+// On RustCFML 0.37.0 `new` is a HARD reserved keyword, so `function new(){...}`
+// fails to parse ("Expected identifier, found New") and the component degrades
+// to a non-object.
+//
+// Wheels' core object-creation API depends on this: `model("User").new()` is
+// backed by `public any function new(...)` in vendor/wheels/model/create.cfc.
+component {
+	public string function new() {
+		return "made";
+	}
+	public string function probe() {
+		return this.new();
+	}
+}

--- a/tests/core/QuotedCatchFixture.cfc
+++ b/tests/core/QuotedCatchFixture.cfc
@@ -1,0 +1,21 @@
+// Fixture: a try/catch whose catch clause names the exception type as a QUOTED
+// string literal (a dotted custom type that is not a bare identifier). On
+// Lucee/Adobe CF/BoxLang the catch type may be written as a quoted string, which
+// is how you catch a namespaced custom exception. On RustCFML 0.37.0 the catch
+// parser expects a bare identifier and rejects the string literal ("Expected
+// identifier, found String(...)"), so the component degrades to a non-object.
+//
+// Wheels uses this on the boot path — e.g. vendor/wheels/Public.cfc:
+//   catch ("Wheels.Packages.RegistryUnavailable" e) { ... }
+// and vendor/wheels/auth/JwtStrategy.cfc:
+//   catch ("Wheels.Auth.JWT.TokenExpired" e) { ... }
+component {
+	public string function probe() {
+		try {
+			throw(type = "A.B.C", message = "boom");
+		} catch ("A.B.C" e) {
+			return "caught";
+		}
+		return "not-caught";
+	}
+}

--- a/tests/core/ReservedParamFixture.cfc
+++ b/tests/core/ReservedParamFixture.cfc
@@ -1,0 +1,16 @@
+// Fixture: a function whose parameters are named with the soft keywords
+// `extends` and `implements`. On Lucee/Adobe CF/BoxLang these are legal
+// parameter names (and reachable via the arguments scope). On RustCFML 0.37.0
+// they are hard reserved keywords, so the parameter declaration fails to parse
+// ("Expected RParen, found Extends") and the component degrades to a non-object.
+//
+// Mirrors vendor/wheels/wheelstest/system/mockutils/MockGenerator.cfc:
+//   function generateClass( string extends="", string implements="" ) { ... }
+component {
+	public string function gen(string extends = "", string implements = "") {
+		return arguments.extends & "/" & arguments.implements;
+	}
+	public string function probe() {
+		return gen("a", "b");
+	}
+}

--- a/tests/core/test_quoted_catch_type.cfm
+++ b/tests/core/test_quoted_catch_type.cfm
@@ -1,0 +1,34 @@
+<cfscript>
+suiteBegin("Core: quoted string catch type");
+
+// ============================================================
+// Background
+// ============================================================
+// A try/catch clause may name the exception type either as a bare identifier
+// (`catch (any e)`, `catch (Application e)`) or as a QUOTED STRING literal
+// (`catch ("My.Custom.Type" e)`). The quoted form is how CFML catches a dotted,
+// namespaced custom exception, and it is accepted on Lucee 5/6/7, Adobe CF
+// 2018-2025, and BoxLang.
+//
+// RustCFML 0.37.0's catch parser expects a bare identifier in the type position
+// and rejects the string literal: "Expected identifier, found String(...)". The
+// enclosing component then fails to parse and degrades to a non-object.
+//
+// This is the next blocker on the Wheels boot path after the component-header
+// gaps: vendor/wheels/Public.cfc:56 (instantiated at onApplicationStart) does
+// `catch ("Wheels.Packages.RegistryUnavailable" e) {`, and
+// vendor/wheels/auth/JwtStrategy.cfc does `catch ("Wheels.Auth.JWT.TokenExpired" e) {`.
+//
+// The failing catch lives in a fixture (a parse error escapes try/catch and
+// would abort the runner); via createObject it degrades to a non-object.
+// ============================================================
+
+function loadProbe(required string name) {
+	var o = createObject("component", arguments.name);
+	return isObject(o) ? o.probe() : "NOT-A-COMPONENT";
+}
+
+assert("a quoted string catch type parses and catches the thrown type", loadProbe("QuotedCatchFixture"), "caught");
+
+suiteEnd();
+</cfscript>

--- a/tests/core/test_reserved_word_identifiers.cfm
+++ b/tests/core/test_reserved_word_identifiers.cfm
@@ -1,0 +1,39 @@
+<cfscript>
+suiteBegin("Core: reserved words usable as identifiers");
+
+// ============================================================
+// Background
+// ============================================================
+// Several words RustCFML treats as hard reserved keywords are only SOFT
+// keywords on Lucee 5/6/7, Adobe ColdFusion 2018-2025, and BoxLang — reserved
+// for one grammatical role, but otherwise legal as ordinary identifiers. v0.36.0
+// already made `component` soft (usable as a variable / struct key / cfinvoke
+// attribute). Two more that the Wheels framework relies on are still hard:
+//
+//   * `new` as a FUNCTION NAME. `new Foo()` is the instantiation operator, but
+//     `new` is also a valid method name. Wheels' core creation API is built on
+//     it: `model("User").new()` -> `public any function new(...)` in
+//     vendor/wheels/model/create.cfc. On RustCFML the declaration
+//     `function new(){...}` fails to parse: "Expected identifier, found New".
+//
+//   * `extends` / `implements` as PARAMETER NAMES. Both are declaration keywords
+//     but legal argument names. Wheels uses them in
+//     vendor/wheels/wheelstest/system/mockutils/MockGenerator.cfc:
+//     `function generateClass( string extends="", string implements="" )`.
+//     On RustCFML the parameter declaration fails: "Expected RParen, found Extends".
+//
+// An unparseable component degrades to a non-object (silently, no throw), so the
+// failing declarations live in fixtures and are reached via createObject; the
+// helper returns a sentinel when the fixture did not parse.
+// ============================================================
+
+function loadProbe(required string name) {
+	var o = createObject("component", arguments.name);
+	return isObject(o) ? o.probe() : "NOT-A-COMPONENT";
+}
+
+assert("a method named `new` parses and is callable (model().new())", loadProbe("NewMethodFixture"), "made");
+assert("`extends`/`implements` are usable as parameter names", loadProbe("ReservedParamFixture"), "a/b");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -238,6 +238,16 @@ try { include "core/test_component_soft_keyword.cfm"; } catch (any e) { writeOut
 //     also accepts the ACF-style cf-prefixed `cfinvoke` spelling, but Lucee
 //     rejects it, so the cross-engine test uses the cf-less `invoke`.)
 try { include "tags/test_cfinvoke_statement.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfinvoke_statement.cfm | " & e.message & chr(10)); }
+//   - reserved_word_identifiers: extends component_soft_keyword to two more words
+//     that are SOFT keywords on Lucee/ACF/BoxLang but hard-reserved on RustCFML:
+//     `new` as a function name (Wheels' model().new() core API) and `extends`/
+//     `implements` as parameter names. Failing decls live in fixtures.
+try { include "core/test_reserved_word_identifiers.cfm"; } catch (any e) { writeOutput("ERROR | core/test_reserved_word_identifiers.cfm | " & e.message & chr(10)); }
+//   - quoted_catch_type: a catch clause may name the exception type as a quoted
+//     string (`catch ("My.Type" e)`) on Lucee/ACF/BoxLang. RustCFML expects a
+//     bare identifier. This is the next Wheels boot blocker after the header
+//     gaps (Public.cfc onApplicationStart). Failing catch lives in a fixture.
+try { include "core/test_quoted_catch_type.cfm"; } catch (any e) { writeOutput("ERROR | core/test_quoted_catch_type.cfm | " & e.message & chr(10)); }
 
 printSummary();
 </cfscript>


### PR DESCRIPTION
Continuing the Wheels-on-RustCFML compatibility work (follow-on to #24). While booting the Wheels framework on **v0.37.0**, three more constructs that Lucee 5/6/7, Adobe CF 2018-2025, and BoxLang all accept still fail to parse on RustCFML — and because the enclosing component then degrades to a non-object silently, they're invisible until you ask `isObject()`.

This PR adds **two cross-engine suites** (+ 3 fixtures).

## Suite 1 — reserved words usable as identifiers

A direct follow-on to the v0.36.0 *soft `component` keyword* work: two more words that are soft keywords on the JVM engines but hard-reserved on RustCFML.

**`new` as a function name.** `new Foo()` is the instantiation operator, but `new` is equally legal as a method name — and Wheels' core creation API depends on it:

```cfml
component { public any function new() { /* ... */ } }   // FAIL: Expected identifier, found New
```

`model("User").new()` is backed by `public any function new(...)` in `vendor/wheels/model/create.cfc`.

**`extends` / `implements` as parameter names:**

```cfml
function generateClass( string extends="", string implements="" ) {}   // FAIL: Expected RParen, found Extends
```

Used verbatim in `vendor/wheels/wheelstest/system/mockutils/MockGenerator.cfc`.

## Suite 2 — quoted string catch type

A catch clause may name the exception type as a quoted string (the idiomatic way to catch a dotted, namespaced custom exception):

```cfml
try { throw(type="My.Custom.Type", message="x"); }
catch ("My.Custom.Type" e) { /* ... */ }                // FAIL: Expected identifier, found String(...)
```

**This is the next blocker on the Wheels boot path after #24's header gaps.** `vendor/wheels/Public.cfc:56` (`catch ("Wheels.Packages.RegistryUnavailable" e)`) is instantiated unconditionally at `onApplicationStart` in development mode; `vendor/wheels/auth/JwtStrategy.cfc` does the same with `"Wheels.Auth.JWT.TokenExpired"`.

## Verification

| Engine | Result |
|--------|--------|
| Lucee 7.0.2 | **3/3 pass** |
| RustCFML 0.37.0 | 0/3 — all three degrade to a non-object |

Failing declarations live in runtime-instantiated **fixtures** (a parse error escapes `try/catch` and would abort the runner); via `createObject` they degrade to a non-object so the assertions surface the gap and the full runner still completes (3104/3107, the 3 intended new reds the only failures).

---

## Other parse gaps found while booting Wheels on 0.37 (not in this PR — signal only)

In addition to #24's roadmap (component `extends`-after-attribute & unquoted-boolean attrs — both still open here) and its noted items (interface `extends=`, dotted-FQN param types, `+=` in a `for` increment, `function f() output=true {...}`), the 0.37 sweep surfaced a few more — all fail on 0.37, pass on Lucee/ACF/BoxLang, happy to send tests for any:

- **Compound assignment in more positions** — `+=` inside a braced `switch`/`case` block (`case "x": { total += 1; }`), and a chained `&=` (`local.sql = local.sql &= ";"`, `vendor/wheels/migrator/Base.cfc`). Bare `+=`/`&=` statements parse fine; only these positions fail.
- **Script tag-with-body** — `transaction action="begin" { ... }` (cfscript transaction with attributes + body) → `Expected RBrace, found LBrace`; and `for (item in collection)` nested inside a `cfhttp(){ ... }` script-tag body → `Expected RParen, found In`.

(FYI, unchanged & not Wheels blockers: the script-statement `cfinvoke component=... method=...;` form added in 0.36 still works great; only the function-call form `cfinvoke(component="x", ...)` ignores the `component` named arg at runtime. `this.mappings`-based `cfinclude` remains fixed.)
