### PR TITLE
Add CFML test for cfhttpparam attribute interpolation

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -135,6 +135,7 @@ try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeO
 try { include "tags/test_tags_cfimport.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfimport.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfthread.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfthread.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfscript_statements.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfscript_statements.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tags_cfhttpparam_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttpparam_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfzip.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfzip.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_tld.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_tld.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_whitespace.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_whitespace.cfm | " & e.message & chr(10)); }

--- a/tests/tags/http_statements_target.cfm
+++ b/tests/tags/http_statements_target.cfm
@@ -27,6 +27,10 @@ switch (url.test) {
         writeOutput('{"status":"ok"}');
         break;
 
+    case "url-echo":
+        writeOutput(url.probe ?: "");
+        break;
+
     default:
         writeOutput("unknown-test");
 }

--- a/tests/tags/test_tags_cfhttpparam_interpolation.cfm
+++ b/tests/tags/test_tags_cfhttpparam_interpolation.cfm
@@ -1,0 +1,35 @@
+<cfscript>
+suiteBegin("Tags: cfhttpparam interpolation");
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+if (skip) {
+    assertTrue("tag cfhttpparam interpolation skipped (no cgi.server_port)", true);
+} else {
+    requestUrl = "http://127.0.0.1:" & serverPort & "/tests/tags/http_statements_target.cfm?test=url-echo";
+    paramValue = "dynamic";
+    paramError = "";
+}
+</cfscript>
+
+<cfif NOT skip>
+    <cftry>
+        <cfhttp url="#requestUrl#" method="GET" result="paramHttpResult">
+            <cfhttpparam type="url" name="probe" value="value-#paramValue#">
+        </cfhttp>
+        <cfcatch type="any">
+            <cfset paramError = cfcatch.message>
+        </cfcatch>
+    </cftry>
+    <cfscript>
+        assert("tag cfhttpparam interpolated value error", paramError, "");
+        assert("tag cfhttpparam interpolated value body",
+            structKeyExists(variables, "paramHttpResult") ? trim(paramHttpResult.filecontent) : "",
+            "value-dynamic");
+    </cfscript>
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

Adds a CFML server-runner test for hash interpolation in quoted `<cfhttpparam>` attributes inside `<cfhttp>`.

The test is skipped in plain CLI mode and runs when `tests/runner.cfm` is served by RustCFML. It sends a local request using:

```cfml
<cfhttpparam type="url" name="probe" value="value-#paramValue#">
```

and expects the target page to receive `value-dynamic`.

## Why this matters

Moopa and Lucee applications use `cfhttpparam` for dynamic URL/query/form/header values. Lucee treats quoted attributes with embedded `#...#` as interpolated strings; RustCFML should preserve the literal portions and evaluate only the expression portions.

## Current RustCFML result

When served via RustCFML on current upstream, the new body assertion fails:

```text
FAIL: tag cfhttpparam interpolated value body | expected: [value-dynamic] | got: [0]
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
