### PR TITLE
Add CFML test for cfdirectory query result

### DIFF
--- a/tests/tags/test_cfdirectory_mapping_path.cfm
+++ b/tests/tags/test_cfdirectory_mapping_path.cfm
@@ -7,5 +7,21 @@ suiteBegin("cfdirectory mapping paths");
     filter="*.cfc">
 <cfscript>
 assert("mapped directory resolves via Application.cfc mapping", mappedCfcFiles.recordCount, 3);
+assertTrue("cfdirectory list result is query", isQuery(mappedCfcFiles));
+
+if (isQuery(mappedCfcFiles)) {
+    assertTrue("cfdirectory query has name column", queryColumnExists(mappedCfcFiles, "name"));
+    assertTrue("cfdirectory query has directory column", queryColumnExists(mappedCfcFiles, "directory"));
+    assertTrue("cfdirectory query has size column", queryColumnExists(mappedCfcFiles, "size"));
+    assertTrue("cfdirectory query has type column", queryColumnExists(mappedCfcFiles, "type"));
+    assertTrue("cfdirectory query has dateLastModified column", queryColumnExists(mappedCfcFiles, "dateLastModified"));
+    assertTrue("cfdirectory query has attributes column", queryColumnExists(mappedCfcFiles, "attributes"));
+    assertTrue("cfdirectory query has mode column", queryColumnExists(mappedCfcFiles, "mode"));
+
+    firstMappedFile = queryGetRow(mappedCfcFiles, 1);
+    assertTrue("cfdirectory row exposes cfc file name", listFindNoCase(valueList(mappedCfcFiles.name), "counter_child.cfc") > 0);
+    assertTrue("cfdirectory row exposes mapped directory", findNoCase("/tests/oop/native_cfcs", replace(firstMappedFile.directory, "\", "/", "all")) > 0);
+    assert("cfdirectory row type is file", firstMappedFile.type, "file");
+}
 suiteEnd();
 </cfscript>


### PR DESCRIPTION
## Summary

Adds CFML runner assertions that `<cfdirectory action="list" ...>` returns a real query object with Lucee-style directory listing columns.

The existing mapping-path test already confirms that `cfdirectory` can resolve an Application.cfc mapping. This extends that test to assert that the named result is a query and, once it is query-shaped, exposes the expected file listing columns and row data.

## Why this matters

Moopa uses `cfdirectory` results like normal Lucee query objects: checking columns, reading rows, and using query helpers. A value that only exposes `recordCount` is not compatible with that code path.

## Current RustCFML result

On current upstream, the new assertion fails with:

```text
FAIL: cfdirectory list result is query | expected truthy | got: [false]
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
