### PR TITLE
Add CFML test for cfquery control tags

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -131,6 +131,7 @@ try { include "tags/test_tags_cfmail.cfm"; } catch (any e) { writeOutput("ERROR 
 try { include "tags/test_tags_cfcache.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfcache.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfstoredproc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfstoredproc.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfqueryparam_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfqueryparam_attribute_collection.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfquery_control_tags.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_mapping_path.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfimport.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfimport.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfthread.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfthread.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_tags_cfquery_control_tags.cfm
+++ b/tests/tags/test_tags_cfquery_control_tags.cfm
@@ -1,0 +1,67 @@
+<cfscript>
+suiteBegin("Tags: cfquery control tags");
+
+tmpfile = getTempDirectory() & "/rustcfml_cfquery_control_" & createUUID() & ".sqlite";
+ds = "sqlite://" & tmpfile;
+skip = false;
+
+try {
+    queryExecute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)", [], { datasource: ds });
+    queryExecute("INSERT INTO t (id, name) VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')", [], { datasource: ds });
+} catch (any e) {
+    skip = true;
+    assertTrue("cfquery control tags skipped (no sqlite): " & e.message, true);
+}
+</cfscript>
+
+<cfif NOT skip>
+
+<cfscript>
+includeBeta = false;
+filteredError = "";
+</cfscript>
+<cftry>
+    <cfquery name="qFiltered" datasource="#ds#">
+        SELECT * FROM t
+        WHERE 1 = 1
+        <cfif NOT includeBeta>
+            AND name <> <cfqueryparam value="beta" cfsqltype="cf_sql_varchar">
+        </cfif>
+        ORDER BY id
+    </cfquery>
+    <cfcatch type="any">
+        <cfset filteredError = cfcatch.message>
+    </cfcatch>
+</cftry>
+<cfscript>
+assert("cfquery cfif filtered query error", filteredError, "");
+assert("cfquery cfif filters rows", structKeyExists(variables, "qFiltered") ? valueList(qFiltered.name) : "", "alpha,gamma");
+
+includeBeta = true;
+allError = "";
+</cfscript>
+<cftry>
+    <cfquery name="qAll" datasource="#ds#">
+        SELECT * FROM t
+        WHERE 1 = 1
+        <cfif NOT includeBeta>
+            AND name <> <cfqueryparam value="beta" cfsqltype="cf_sql_varchar">
+        </cfif>
+        ORDER BY id
+    </cfquery>
+    <cfcatch type="any">
+        <cfset allError = cfcatch.message>
+    </cfcatch>
+</cftry>
+<cfscript>
+assert("cfquery cfif unfiltered query error", allError, "");
+assert("cfquery cfif omitted when false", structKeyExists(variables, "qAll") ? valueList(qAll.name) : "", "alpha,beta,gamma");
+
+try { fileDelete(tmpfile); } catch (any e) {}
+</cfscript>
+
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

Adds a CFML runner test for Lucee-style control tags inside a `<cfquery>` body.

The test uses SQLite and expects `<cfif>` inside the query body to be evaluated before SQL execution, so conditional SQL fragments are included or omitted instead of being sent to the database literally.

## Why this matters

Moopa and Lucee applications commonly build SQL with CFML control tags inside `cfquery`. Without this behavior, dynamic query fragments become literal SQL and fail before the query can run.

## Current RustCFML result

On current upstream, the new assertions fail because the SQL still contains the raw `<cfif>` tags:

```text
FAIL: cfquery cfif filtered query error | expected: [] | got: [queryExecute: SQL error: near "includeBeta": syntax error ... <cfif NOT includeBeta> ...]
FAIL: cfquery cfif filters rows | expected: [alpha,gamma] | got: []
FAIL: cfquery cfif unfiltered query error | expected: [] | got: [queryExecute: SQL error: near "includeBeta": syntax error ... <cfif NOT includeBeta> ...]
FAIL: cfquery cfif omitted when false | expected: [alpha,beta,gamma] | got: []
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
