### PR TITLE
Add CFML test for cfhttp attribute interpolation

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -135,6 +135,7 @@ try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeO
 try { include "tags/test_tags_cfimport.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfimport.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfthread.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfthread.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfscript_statements.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfscript_statements.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tags_cfhttp_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttp_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfzip.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfzip.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_tld.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_tld.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_whitespace.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_whitespace.cfm | " & e.message & chr(10)); }

--- a/tests/tags/http_statements_target.cfm
+++ b/tests/tags/http_statements_target.cfm
@@ -27,6 +27,11 @@ switch (url.test) {
         writeOutput('{"status":"ok"}');
         break;
 
+    case "echo":
+        header name="X-Echo-Method" value=cgi.request_method ?: "";
+        writeOutput("echo-ok");
+        break;
+
     default:
         writeOutput("unknown-test");
 }

--- a/tests/tags/test_tags_cfhttp_interpolation.cfm
+++ b/tests/tags/test_tags_cfhttp_interpolation.cfm
@@ -1,0 +1,35 @@
+<cfscript>
+suiteBegin("Tags: cfhttp interpolation");
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+if (skip) {
+    assertTrue("tag cfhttp interpolation skipped (no cgi.server_port)", true);
+} else {
+    baseUrl = "http://127.0.0.1:" & serverPort;
+    targetPath = "/tests/tags/http_statements_target.cfm";
+    httpMethod = "GET";
+    dynamicPath = targetPath & "?test=echo";
+    dynamicHttpError = "";
+}
+</cfscript>
+
+<cfif NOT skip>
+    <cftry>
+        <cfhttp url="#baseUrl##dynamicPath#" method="#httpMethod#" result="dynamicHttpResult">
+        <cfcatch type="any">
+            <cfset dynamicHttpError = cfcatch.message>
+        </cfcatch>
+    </cftry>
+    <cfscript>
+        assert("tag cfhttp interpolated attributes error", dynamicHttpError, "");
+        assert("tag cfhttp interpolated attributes body",
+            structKeyExists(variables, "dynamicHttpResult") ? trim(dynamicHttpResult.filecontent) : "",
+            "echo-ok");
+    </cfscript>
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>

--- a/tests/tags/test_tags_cfscript_statements.cfm
+++ b/tests/tags/test_tags_cfscript_statements.cfm
@@ -85,6 +85,7 @@ if (serverPort == "" || serverPort == "0") {
     assertTrue("location header set",
         structKeyExists(locResult.responseheader, "Location")
         && findNoCase("redirect-target", locResult.responseheader["Location"]) > 0);
+
 }
 
 suiteEnd();


### PR DESCRIPTION
## Summary

Adds a CFML server-runner test for hash interpolation in quoted `<cfhttp>` attributes.

The test is skipped in plain CLI mode, like the existing HTTP statement subtests, and runs when `tests/runner.cfm` is served by RustCFML. It calls a local target page using:

```cfml
<cfhttp url="#baseUrl##dynamicPath#" method="#httpMethod#" result="dynamicHttpResult">
```

## Why this matters

Moopa and Lucee applications often build request URLs dynamically in tag attributes. Lucee treats quoted attributes with embedded `#...#` as interpolated strings; RustCFML should not collapse the expressions into one bare variable name.

## Current RustCFML result

When served via RustCFML on current upstream, the new assertions fail with:

```text
FAIL: tag cfhttp interpolated attributes error | expected: [] | got: [Variable 'baseUrldynamicPath' is undefined]
FAIL: tag cfhttp interpolated attributes body | expected: [echo-ok] | got: []
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
