### PR TITLE
Add CFML test for compound assignment function RHS

### DIFF
--- a/tests/core/test_compound_assignment.cfm
+++ b/tests/core/test_compound_assignment.cfm
@@ -60,6 +60,17 @@ fc = 10;
 fc -= five();
 assert("-= function() order", fc, 5);
 
+profileInitials = "";
+part = "Mat";
+profileInitials &= uCase(left(part, 1));
+assert("&= function() concat", profileInitials, "M");
+
+item = { count = 2, label = "A" };
+item.count += val("3");
+item.label &= uCase(left("bee", 1));
+assert("struct += function() RHS", item.count, 5);
+assert("struct &= function() RHS", item.label, "AB");
+
 // --- nested array index RHS ---
 matrix = [[1, 2], [3, 4]];
 n = 0;


### PR DESCRIPTION
## Summary
- Adds CFML runner assertions for compound assignment where the right-hand side is a function call.
- Moopa builds initials and updates struct fields with expressions like `value &= uCase(left(...))` and `item.count += val(...)`.

## Expected Behaviour
Compound assignment should evaluate the current target value, then the full RHS expression, then apply the operator. Struct-member targets should be updated the same way simple variable targets are.

## Current RustCFML Behaviour
Running the runner on current `main` fails the new struct-target assertion:

```text
FAIL | Compound assignment with multi-op RHS | 14/15 passed (1 failed)
FAIL: struct += function() RHS | expected: [5] | got: [2]
```

## Test
- `cargo run -- tests/runner.cfm`
