### PR TITLE
Document cached function source metadata issue

### DIFF
--- a/crates/cfml-vm/tests/compiled_function_source_file.rs
+++ b/crates/cfml-vm/tests/compiled_function_source_file.rs
@@ -1,0 +1,35 @@
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_vm::compile_file_cached;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+#[test]
+fn cached_file_compilation_records_function_source_file() {
+    let mut files = HashMap::new();
+    files.insert(
+        "lib/db.cfc".to_string(),
+        r#"
+<cfcomponent>
+    <cffunction name="read">
+        <cfargument name="table_name" />
+        <cfreturn arguments.table_name />
+    </cffunction>
+</cfcomponent>
+"#
+        .as_bytes()
+        .to_vec(),
+    );
+
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+    let component_path = format!("{}/lib/db.cfc", VROOT);
+    let program = compile_file_cached(&component_path, None, vfs.as_ref()).unwrap();
+    let function = program
+        .functions
+        .iter()
+        .find(|function| function.name.eq_ignore_ascii_case("read"))
+        .expect("compiled read function");
+
+    assert_eq!(Some(component_path.as_str()), function.source_file.as_deref());
+}

--- a/docs/compatibility-notes/compiled-function-source-file.md
+++ b/docs/compatibility-notes/compiled-function-source-file.md
@@ -1,0 +1,51 @@
+# Cached compiled functions should retain source file metadata
+
+## Summary
+
+This is a VM-internal compatibility issue found during the Moopa port. It is not
+currently exposed as a clean CFML runner test.
+
+When `compile_file_cached()` compiles a CFML/CFC file, functions in the returned
+`BytecodeProgram` should retain the source file path they came from. Cached
+component/application functions may later need that metadata when they are
+restored or rebound into a request program.
+
+## Observed Behavior
+
+Functions produced through cached file compilation did not have `source_file`
+populated. That left later function restoration/rebinding paths without the
+original file identity for a cached function.
+
+## Expected Behavior
+
+After compiling a source file through `compile_file_cached(path, ...)`, every
+function originating from that file should have:
+
+```text
+function.source_file == Some(path)
+```
+
+## Suggested Fix Shape
+
+After `compiler.compile(ast)` returns the `BytecodeProgram`, iterate over the
+program functions and assign the source path before caching/returning it:
+
+```rust
+let mut program = compiler.compile(ast);
+for func in &mut program.functions {
+    Arc::make_mut(func).source_file = Some(path.to_string());
+}
+```
+
+## Moopa Port Context
+
+This came up while debugging cached component/application function behavior.
+Moopa exercises a lot of application-scoped functions and cached component
+methods, so stale or incomplete function metadata can surface as incorrect
+rebinding behavior after cached code is reused.
+
+## Why This Is Markdown-Only
+
+The useful assertion is against RustCFML VM metadata, not a direct CFML output.
+I did not find a clean CFML-only runner test that observes this invariant
+without depending on surrounding cache/rebinding internals.

--- a/docs/compatibility-notes/compiled-function-source-file.md
+++ b/docs/compatibility-notes/compiled-function-source-file.md
@@ -49,3 +49,12 @@ rebinding behavior after cached code is reused.
 The useful assertion is against RustCFML VM metadata, not a direct CFML output.
 I did not find a clean CFML-only runner test that observes this invariant
 without depending on surrounding cache/rebinding internals.
+
+This PR therefore includes a focused Rust integration test:
+
+```text
+crates/cfml-vm/tests/compiled_function_source_file.rs
+```
+
+The test compiles a CFC through `compile_file_cached()` and asserts that the
+compiled `read` function has `source_file` set to the CFC path.


### PR DESCRIPTION
Adds a markdown note plus a focused Rust integration test describing the VM-internal `source_file` metadata issue found during the Moopa port.

The test compiles a CFC through `compile_file_cached()` and asserts that the compiled function records the originating CFC path in `function.source_file`.

## Validation

Native targeted test currently fails as expected, illustrating the issue:

```sh
cargo test -p cfml-vm --test compiled_function_source_file cached_file_compilation_records_function_source_file
```

Observed failure:

```text
assertion `left == right` failed
  left: Some("/app/lib/db.cfc")
 right: None
```

WASM checks attempted per project expectation:

```sh
cargo build -p cfml-worker -p rustcfml-wasm --target wasm32-unknown-unknown
cargo test -p cfml-vm --target wasm32-unknown-unknown --test compiled_function_source_file --no-run
```

Both could not run in this local environment because the `wasm32-unknown-unknown` target is not installed and `rustup` is not available here to add it:

```text
can't find crate for `core`
the `wasm32-unknown-unknown` target may not be installed
zsh:1: command not found: rustup
```
