### PR TITLE
Add CFML test for custom tag attributeCollection

### DIFF
--- a/docs/compatibility-notes/custom-tag-attribute-collection.md
+++ b/docs/compatibility-notes/custom-tag-attribute-collection.md
@@ -1,0 +1,16 @@
+# Custom Tag `attributeCollection`
+
+Moopa renders form controls through nested custom tags. Those tags commonly pass
+resolved control metadata through `attributeCollection`, while also supplying a
+small number of explicit attributes at the call site.
+
+Lucee-compatible behavior:
+
+- `attributeCollection` merges the supplied struct into the custom tag
+  `attributes` scope.
+- The behavior applies to both `cfmodule` and `cf_` prefix custom tags.
+- Explicit attributes override values supplied by `attributeCollection`.
+- The source struct is not mutated.
+
+The added CFML test captures that behavior without prescribing an implementation
+strategy.

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -133,6 +133,7 @@ try { include "tags/test_tags_param.cfm"; } catch (any e) { writeOutput("ERROR |
 try { include "tags/test_tags_param_dynamic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_param_dynamic.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_misc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_misc.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_customtag.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_customtag.cfm | " & e.message & chr(10)); }
+try { include "tags/test_custom_tag_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_custom_tag_attribute_collection.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_customtag_lifecycle.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_customtag_lifecycle.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_buffer_recovery.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_buffer_recovery.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfexecute.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfexecute.cfm | " & e.message & chr(10)); }

--- a/tests/tags/customtags/showattrs.cfm
+++ b/tests/tags/customtags/showattrs.cfm
@@ -1,0 +1,8 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfif structKeyExists(attributes, "placeholder")>
+        <cfset labelText = attributes.placeholder>
+    <cfelse>
+        <cfset labelText = attributes.label>
+    </cfif>
+    <cfoutput>#attributes.model#|#labelText#|#attributes.class#</cfoutput>
+</cfif>

--- a/tests/tags/showattrs.cfm
+++ b/tests/tags/showattrs.cfm
@@ -1,0 +1,8 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfif structKeyExists(attributes, "placeholder")>
+        <cfset labelText = attributes.placeholder>
+    <cfelse>
+        <cfset labelText = attributes.label>
+    </cfif>
+    <cfoutput>#attributes.model#|#labelText#|#attributes.class#</cfoutput>
+</cfif>

--- a/tests/tags/test_custom_tag_attribute_collection.cfm
+++ b/tests/tags/test_custom_tag_attribute_collection.cfm
@@ -1,0 +1,35 @@
+<cfscript>
+suiteBegin("Custom tags: attributeCollection");
+
+control_attrs = {
+    model: "current_record.full_name",
+    placeholder: "Full name",
+    class: "input w-full"
+};
+</cfscript>
+
+<cfsavecontent variable="moduleOutput">
+    <cfmodule template="customtags/showattrs.cfm" attributeCollection="#control_attrs#" model="override.model">
+</cfsavecontent>
+
+<cfscript>
+assert("cfmodule merges attributeCollection and explicit attrs override", trim(moduleOutput), "override.model|Full name|input w-full");
+assert("cfmodule attributeCollection source struct is not mutated", control_attrs.model, "current_record.full_name");
+
+control_attrs = {
+    model: "current_record.email",
+    label: "Email",
+    class: "input w-full"
+};
+</cfscript>
+
+<cfsavecontent variable="prefixOutput">
+    <cf_showattrs attributeCollection="#control_attrs#" model="override.email"></cf_showattrs>
+</cfsavecontent>
+
+<cfscript>
+assert("cf_ custom tag merges attributeCollection and explicit attrs override", trim(prefixOutput), "override.email|Email|input w-full");
+assert("cf_ custom tag attributeCollection source struct is not mutated", control_attrs.model, "current_record.email");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What changed

Adds a CFML regression test and short compatibility note for generic custom tag `attributeCollection` handling.

The test covers both:

- `cfmodule template="..." attributeCollection="#attrs#"`
- `cf_showattrs attributeCollection="#attrs#"`

It also checks that explicit attributes override values from `attributeCollection` and that the source struct is not mutated.

## Why

Moopa renders form controls through nested custom tags and passes resolved control metadata through `attributeCollection`. On Lucee, those attributes are merged into the custom tag `attributes` scope for both `cfmodule` and `cf_` prefix custom tags.

## Validation

- `cargo run -- tests/runner.cfm`
  - expected regression failure on current upstream: `Custom tags: attributeCollection` has 2 failing assertions.
- `cargo test -p rustcfml-wasm`
  - passes.

No Rust implementation changes are included.


- `wasm-pack build crates/wasm --target web`
  - not run locally because `wasm-pack` is not installed.
