### PR TITLE
Add cross-engine test for the cfdirectory function-call form

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -310,6 +310,12 @@ try { include "core/test_quoted_catch_type.cfm"; } catch (any e) { writeOutput("
 //     inside a braced `case`/`default` body. Both surfaced while booting Wheels.
 try { include "core/test_chained_compound_assignment.cfm"; } catch (any e) { writeOutput("ERROR | core/test_chained_compound_assignment.cfm | " & e.message & chr(10)); }
 try { include "core/test_switch_braced_case.cfm"; } catch (any e) { writeOutput("ERROR | core/test_switch_braced_case.cfm | " & e.message & chr(10)); }
+//   - cfdirectory_function_form: cfdirectory invoked as a script function with
+//     named args (action/directory/name, or attributeCollection) throws
+//     "cfdirectory requires a struct argument" on RustCFML, while directoryList()
+//     works and attributeCollection works on other tags. Wheels' Global.cfc
+//     $directory() wrapper hits it during onApplicationStart plugin discovery.
+try { include "tags/test_cfdirectory_function_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_function_form.cfm | " & e.message & chr(10)); }
 
 printSummary();
 </cfscript>

--- a/tests/tags/test_cfdirectory_function_form.cfm
+++ b/tests/tags/test_cfdirectory_function_form.cfm
@@ -1,0 +1,47 @@
+<cfscript>
+suiteBegin("Tags: cfdirectory function-call form");
+
+// ============================================================
+// Background
+// ============================================================
+// Invoked as a CFScript function with named arguments — either explicitly
+// (action / directory / filter / name) or via attributeCollection — `cfdirectory`
+// performs the directory operation on Lucee 5/6/7, Adobe CF 2018-2025, and
+// BoxLang. For action="list" it populates the `name` variable with a directory
+// query.
+//
+// On RustCFML the cfdirectory function-call form rejects its named arguments and
+// throws "cfdirectory requires a struct argument" — BOTH the explicit-args form
+// and the attributeCollection form fail. (The `directoryList()` function works,
+// and attributeCollection works on other tags e.g. cfheader, so this is specific
+// to cfdirectory's function-call handler.)
+//
+// Wheels reaches this on the boot path: vendor/wheels/Global.cfc's $directory()
+// wrapper calls cfdirectory(attributeCollection=...), used during plugin
+// discovery and case-insensitive file lookup at onApplicationStart.
+//
+// The error is a catchable runtime error (not a parse error), so this test wraps
+// the call in try/catch and asserts the listing succeeds rather than throws.
+// ============================================================
+
+function listViaCfdirectory() {
+	var tmp = getTempDirectory() & "rustcfml_cfdir_" & createUUID() & "/";
+	directoryCreate(tmp);
+	fileWrite(tmp & "a.txt", "1");
+	fileWrite(tmp & "b.txt", "2");
+	var result = "";
+	try {
+		cfdirectory(action = "list", directory = tmp, filter = "*.txt", name = "dirQ");
+		result = isQuery(dirQ) ? "rows=" & dirQ.recordCount : "not-a-query";
+	} catch (any e) {
+		result = "ERROR: " & e.message;
+	}
+	directoryDelete(tmp, true);
+	return result;
+}
+
+assert("cfdirectory(action='list', directory=, filter=, name=) lists the directory as a query",
+	listViaCfdirectory(), "rows=2");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
Continuing the Wheels-on-RustCFML compatibility work. While booting the Wheels framework on v0.41.0 (now well past the parse-gap fixes), `cfdirectory` invoked as a **CFScript function call** is rejected.

## The gap

`cfdirectory(action="list", directory=D, name="Q")` — and the `attributeCollection` form — throw **`cfdirectory requires a struct argument`** on RustCFML, where Lucee 5/6/7, Adobe CF 2018-2025, and BoxLang perform the listing and populate `Q` with a directory query.

It's specific to `cfdirectory`'s function-call handler, not a general named-arg/attributeCollection problem:
- `directoryList(dir, false, "query", "*.txt")` → **works** on RustCFML
- `cfheader(attributeCollection="#struct#")` → **works** on RustCFML
- `cfdirectory(action="list", ...)` and `cfdirectory(attributeCollection=...)` → **both fail**

## Where Wheels hits it

`vendor/wheels/Global.cfc`'s `$directory()` wrapper calls `cfdirectory(attributeCollection=...)` and is reached during `onApplicationStart` (plugin discovery + case-insensitive file lookup), so a Wheels app errors at boot once it gets past the earlier rungs.

## The test

`tests/tags/test_cfdirectory_function_form.cfm` creates a temp dir with two files, lists it via `cfdirectory(action="list", …, name="dirQ")`, and asserts `rows=2`. The error is a catchable runtime error (not a parse error), so it's wrapped in try/catch and the assertion surfaces the gap without aborting the runner.

| Engine | Result |
|--------|--------|
| Lucee 7.0.2 | **rows=2** (pass) |
| RustCFML 0.41.0 | `ERROR: cfdirectory requires a struct argument` (fail) |

Full suite on 0.41.0: 3201/3202, this the only (intended) red.
