### PR TITLE
Add CFML test for cfqueryparam interpolated value

### DIFF
--- a/docs/compatibility-notes/cfqueryparam-interpolated-value.md
+++ b/docs/compatibility-notes/cfqueryparam-interpolated-value.md
@@ -1,0 +1,15 @@
+# `cfqueryparam value` With Interpolated Text
+
+Moopa search and filter queries use `cfqueryparam` values that combine literal
+text with interpolated variables, commonly wildcard search parameters:
+
+```cfml
+<cfqueryparam value="%#url.q#%" cfsqltype="cf_sql_varchar">
+```
+
+Lucee-compatible behavior is that the quoted `value` attribute is evaluated as
+a string with literal `%` characters preserved and `#url.q#` interpolated.
+
+The added CFML test keeps the raw syntax that exposed the compatibility gap.
+It is expected to fail during parsing on current upstream until the syntax is
+supported.

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -140,6 +140,7 @@ try { include "tags/test_tags_cfmail.cfm"; } catch (any e) { writeOutput("ERROR 
 try { include "tags/test_tags_cfcache.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfcache.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfstoredproc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfstoredproc.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfqueryparam_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfqueryparam_attribute_collection.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cfqueryparam_interpolated_value.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_interpolated_value.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfquery_control_tags.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_mapping_path.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfimport.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfimport.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_cfqueryparam_interpolated_value.cfm
+++ b/tests/tags/test_cfqueryparam_interpolated_value.cfm
@@ -1,0 +1,38 @@
+<cfscript>
+suiteBegin("cfqueryparam: interpolated value attribute");
+
+tmpfile = getTempDirectory() & "/rustcfml_qparam_interp_" & createUUID() & ".sqlite";
+ds = "sqlite://" & tmpfile;
+skip = false;
+
+try {
+    queryExecute("CREATE TABLE t (id INTEGER PRIMARY KEY, search_value TEXT)", [], { datasource: ds });
+    queryExecute("INSERT INTO t (id, search_value) VALUES (1, '%mat%'), (2, '%other%')", [], { datasource: ds });
+} catch (any e) {
+    skip = true;
+    assertTrue("cfqueryparam interpolated value skipped (no sqlite): " & e.message, true);
+}
+</cfscript>
+
+<cfif NOT skip>
+
+<cfscript>
+url = { q: "mat" };
+</cfscript>
+
+<cfquery name="q" datasource="#ds#">
+    SELECT search_value
+    FROM t
+    WHERE search_value = <cfqueryparam value="%#url.q#%" cfsqltype="cf_sql_varchar">
+</cfquery>
+
+<cfscript>
+assert("cfqueryparam preserves literal text around interpolated value", q.search_value[1], "%mat%");
+assert("cfqueryparam interpolated value finds one row", q.recordCount, 1);
+
+try { fileDelete(tmpfile); } catch (any e) {}
+</cfscript>
+
+</cfif>
+
+<cfscript>suiteEnd();</cfscript>


### PR DESCRIPTION
## What changed

Adds a CFML regression test and short compatibility note for `cfqueryparam value` attributes that combine literal text and interpolation.

The test uses the Moopa/Lucee-compatible shape:

```cfml
<cfqueryparam value="%#url.q#%" cfsqltype="cf_sql_varchar">
```

## Why

Moopa search/filter SQL uses this shape for wildcard search values. Lucee preserves the literal `%` characters and interpolates the `#url.q#` segment before binding the query parameter.

## Validation

- `cargo run -- tests/runner.cfm`
  - expected regression failure on current upstream: parse error `Expected RBrace, found Identifier("url")` in `tests/tags/test_cfqueryparam_interpolated_value.cfm`.
- `cargo test -p rustcfml-wasm`
  - passes.

No Rust implementation changes are included.


- `wasm-pack build crates/wasm --target web`
  - not run locally because `wasm-pack` is not installed.
