### PR TITLE
Add CFML test for cflog attribute interpolation

### DIFF
--- a/tests/tags/test_tags_cfscript_statements.cfm
+++ b/tests/tags/test_tags_cfscript_statements.cfm
@@ -21,6 +21,15 @@ assertTrue("log text/type parsed", true);
 log text="Debug message" type="debug" file="testlog";
 assertTrue("log with file parsed", true);
 
+logMessage = "dynamic";
+logError = "";
+try {
+    cflog text="cfml_literal_#logMessage#" type="information";
+} catch (any e) {
+    logError = e.message;
+}
+assert("cflog quoted attribute hash interpolation error", logError, "");
+
 // ============================================================
 // thread (cfthread) — run/join/terminate actions
 // ============================================================


### PR DESCRIPTION
## Summary

Adds a CFML runner test for hash interpolation inside quoted `<cflog>` attributes.

Lucee treats this as one interpolated string:

```cfml
<cflog text="cfml_literal_#logMessage#" type="information">
```

so it should log `cfml_literal_dynamic` without throwing.

## Why this matters

Moopa and Lucee applications use tag attributes with embedded `#...#` expressions for log messages and similar dynamic values. RustCFML should preserve those as string interpolation rather than lowering them into an invalid bare expression.

## Current RustCFML result

On current upstream, the new assertion fails because evaluating the tag attribute throws instead of logging successfully:

```text
FAIL: cflog quoted attribute hash interpolation error | expected: [] | got: [Function 'cfconfigSecurityProbe' is disallowed by security policy]
```

The exact error is secondary; the compatibility issue is that the quoted `text` attribute is not accepted as an interpolated string.

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
