### PR TITLE
Add CFML test for function reference named args

### DIFF
--- a/tests/functions/test_function_references.cfm
+++ b/tests/functions/test_function_references.cfm
@@ -50,5 +50,14 @@ math = buildMathService();
 assert("service add", math.add(3, 4), 7);
 assert("service multiply", math.multiply(3, 4), 12);
 
+// Named arguments through a function reference should bind by parameter name,
+// not by the order supplied at the call site.
+function read(table_name, id) {
+    return arguments.table_name & ":" & arguments.id;
+}
+db = {};
+db.read = read;
+assert("function ref named args reorder by parameter", db.read(id="p1", table_name="moo_profile"), "moo_profile:p1");
+
 suiteEnd();
 </cfscript>


### PR DESCRIPTION
## Summary
- Adds a CFML runner assertion for named arguments passed through a first-class function reference stored in a struct.
- Moopa stores framework helpers in structs (for example `db.read`) and calls them with named arguments out of declaration order.

## Expected Behaviour
Calling a function reference with named arguments should bind values by the referenced function's parameter names, not by call-site order.

## Current RustCFML Behaviour
Running the runner on current `main` fails the new assertion by binding in supplied order:

```text
FAIL | First-Class Function References | 9/10 passed (1 failed)
FAIL: function ref named args reorder by parameter | expected: [moo_profile:p1] | got: [p1:moo_profile]
```

## Test
- `cargo run -- tests/runner.cfm`
