### PR TITLE
Add CFML test for application mappings in lifecycle

### DIFF
--- a/tests/lifecycle/application_mapping/Application.cfc
+++ b/tests/lifecycle/application_mapping/Application.cfc
@@ -1,0 +1,6 @@
+component extends="BaseApplication" {
+    this.name = "rustcfml-application-mapping-test";
+    this.mappings = {
+        "/lib": "lib"
+    };
+}

--- a/tests/lifecycle/application_mapping/BaseApplication.cfc
+++ b/tests/lifecycle/application_mapping/BaseApplication.cfc
@@ -1,0 +1,13 @@
+component {
+
+    function onApplicationStart() {
+        application.expanded = expandPath("/lib");
+        application.widget = createObject("component", "/lib/widget").init();
+        return true;
+    }
+
+    function onRequest(targetPage) {
+        writeOutput(application.expanded & "|" & application.widget.ready);
+    }
+
+}

--- a/tests/lifecycle/application_mapping/index.cfm
+++ b/tests/lifecycle/application_mapping/index.cfm
@@ -1,0 +1,1 @@
+<cfoutput>direct</cfoutput>

--- a/tests/lifecycle/application_mapping/lib/widget.cfc
+++ b/tests/lifecycle/application_mapping/lib/widget.cfc
@@ -1,0 +1,8 @@
+component {
+
+    function init() {
+        this.ready = "ok";
+        return this;
+    }
+
+}

--- a/tests/lifecycle/test_application_mapping_coverage.cfm
+++ b/tests/lifecycle/test_application_mapping_coverage.cfm
@@ -1,0 +1,17 @@
+<cfscript>
+suiteBegin("Lifecycle: application mappings");
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+
+if (serverPort == "" || serverPort == "0") {
+    assertTrue("application mapping lifecycle skipped (no cgi.server_port)", true);
+} else {
+    targetPath = "/tests/lifecycle/application_mapping/index.cfm";
+    http url="http://127.0.0.1:#serverPort##targetPath#" method="GET" result="mappingResult";
+    assert("application mapping status", mappingResult.statuscode, "200 OK");
+    assertTrue("inherited lifecycle sees child mapping",
+        findNoCase("/tests/lifecycle/application_mapping/lib|ok", replace(trim(mappingResult.filecontent), "\", "/", "all")) > 0);
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -143,6 +143,9 @@ try { include "tags/test_tags_whitespace.cfm"; } catch (any e) { writeOutput("ER
 try { include "includes/test_variables_scope_includes.cfm"; } catch (any e) { writeOutput("ERROR | includes/test_variables_scope_includes.cfm | " & e.message & chr(10)); }
 try { include "includes/test_named_args_includes.cfm"; } catch (any e) { writeOutput("ERROR | includes/test_named_args_includes.cfm | " & e.message & chr(10)); }
 
+// --- Lifecycle / server request fixtures ---
+try { include "lifecycle/test_application_mapping_coverage.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_mapping_coverage.cfm | " & e.message & chr(10)); }
+
 // --- Java Shims ---
 try { include "java_shims/test_all.cfm"; } catch (any e) { writeOutput("ERROR | java_shims/test_all.cfm | " & e.message & chr(10)); }
 try { include "java_shims/test_comprehensive.cfm"; } catch (any e) { writeOutput("ERROR | java_shims/test_comprehensive.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary

Adds a CFML server-runner test for `this.mappings` being available to inherited Application.cfc lifecycle methods.

The fixture has a child `Application.cfc` that extends `BaseApplication` and defines:

```cfml
this.mappings = { "/lib": "lib" };
```

The inherited `onApplicationStart()` then calls both `expandPath("/lib")` and `createObject("component", "/lib/widget")`.

## Why this matters

Moopa uses package/application mappings during lifecycle startup, including from inherited application methods. Lucee makes the child application's mappings available to those lifecycle methods.

## Current RustCFML result

When served via RustCFML on current upstream, the new assertion fails:

```text
FAIL: inherited lifecycle sees child mapping | expected truthy | got: [false]
```

Directly hitting the fixture returns the expanded mapped path but misses the component result:

```text
/Users/mat/dev/blute-RustCFML/tests/lifecycle/application_mapping/lib|
```

Expected output includes `|ok` after constructing `/lib/widget`.

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
