### PR TITLE
Add CFML test for leading-slash cfmodule template

### DIFF
--- a/tests/tags/test_tags_customtag.cfm
+++ b/tests/tags/test_tags_customtag.cfm
@@ -72,4 +72,18 @@
 <cfmodule template="customtags/echo_attr.cfm" value="mod-hyphen-ok">
 <cfscript>assert("cfmodule attr with hyphen", echoed, "mod-hyphen-ok");</cfscript>
 
+<!--- Test 15: cfmodule with leading-slash template resolves through mappings --->
+<cfset echoed = "">
+<cfset leadingSlashModuleError = "">
+<cftry>
+    <cfmodule template="/tags/customtags/echo_attr.cfm" value="leading-slash-module">
+    <cfcatch type="any">
+        <cfset leadingSlashModuleError = cfcatch.message>
+    </cfcatch>
+</cftry>
+<cfscript>
+    assert("cfmodule leading-slash mapped template error", leadingSlashModuleError, "");
+    assert("cfmodule leading-slash mapped template", echoed, "leading-slash-module");
+</cfscript>
+
 <cfscript>suiteEnd();</cfscript>


### PR DESCRIPTION
## Summary

Adds a CFML runner test for `cfmodule template` paths that start with `/` and should resolve through Application.cfc mappings.

The test uses the existing `/tags` mapping and expects:

```cfml
<cfmodule template="/tags/customtags/echo_attr.cfm" value="leading-slash-module">
```

to resolve the mapped custom tag template and run normally.

## Why this matters

Moopa package controls/custom tags are commonly referenced with leading-slash mapped paths. Lucee resolves those paths through configured mappings; RustCFML needs the same behavior for package-oriented apps.

## Current RustCFML result

On current upstream, the new assertions fail with:

```text
FAIL: cfmodule leading-slash mapped template error | expected: [] | got: [Custom tag template '/tags/customtags/echo_attr.cfm' not found]
FAIL: cfmodule leading-slash mapped template | expected: [leading-slash-module] | got: []
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
