### PR TITLE
Add CFML test for custom tag cfreturn locals

### DIFF
--- a/tests/tags/ltreturn.cfm
+++ b/tests/tags/ltreturn.cfm
@@ -1,0 +1,11 @@
+<cfif thisTag.executionMode NEQ "end">
+    <cfset attributes.content_class = "px-5 py-5">
+    <cfreturn>
+</cfif>
+
+<cfif len(trim(thisTag.generatedContent))>
+    <cfset attributes.body = thisTag.generatedContent>
+    <cfset thisTag.generatedContent = "">
+</cfif>
+
+<cfoutput><main class="#attributes.content_class#">#attributes.body#</main></cfoutput>

--- a/tests/tags/test_tags_customtag_lifecycle.cfm
+++ b/tests/tags/test_tags_customtag_lifecycle.cfm
@@ -26,4 +26,10 @@
 <cf_ltlocal outVar="ltLocalOut" />
 <cfscript>assert("custom tag template has local scope", ltLocalOut, "ok");</cfscript>
 
+<!--- Start-phase cfreturn still preserves attributes/locals for the end phase. --->
+<cfsavecontent variable="ltReturnOut"><cf_ltreturn>body</cf_ltreturn></cfsavecontent>
+<cfscript>
+    assert("body tag start cfreturn preserves start attributes", trim(ltReturnOut), '<main class="px-5 py-5">body</main>');
+</cfscript>
+
 <cfscript>suiteEnd();</cfscript>


### PR DESCRIPTION
## Summary

Adds a CFML runner test for a body custom tag whose start phase sets an attribute value and exits with `<cfreturn>` before the end phase renders.

Lucee preserves the start-phase custom tag state for the end phase, so this tag should render:

```html
<main class="px-5 py-5">body</main>
```

## Why this matters

Moopa layout/control tags often initialize defaults during the start phase and return early, then use those values when rendering the end phase. If start-phase state is lost, layouts render with missing attributes/classes.

## Current RustCFML result

On current upstream, the new assertion fails with:

```text
FAIL: body tag start cfreturn preserves start attributes | expected: [<main class="px-5 py-5">body</main>] | got: [<main class="">body</main>]
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
