### PR TITLE
Add CFML test for optional argument omission

### DIFF
--- a/tests/core/test_functions.cfm
+++ b/tests/core/test_functions.cfm
@@ -29,6 +29,21 @@ function greet(name, greeting="Hello") {
 assert("default arg used", greet("World"), "Hello World");
 assert("default arg overridden", greet("World", "Hi"), "Hi World");
 
+// --- Optional argument omission ---
+function checkOffset(offset) {
+    if (structKeyExists(arguments, "offset")) {
+        return "present:" & arguments.offset;
+    }
+    return "missing";
+}
+assert("omitted optional argument absent from arguments", checkOffset(), "missing");
+assert("provided optional argument present in arguments", checkOffset(5), "present:5");
+
+function pageArgs(table_name, offset, limit=250) {
+    return (structKeyExists(arguments, "offset") ? "offset" : "no-offset") & ":" & arguments.limit;
+}
+assert("named later argument does not materialize omitted optional argument", pageArgs(table_name="moo_role", limit=20), "no-offset:20");
+
 // --- Closures ---
 multiply = function(a, b) {
     return a * b;


### PR DESCRIPTION
## Summary

Adds CFML runner assertions for Lucee-compatible optional argument omission.

When an optional function argument is not supplied, it should not be materialized into the `arguments` scope as an empty value. Supplying a later named argument should also not cause an earlier omitted optional argument to appear.

## Why this matters

Moopa checks `structKeyExists(arguments, "offset")` and similar guards to distinguish an intentionally supplied argument from an omitted one. If RustCFML inserts omitted arguments into `arguments`, application code treats absent filters/pagination values as explicitly provided.

## Current RustCFML result

On current upstream, the new assertions fail with:

```text
FAIL: omitted optional argument absent from arguments | expected: [missing] | got: [present:]
FAIL: named later argument does not materialize omitted optional argument | expected: [no-offset:20] | got: [offset:20]
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
