### PR TITLE
Add CFML test for returned service chain

### DIFF
--- a/docs/compatibility-notes/returned-service-chain.md
+++ b/docs/compatibility-notes/returned-service-chain.md
@@ -1,0 +1,15 @@
+# Returned Service Chain Receiver Preservation
+
+Moopa resolves table services dynamically and immediately calls methods on the
+returned service:
+
+```cfml
+application.lib.db.getService("moo_profile").login(...)
+```
+
+Lucee-compatible behavior is that `getService()` runs on the factory component,
+`login()` runs on the returned service component, and the original factory
+receiver remains unchanged after the chained call.
+
+The added CFML test captures that behavior without prescribing an implementation
+strategy.

--- a/tests/oop/ChainFactory.cfc
+++ b/tests/oop/ChainFactory.cfc
@@ -1,0 +1,15 @@
+<cfcomponent>
+    <cffunction name="init">
+        <cfset variables.kind = "factory">
+        <cfreturn this>
+    </cffunction>
+
+    <cffunction name="kind">
+        <cfreturn variables.kind>
+    </cffunction>
+
+    <cffunction name="getService">
+        <cfargument name="table_name" default="moo_profile">
+        <cfreturn createObject("component", "oop.ChainService").init()>
+    </cffunction>
+</cfcomponent>

--- a/tests/oop/ChainService.cfc
+++ b/tests/oop/ChainService.cfc
@@ -1,0 +1,13 @@
+<cfcomponent>
+    <cffunction name="init">
+        <cfset variables.prefix = "service">
+        <cfreturn this>
+    </cffunction>
+
+    <cffunction name="login">
+        <cfargument name="profile_id" required="true">
+        <cfargument name="stay_logged_in" default="false">
+
+        <cfreturn variables.prefix & ":" & arguments.profile_id & ":" & arguments.stay_logged_in>
+    </cffunction>
+</cfcomponent>

--- a/tests/oop/test_returned_service_chain.cfm
+++ b/tests/oop/test_returned_service_chain.cfm
@@ -1,0 +1,40 @@
+<cfscript>
+suiteBegin("Returned service chain");
+
+factory = createObject("component", "oop.ChainFactory").init();
+
+assert(
+    "method call works on CFC returned from factory method",
+    factory.getService("moo_profile").login(profile_id = "p1", stay_logged_in = false),
+    "service:p1:false"
+);
+
+assert(
+    "factory receiver is not overwritten by chained returned-service call",
+    factory.kind(),
+    "factory"
+);
+
+assert(
+    "factory can still create another service after chained call",
+    factory.getService("moo_profile").login(profile_id = "p2", stay_logged_in = false),
+    "service:p2:false"
+);
+
+application.lib = {};
+application.lib.db = createObject("component", "oop.ChainFactory").init();
+
+assert(
+    "application-scoped factory supports Moopa-style service chain",
+    application.lib.db.getService("moo_profile").login(profile_id = "p3", stay_logged_in = false),
+    "service:p3:false"
+);
+
+assert(
+    "application-scoped factory remains the factory after service chain",
+    application.lib.db.kind(),
+    "factory"
+);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -121,6 +121,7 @@ try { include "oop/test_repeated_instantiation.cfm"; } catch (any e) { writeOutp
 try { include "oop/test_component_mapping_paths.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_mapping_paths.cfm | " & e.message & chr(10)); }
 try { include "oop/test_component_method_named_args.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_method_named_args.cfm | " & e.message & chr(10)); }
 try { include "oop/test_component_method_precedence.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_method_precedence.cfm | " & e.message & chr(10)); }
+try { include "oop/test_returned_service_chain.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_returned_service_chain.cfm | " & e.message & chr(10)); }
 
 // --- Tags ---
 try { include "tags/test_tags_basic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_basic.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## What changed

Adds a CFML regression test and short compatibility note for chained method calls where the second method is invoked on a CFC returned by the first method.

The test covers the Moopa-style shape:

```cfml
application.lib.db.getService("moo_profile").login(...)
```

## Why

Moopa dynamically resolves table services and immediately calls methods on the returned service. Lucee keeps the original factory receiver intact after the chained call.

## Validation

- `cargo run -- tests/runner.cfm`
  - observed current upstream regression: `ERROR | oop/test_returned_service_chain.cfm | Component [oop.ChainService] has no function with name [kind]`.
  - this indicates the original factory receiver was clobbered by the returned service during the chain.
- `cargo test -p rustcfml-wasm`
  - passes.

No Rust implementation changes are included.


- `wasm-pack build crates/wasm --target web`
  - not run locally because `wasm-pack` is not installed.
