### PR TITLE
Add CFML test for tag string interpolation

### DIFF
--- a/docs/compatibility-notes/tag-string-interpolation.md
+++ b/docs/compatibility-notes/tag-string-interpolation.md
@@ -1,0 +1,15 @@
+# Tag Attribute And Tag-Form String Interpolation
+
+Moopa control templates build Alpine bindings and element ids using tag-form
+`cfset` strings such as:
+
+```cfml
+<cfset model = "#attributes.model_record#.#field_name#">
+```
+
+Lucee-compatible behavior is that quoted tag attribute strings preserve literal
+text while evaluating `#...#` interpolation. Text before, between, and after
+interpolation segments should remain part of the final string.
+
+The added CFML test captures the Moopa-shaped `cfset` behavior without
+prescribing an implementation strategy.

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -148,6 +148,7 @@ try { include "tags/test_tags_cfthread_concurrency.cfm"; } catch (any e) { write
 try { include "tags/test_tags_cfscript_statements.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfscript_statements.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfhttp_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttp_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfhttpparam_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttpparam_interpolation.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tag_string_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_string_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfzip.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfzip.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_tld.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_tld.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_whitespace.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_whitespace.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_tag_string_interpolation.cfm
+++ b/tests/tags/test_tag_string_interpolation.cfm
@@ -1,0 +1,22 @@
+<cfscript>
+suiteBegin("Tag string interpolation");
+</cfscript>
+
+<cfset attributes = { model_record: "current_record", table_name: "moo_profile" }>
+<cfset field_name = "email">
+<cfset model = "#attributes.model_record#.#field_name#">
+<cfset control_id = "#attributes.table_name#_#field_name#">
+
+<cfscript>
+assert("tag-form cfset interpolates nested struct value in quoted string", model, "current_record.email");
+assert("tag-form cfset interpolates multiple values in quoted string", control_id, "moo_profile_email");
+
+route = { url: "/sysadmin/profiles" };
+endpoint = "save";
+start_time = getTickCount() - 7;
+message = "Security check for route #route.url# and endpoint #endpoint# took #getTickCount() - start_time#ms";
+
+assert("script string interpolation remains available as control", find("Security check for route /sysadmin/profiles and endpoint save took ", message) EQ 1, true);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What changed

Adds a CFML regression test and short compatibility note for tag-form string interpolation.

The test covers Moopa-shaped tag syntax such as:

```cfml
<cfset model = "#attributes.model_record#.#field_name#">
```

## Why

Moopa control templates use this pattern to build Alpine bindings and control ids. Lucee evaluates `#...#` interpolation inside quoted tag attribute strings while preserving surrounding literal text.

## Validation

- `cargo run -- tests/runner.cfm`
  - expected regression failure on current upstream: `Tag string interpolation` has 2 failing assertions.
- `cargo test -p rustcfml-wasm`
  - passes.

No Rust implementation changes are included.


- `wasm-pack build crates/wasm --target web`
  - not run locally because `wasm-pack` is not installed.
