### PR TITLE
Add CFML test for dynamic cfmodule template

### DIFF
--- a/tests/tags/test_tags_customtag.cfm
+++ b/tests/tags/test_tags_customtag.cfm
@@ -72,4 +72,19 @@
 <cfmodule template="customtags/echo_attr.cfm" value="mod-hyphen-ok">
 <cfscript>assert("cfmodule attr with hyphen", echoed, "mod-hyphen-ok");</cfscript>
 
+<!--- Test 15: cfmodule template supports hash interpolation --->
+<cfset echoed = "">
+<cfset modulePath = "customtags/echo_attr.cfm">
+<cfset dynamicModuleError = "">
+<cftry>
+    <cfmodule template="#modulePath#" value="dynamic-module">
+    <cfcatch type="any">
+        <cfset dynamicModuleError = cfcatch.message>
+    </cfcatch>
+</cftry>
+<cfscript>
+    assert("cfmodule dynamic template error", dynamicModuleError, "");
+    assert("cfmodule dynamic template", echoed, "dynamic-module");
+</cfscript>
+
 <cfscript>suiteEnd();</cfscript>


### PR DESCRIPTION
## Summary

Adds a CFML runner test for hash interpolation in `cfmodule template`.

Lucee resolves this dynamic template value:

```cfml
<cfset modulePath = "customtags/echo_attr.cfm">
<cfmodule template="#modulePath#" value="dynamic-module">
```

as `customtags/echo_attr.cfm` and executes the custom tag.

## Why this matters

Moopa package/control rendering can build custom tag template paths dynamically. Treating `#modulePath#` as the literal string `modulePath` prevents those dynamic includes/modules from resolving.

## Current RustCFML result

On current upstream, the new assertions fail with:

```text
FAIL: cfmodule dynamic template error | expected: [] | got: [Custom tag template 'modulePath' not found]
FAIL: cfmodule dynamic template | expected: [dynamic-module] | got: []
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
