### PR TITLE
Add CFML test for Java regex Pattern shim

### DIFF
--- a/tests/java_shims/test_all.cfm
+++ b/tests/java_shims/test_all.cfm
@@ -148,6 +148,17 @@ assertTrue( "Path isAbsolute", paths.isAbsolute() );
 test27 = paths.toString() == "/home/user/file.txt";
 assertTrue( "Path toString", test27 );
 
+// Test java.util.regex.Pattern — used by Lucee apps for dynamic route matching.
+writeOutput( "\n--- Testing Pattern ---\n" );
+pattern = createObject( "java", "java.util.regex.Pattern" );
+matcher = pattern
+    .compile( javaCast( "string", "^\/sysadmin\/routes\/([0-9A-Za-z\s\-_]+)$" ) )
+    .matcher( javaCast( "string", "/sysadmin/routes/4e4727bd-f93d-40e6-9409-bed317fe76df" ) );
+
+assertTrue( "Pattern matcher find", matcher.find() );
+assert( "Pattern matcher group", matcher.group( 1 ), "4e4727bd-f93d-40e6-9409-bed317fe76df" );
+assert( "Pattern matcher groupCount", matcher.groupCount(), 1 );
+
 writeOutput( "\n=== All Java shim tests passed! ===\n" );
 
 suiteEnd( "Java Shims" );


### PR DESCRIPTION
## Summary

Adds a CFML runner test for `createObject("java", "java.util.regex.Pattern")` using Lucee-style chained `compile(...).matcher(...)` route matching.

## Why this matters

Moopa uses Java `Pattern`/`Matcher` interop for dynamic route matching. Lucee supports this pattern through normal Java interop; RustCFML needs a compatible shim for the same CFML to run.

## Current RustCFML result

On current upstream, the new assertions fail with:

```text
FAIL: Pattern matcher find | expected truthy | got: []
FAIL: Pattern matcher group | expected: [4e4727bd-f93d-40e6-9409-bed317fe76df] | got: []
FAIL: Pattern matcher groupCount | expected: [1] | got: []
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
