### PR TITLE
Add cross-engine test for undeclared named arguments keeping their names

### DIFF
--- a/tests/core/UndeclaredArgFixture.cfc
+++ b/tests/core/UndeclaredArgFixture.cfc
@@ -1,0 +1,19 @@
+// Fixture for the "undeclared named arguments keep their names" behavior.
+// `capture()` declares only `a`, but is called with extra named args (b, c).
+// On Lucee/Adobe CF/BoxLang those extras remain reachable by name in the
+// `arguments` scope; on RustCFML they are stored positionally (numeric keys),
+// so StructKeyExists(arguments, "b") is false.
+//
+// Wheels relies on this in vendor/wheels/Global.cfc $createObjectFromRoot: it
+// declares path/fileName/method, receives extra named args (e.g. pluginPath),
+// then forwards the whole `arguments` struct to the target method.
+component {
+	public string function probe() {
+		return capture(a = "A", b = "B", c = "C");
+	}
+	private string function capture(required string a) {
+		return StructKeyExists(arguments, "b") && StructKeyExists(arguments, "c")
+			? "a=" & arguments.a & ",b=" & arguments.b & ",c=" & arguments.c
+			: "MISSING (keys=" & StructKeyList(arguments) & ")";
+	}
+}

--- a/tests/core/test_undeclared_named_args.cfm
+++ b/tests/core/test_undeclared_named_args.cfm
@@ -1,0 +1,30 @@
+<cfscript>
+suiteBegin("Core: undeclared named arguments keep their names");
+
+// ============================================================
+// Background
+// ============================================================
+// Calling a function with MORE named arguments than it declares is standard
+// CFML on Lucee 5/6/7, Adobe CF 2018-2025, and BoxLang: the extra named args
+// remain reachable BY NAME in the `arguments` scope. This underpins the common
+// framework pattern of declaring a few params, accepting arbitrary extra named
+// args, and forwarding `arguments` on to another method.
+//
+// On RustCFML the extra (undeclared) named args are stored POSITIONALLY — the
+// `arguments` scope gets numeric keys (1, 2, 3, ...) instead of the names, so
+// StructKeyExists(arguments, "<name>") is false and the values can't be read by
+// name or forwarded.
+//
+// This blocks the Wheels boot: vendor/wheels/Global.cfc $createObjectFromRoot
+// declares path/fileName/method, is called with extra named args (pluginPath,
+// deletePluginDirectories, ...), and forwards `arguments` to the target $init —
+// which then receives an empty pluginPath, sending the plugin-directory scan to
+// the wrong path.
+// ============================================================
+
+o = createObject("component", "UndeclaredArgFixture");
+assert("extra named args are reachable by name in the arguments scope",
+	o.probe(), "a=A,b=B,c=C");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -310,6 +310,12 @@ try { include "core/test_quoted_catch_type.cfm"; } catch (any e) { writeOutput("
 //     inside a braced `case`/`default` body. Both surfaced while booting Wheels.
 try { include "core/test_chained_compound_assignment.cfm"; } catch (any e) { writeOutput("ERROR | core/test_chained_compound_assignment.cfm | " & e.message & chr(10)); }
 try { include "core/test_switch_braced_case.cfm"; } catch (any e) { writeOutput("ERROR | core/test_switch_braced_case.cfm | " & e.message & chr(10)); }
+//   - undeclared_named_args: calling a function with more named args than it
+//     declares keeps the extras reachable by name in `arguments` on
+//     Lucee/ACF/BoxLang; RustCFML stores them positionally (numeric keys).
+//     Wheels' $createObjectFromRoot forwards such extras (pluginPath, ...) to a
+//     target method — they arrive empty, breaking the boot plugin scan.
+try { include "core/test_undeclared_named_args.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undeclared_named_args.cfm | " & e.message & chr(10)); }
 
 printSummary();
 </cfscript>


### PR DESCRIPTION
Continuing the Wheels-on-RustCFML work. Calling a function with **more named arguments than it declares** behaves differently on RustCFML, and it blocks the Wheels boot.

## The gap

On Lucee 5/6/7, Adobe CF 2018-2025, and BoxLang, extra (undeclared) named arguments remain reachable **by name** in the `arguments` scope:

```cfml
function f(required string a) {
    // called as f(a="A", b="B", c="C")
    return StructKeyExists(arguments, "b");   // true on JVM engines
}
```

On RustCFML the extras are stored **positionally** — `arguments` ends up with numeric keys (`a,1,2,3,...`) instead of `a,b,c`, so `StructKeyExists(arguments, "b")` is `false` and the value can't be read by name or forwarded.

This underpins a very common framework idiom: declare a few params, accept arbitrary extra named args, and forward the whole `arguments` struct onward.

## Where Wheels hits it

`vendor/wheels/Global.cfc` `$createObjectFromRoot(required string path, required string fileName, required string method)` is called with **extra** named args:

```cfml
$createObjectFromRoot(path="wheels", fileName="Plugins", method="$init",
                      pluginPath=local.pluginPath, deletePluginDirectories=..., ...);
```

It then does `local.argumentCollection = arguments;` and `Invoke(instance, method, argumentCollection)`. On RustCFML the `pluginPath` (and the other extras) aren't keyed by name in `arguments`, so `Plugins.$init` receives an **empty** `pluginPath` → `ExpandPath("")` resolves to the webroot → the plugin-directory scan runs against the wrong path and the boot dies in `directoryList`.

## The test

`tests/core/test_undeclared_named_args.cfm` calls a fixture method declaring only `a` with extra named args `b`/`c`, and asserts they're reachable by name.

| Engine | Result |
|--------|--------|
| Lucee 7.0.2 | `a=A,b=B,c=C` (pass) |
| RustCFML 0.41.0 | `MISSING (keys=a,1,2,3,4,5)` (fail) |

Full suite on 0.41.0: 3201/3202, this the only (intended) red.
