### PR TITLE
Add CFML test for cfdirectory in component method

### DIFF
--- a/tests/oop/CfdirectoryLoader.cfc
+++ b/tests/oop/CfdirectoryLoader.cfc
@@ -1,0 +1,8 @@
+<cfcomponent>
+
+    <cffunction name="loadRoutes" returntype="string">
+        <cfdirectory action="list" directory="/oop/native_cfcs" name="qRoutes" filter="*.cfc">
+        <cfreturn qRoutes.recordCount & "|" & qRoutes.columnList>
+    </cffunction>
+
+</cfcomponent>

--- a/tests/tags/test_cfdirectory_mapping_path.cfm
+++ b/tests/tags/test_cfdirectory_mapping_path.cfm
@@ -7,5 +7,8 @@ suiteBegin("cfdirectory mapping paths");
     filter="*.cfc">
 <cfscript>
 assert("mapped directory resolves via Application.cfc mapping", mappedCfcFiles.recordCount, 3);
+
+loader = createObject("component", "oop.CfdirectoryLoader");
+assert("cfdirectory unscoped name inside component method", loader.loadRoutes(), "3|name,directory,size,type,dateLastModified,attributes,mode");
 suiteEnd();
 </cfscript>


### PR DESCRIPTION
## Summary

Adds a CFML runner test for using `<cfdirectory>` inside a CFC method with an unscoped `name` target.

The fixture component calls:

```cfml
<cfdirectory action="list" directory="/oop/native_cfcs" name="qRoutes" filter="*.cfc">
<cfreturn qRoutes.recordCount & "|" & qRoutes.columnList>
```

## Why this matters

Moopa route/table loaders use `cfdirectory` from inside component methods and expect the named result to be available in the method's local/function scope as a normal Lucee query object.

## Current RustCFML result

On current upstream, the new assertion fails with:

```text
FAIL: cfdirectory unscoped name inside component method | expected: [3|name,directory,size,type,dateLastModified,attributes,mode] | got: [3|]
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
