### PR TITLE
Add CFML test for Application.cfc load errors

### DIFF
--- a/tests/lifecycle/application_load_error/Application.cfc
+++ b/tests/lifecycle/application_load_error/Application.cfc
@@ -1,0 +1,3 @@
+<cfcomponent>
+    <cfthrow message="broken application load">
+</cfcomponent>

--- a/tests/lifecycle/application_load_error/index.cfm
+++ b/tests/lifecycle/application_load_error/index.cfm
@@ -1,0 +1,1 @@
+<cfoutput>direct-page-executed</cfoutput>

--- a/tests/lifecycle/test_application_load_errors.cfm
+++ b/tests/lifecycle/test_application_load_errors.cfm
@@ -1,0 +1,19 @@
+<cfscript>
+suiteBegin("Lifecycle: Application.cfc load errors");
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+
+if (serverPort == "" || serverPort == "0") {
+    assertTrue("Application.cfc load error skipped (no cgi.server_port)", true);
+} else {
+    targetPath = "/tests/lifecycle/application_load_error/index.cfm";
+    http url="http://127.0.0.1:#serverPort##targetPath#" method="GET" throwonerror="false" result="loadErrorResult";
+
+    assertTrue("Application.cfc load error returns failure status",
+        left(loadErrorResult.statuscode, 1) == "5");
+    assertTrue("Application.cfc load error does not execute target page",
+        findNoCase("direct-page-executed", loadErrorResult.filecontent) == 0);
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -143,6 +143,9 @@ try { include "tags/test_tags_whitespace.cfm"; } catch (any e) { writeOutput("ER
 try { include "includes/test_variables_scope_includes.cfm"; } catch (any e) { writeOutput("ERROR | includes/test_variables_scope_includes.cfm | " & e.message & chr(10)); }
 try { include "includes/test_named_args_includes.cfm"; } catch (any e) { writeOutput("ERROR | includes/test_named_args_includes.cfm | " & e.message & chr(10)); }
 
+// --- Lifecycle / server request fixtures ---
+try { include "lifecycle/test_application_load_errors.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_load_errors.cfm | " & e.message & chr(10)); }
+
 // --- Java Shims ---
 try { include "java_shims/test_all.cfm"; } catch (any e) { writeOutput("ERROR | java_shims/test_all.cfm | " & e.message & chr(10)); }
 try { include "java_shims/test_comprehensive.cfm"; } catch (any e) { writeOutput("ERROR | java_shims/test_comprehensive.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Summary

Adds a CFML server-runner test for surfacing `Application.cfc` load/execution errors.

The fixture has an `Application.cfc` that throws immediately and an `index.cfm` body that would output `direct-page-executed` if the application load error were skipped.

## Why this matters

Lucee applications expect Application.cfc load failures to stop the request. Silently falling through to the target page hides configuration/startup failures and can make broken applications appear partially functional.

## Current RustCFML result

When served via RustCFML on current upstream, the new assertions fail:

```text
FAIL: Application.cfc load error returns failure status | expected truthy | got: [false]
FAIL: Application.cfc load error does not execute target page | expected truthy | got: [false]
```

Directly hitting the fixture currently returns:

```text
HTTP/1.1 200 OK

direct-page-executed
```

## Scope

This PR intentionally includes only the CFML compatibility test. No runtime fix is included.
