### PR TITLE
Add CFML test for front controller fallback

### DIFF
--- a/tests/.cfconfig.json
+++ b/tests/.cfconfig.json
@@ -2,7 +2,11 @@
   "server": {
     "port": 9999,
     "welcomeFiles": ["index.cfm", "default.cfm"],
-    "maxRequestBodySize": 5242880
+    "maxRequestBodySize": 5242880,
+    "fallback": {
+      "template": "/server/front_controller_fallback.cfm",
+      "routeParam": "route"
+    }
   },
   "runtime": {
     "locale": "en-GB",

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -143,6 +143,9 @@ try { include "tags/test_tags_whitespace.cfm"; } catch (any e) { writeOutput("ER
 try { include "includes/test_variables_scope_includes.cfm"; } catch (any e) { writeOutput("ERROR | includes/test_variables_scope_includes.cfm | " & e.message & chr(10)); }
 try { include "includes/test_named_args_includes.cfm"; } catch (any e) { writeOutput("ERROR | includes/test_named_args_includes.cfm | " & e.message & chr(10)); }
 
+// --- Server ---
+try { include "server/test_front_controller_fallback.cfm"; } catch (any e) { writeOutput("ERROR | server/test_front_controller_fallback.cfm | " & e.message & chr(10)); }
+
 // --- Java Shims ---
 try { include "java_shims/test_all.cfm"; } catch (any e) { writeOutput("ERROR | java_shims/test_all.cfm | " & e.message & chr(10)); }
 try { include "java_shims/test_comprehensive.cfm"; } catch (any e) { writeOutput("ERROR | java_shims/test_comprehensive.cfm | " & e.message & chr(10)); }

--- a/tests/server/front_controller_fallback.cfm
+++ b/tests/server/front_controller_fallback.cfm
@@ -1,0 +1,2 @@
+<cfcontent type="text/plain; charset=utf-8">
+<cfoutput>fallback|route=#url.route ?: ""#|probe=#url.probe ?: ""#</cfoutput>

--- a/tests/server/test_front_controller_fallback.cfm
+++ b/tests/server/test_front_controller_fallback.cfm
@@ -1,0 +1,22 @@
+<cfscript>
+include "../harness.cfm";
+
+suiteBegin("Server: front controller fallback");
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+
+if (serverPort == "" || serverPort == "0") {
+    assertTrue("front controller fallback skipped (no cgi.server_port)", true);
+} else {
+    http
+        url="http://127.0.0.1:#serverPort#/missing/path?probe=abc"
+        method="GET"
+        throwonerror="false"
+        result="fallbackResult";
+
+    assert("unresolved route is served by fallback template", trim(fallbackResult.fileContent), "fallback|route=/missing/path|probe=abc");
+    assert("front controller fallback returns success status", fallbackResult.statusCode, "200 OK");
+}
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

Adds a CFML server-runner test for configured front-controller fallback routing.

The fixture configures `server.fallback.template` in `tests/.cfconfig.json`, then requests an unresolved URL and expects RustCFML to execute the fallback template while preserving the original path in `url.route` and the original query string.

## Expected Lucee-compatible behaviour

Framework-style CFML apps often rely on the web server to route unresolved paths through a front controller. When RustCFML owns the HTTP server directly, the same behaviour needs to be expressible in RustCFML server config so a request such as `/missing/path?probe=abc` can be handled by a configured CFML template.

## Current RustCFML behaviour

The served test currently returns a `404 Not Found` response for the unresolved path instead of executing the configured fallback template.

## Validation

CLI mode skips the server-only assertion:

```sh
cargo run --quiet -- tests/server/test_front_controller_fallback.cfm
```

Served mode demonstrates the current failure:

```sh
cargo run --quiet -- --serve tests --port 8572
curl -sS http://127.0.0.1:8572/server/test_front_controller_fallback.cfm
```

Observed failure:

```text
FAIL | Server: front controller fallback | 0/2 passed (2 failed)
FAIL: unresolved route is served by fallback template | expected: [fallback|route=/missing/path|probe=abc] | got: [<html><body><h1>404 Not Found</h1><p>The requested URL /missing/path was not found.</p></body></html>]
FAIL: front controller fallback returns success status | expected: [200 OK] | got: [404 Not Found]
```
