### PR TITLE
Add CFML test for cfparam quoted defaults

### DIFF
--- a/tests/tags/test_tags_param.cfm
+++ b/tests/tags/test_tags_param.cfm
@@ -32,6 +32,20 @@
 <cfparam name="typedDefault" type="string" default="typed">
 <cfscript>assert("cfparam default with type", typedDefault, "typed");</cfscript>
 
+<!--- cfparam quoted defaults with spaces/operators remain literal strings --->
+<cfset quotedDefaultError = "">
+<cftry>
+    <cfparam name="classDefault" default="px-5 py-5">
+    <cfcatch type="any">
+        <cfset quotedDefaultError = cfcatch.message>
+    </cfcatch>
+</cftry>
+<cfscript>
+    classDefaultValue = structKeyExists(variables, "classDefault") ? variables.classDefault : "";
+    assert("cfparam quoted default error", quotedDefaultError, "");
+    assert("cfparam quoted default with spaces and hyphens", classDefaultValue, "px-5 py-5");
+</cfscript>
+
 <!--- cfparam with type="array" default --->
 <cfparam name="arrDefault" type="array" default="#[]#">
 <cfscript>assertTrue("cfparam array default is array", isArray(arrDefault));</cfscript>


### PR DESCRIPTION
## Summary

Adds a CFML runner test for quoted `<cfparam>` defaults containing spaces and hyphens.

Lucee treats this as a literal string:

```cfml
<cfparam name="classDefault" default="px-5 py-5">
```

and sets `classDefault` to `px-5 py-5` when it is undefined.

## Why this matters

Moopa custom tags use `cfparam` for default CSS class strings and other literal values. If RustCFML evaluates quoted defaults as expressions, ordinary class strings such as `px-5 py-5` fail at runtime.

## Current RustCFML result

On current upstream, the new assertions fail with:

```text
FAIL: cfparam quoted default error | expected: [] | got: [Variable 'px' is undefined]
FAIL: cfparam quoted default with spaces and hyphens | expected: [px-5 py-5] | got: []
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
