### PR TITLE
Add CFML test for tag attribute interpolation

### DIFF
--- a/docs/compatibility-notes/tag-attribute-interpolation.md
+++ b/docs/compatibility-notes/tag-attribute-interpolation.md
@@ -1,0 +1,68 @@
+# Tag Attribute String Interpolation (cfthrow / cfargument / cffile and peers)
+
+Lucee-compatible behavior is that a quoted tag-attribute value evaluates
+`#...#` interpolation while preserving the literal text before, between, and
+after each interpolated segment — and this holds for **every** tag, not just a
+favored subset.
+
+Moopa hit this with messages, defaults, and file paths that combine literal
+text with interpolated variables:
+
+```cfml
+<cfthrow message="APP_NAME '#application.app_name#' does not match an app directory at /apps/#application.app_name#." />
+<cfargument name="path" default="/apps/#request.app_name#/routes" />
+<cffile action="read" file="#local.filePath#" variable="local.jsonContent" />
+```
+
+The local workaround rewrote every such string into explicit `&` concatenation
+(or, for `cffile`, wrapped the whole path in one `#expr#`). The added CFML test
+captures the Moopa-shaped behavior without prescribing an implementation
+strategy.
+
+## Observed gap on current upstream (v0.52.1)
+
+Interpolation is applied inconsistently across tags:
+
+| Tag attribute | bare `#x#` interpolation | notes |
+| --- | --- | --- |
+| `<cfset x = "...">` / `cfif` / `cfreturn` | ✅ works | control |
+| `<cfparam default="...">` | ✅ works | control |
+| `<cfqueryparam value="...">` | ✅ works | fixed previously |
+| `<cfinclude template="...">` | ✅ works | control |
+| `<cfdirectory directory="...">` | ✅ works | control |
+| `<cfthrow message=/type=/detail=>` | ❌ emitted as literal text | single-quote-wrapped `'#x#'` does interpolate |
+| `<cfargument default="...">` | ❌ literal, or mis-parsed as an expression | |
+| `<cffile file="...">` | ❌ single-var path becomes a literal; literal path fails to parse | only a full `#expr#` works |
+| `<cfcookie value="...">` | ❌ mis-parsed as an expression | not asserted in the test (cookie scope is request-time only) |
+| `<cfmail subject="...">` | ❌ mis-parsed as an expression | not asserted (requires a mail server) |
+
+A telling inconsistency: `<cfparam default="/apps/#x#/cfg">` interpolates
+correctly, but `<cfargument default="/apps/#x#/cfg">` (the same value shape) does
+not. Single-quote-wrapping the interpolated segment (`'#x#'`) is the reliable
+escape hatch on current upstream.
+
+## Where the divergence lives
+
+The tag preprocessor (`crates/cfml-compiler/src/tag_parser.rs`) dispatches a
+separate hand-written arm per tag, and those arms emit attribute values through
+**different** helpers:
+
+- **Correct (Lucee parity):** `cfparam` / `cfqueryparam` / custom-tag attrs use
+  `format_attr_value()`, which splits a quoted value into literal segments and
+  `#expr#` segments and emits `"lit" & (expr) & "lit"`.
+- **Affected:** `cfthrow`, `cfargument`, and `cffile` (in `parse_cffile_tag`)
+  use `strip_hashes()` plus ad-hoc re-quoting. `strip_hashes` removes the `#`
+  delimiters from a bare `#expr#`, so the segment is re-emitted as flat literal
+  text. (`cffile` additionally guesses literal-vs-expression from whether the
+  stripped value contains `.`/`(`, so a single-variable path like `#filePath#`
+  is quoted as the literal `"filePath"`, and a literal `/a/b.cfm` is parsed as a
+  division expression.) `'#x#'` survives only because `strip_hashes` preserves
+  hashes inside an inner string literal.
+
+So routing these attributes through `format_attr_value()` — as `cfparam`
+already does — is the natural direction.
+
+The test asserts the Lucee-compatible result. The control cases pass today; the
+`cfthrow` / `cfargument` / `cffile` cases are expected to fail on current
+upstream until tag-attribute interpolation is applied uniformly. Verified
+against Lucee 7.0.2.106 (all assertions pass).

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -153,6 +153,7 @@ try { include "tags/test_tags_cfscript_statements.cfm"; } catch (any e) { writeO
 try { include "tags/test_tags_cfhttp_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttp_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfhttpparam_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttpparam_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_string_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_string_interpolation.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tag_attribute_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_attribute_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfzip.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfzip.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_tld.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_tld.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_whitespace.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_whitespace.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_tag_attribute_interpolation.cfm
+++ b/tests/tags/test_tag_attribute_interpolation.cfm
@@ -1,0 +1,137 @@
+<cfscript>
+suiteBegin("Tag attribute string interpolation");
+</cfscript>
+
+<!---
+    Lucee-compatible behavior: a quoted tag-attribute value evaluates #...#
+    interpolation while preserving the literal text before, between, and after
+    each interpolated segment. This must hold regardless of which tag the
+    attribute belongs to.
+
+    Moopa hit this with <cfthrow message="..."> and <cfargument default="...">
+    that combine literal path/label text with interpolated variables. The local
+    workaround rewrote every such string into explicit "&" concatenation.
+
+    These tests pin the cross-tag behavior. Controls (cfset / cfparam) already
+    pass and document the expected result; the cfthrow / cfargument cases are
+    expected to fail on current upstream until tag-attribute interpolation is
+    applied uniformly.
+--->
+
+<cfset app_name = "hub" />
+<cfset field_name = "email" />
+<cfset detail_part = "profiles" />
+<cfset request.app_name = "hub" />
+
+<!--- ============================================================
+      CONTROLS: contexts where interpolation already works.
+      ============================================================ --->
+<cfset control_set = "/apps/#app_name#/#field_name#" />
+<cfparam name="control_param" default="/apps/#app_name#/cfg" />
+
+<cfscript>
+assert("control: cfset interpolates literal + multiple segments",
+    control_set, "/apps/hub/email");
+assert("control: cfparam default interpolates literal + segment",
+    control_param, "/apps/hub/cfg");
+</cfscript>
+
+<!--- ============================================================
+      cfthrow message: literal text + interpolation.
+      ============================================================ --->
+<cfset msg_single = "" />
+<cftry>
+    <cfthrow message="#app_name#" />
+    <cfcatch><cfset msg_single = cfcatch.message /></cfcatch>
+</cftry>
+
+<cfset msg_trailing = "" />
+<cftry>
+    <cfthrow message="APP_NAME '#app_name#' does not match an app directory at /apps/#app_name#." />
+    <cfcatch><cfset msg_trailing = cfcatch.message /></cfcatch>
+</cftry>
+
+<cfset msg_member_fn = "" />
+<cftry>
+    <cfthrow message="route #request.app_name# took #ucase(detail_part)# ms" />
+    <cfcatch><cfset msg_member_fn = cfcatch.message /></cfcatch>
+</cftry>
+
+<cfset msg_squote = "" />
+<cftry>
+    <cfthrow message="control '#app_name#' missing" />
+    <cfcatch><cfset msg_squote = cfcatch.message /></cfcatch>
+</cftry>
+
+<cfscript>
+assert("cfthrow message: bare single-segment interpolation",
+    msg_single, "hub");
+assert("cfthrow message: interpolation with trailing literal after segment",
+    msg_trailing, "APP_NAME 'hub' does not match an app directory at /apps/hub.");
+assert("cfthrow message: scoped member + function-call interpolation",
+    msg_member_fn, "route hub took PROFILES ms");
+// Single-quote-wrapped interpolation already works; documents the boundary.
+assert("cfthrow message: single-quote-wrapped interpolation (current workaround)",
+    msg_squote, "control 'hub' missing");
+</cfscript>
+
+<!--- ============================================================
+      cfthrow type / detail: same rule applies to every attribute.
+      ============================================================ --->
+<cfset thrown_type = "" />
+<cfset thrown_detail = "" />
+<cftry>
+    <cfthrow type="moopa.app.#app_name#" detail="failed for /apps/#app_name#/#field_name#" message="m" />
+    <cfcatch>
+        <cfset thrown_type = cfcatch.type />
+        <cfset thrown_detail = cfcatch.detail />
+    </cfcatch>
+</cftry>
+
+<cfscript>
+assert("cfthrow type: interpolation in type attribute",
+    thrown_type, "moopa.app.hub");
+assert("cfthrow detail: interpolation in detail attribute",
+    thrown_detail, "failed for /apps/hub/email");
+</cfscript>
+
+<!--- ============================================================
+      cfargument default: interpolation in a function-signature attribute.
+      ============================================================ --->
+<cffunction name="buildPath" returntype="string" output="false">
+    <cfargument name="path" type="string" default="/apps/#request.app_name#/routes" />
+    <cfreturn arguments.path />
+</cffunction>
+
+<cfset arg_default = "" />
+<cftry>
+    <cfset arg_default = buildPath() />
+    <cfcatch><cfset arg_default = "THROWN: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<!--- ============================================================
+      cffile: interpolation in a path attribute. Moopa reads package
+      files via <cffile action="read" file="#local.filePath#">, i.e. a
+      single-variable interpolated path. The file is created with the
+      fileWrite() BIF (function-argument interpolation already works) so
+      the assertion isolates the cffile attribute path specifically.
+      ============================================================ --->
+<cfset cffile_path = getTempDirectory() & "/rustcfml_attr_interp_" & createUUID() & ".txt" />
+<cfset fileWrite(cffile_path, "payload-marker") />
+
+<cfset cffile_read = "" />
+<cftry>
+    <cffile action="read" file="#cffile_path#" variable="cffile_contents" />
+    <cfset cffile_read = cffile_contents />
+    <cfcatch><cfset cffile_read = "THROWN: " & cfcatch.message /></cfcatch>
+</cftry>
+<cftry><cfset fileDelete(cffile_path) /><cfcatch></cfcatch></cftry>
+
+<cfscript>
+assert("cfargument default: interpolation in default attribute",
+    arg_default, "/apps/hub/routes");
+assert("cffile read: single-variable interpolation in file attribute",
+    cffile_read, "payload-marker");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

Lucee-compatible behavior is that a quoted **tag-attribute** value evaluates `#...#` interpolation while preserving the literal text around each segment — for *every* tag. On current upstream (v0.52.1) this holds for some tags but not others.

Real shapes from a downstream app (Moopa):

```cfml
<cfthrow message="APP_NAME '#application.app_name#' does not match an app directory at /apps/#application.app_name#." />
<cfargument name="path" default="/apps/#request.app_name#/routes" />
<cffile action="read" file="#local.filePath#" variable="local.jsonContent" />
```

## Observed gap

| Tag attribute | bare `#x#` | |
| --- | --- | --- |
| `cfset` / `cfif` / `cfreturn`, `cfparam`, `cfqueryparam`, `cfinclude`, `cfdirectory` | ✅ works | controls |
| `cfthrow` message/type/detail | ❌ emitted as literal | `'#x#'` (single-quote-wrapped) does interpolate |
| `cfargument` default | ❌ literal / mis-parsed as expression | |
| `cffile` file | ❌ single-var path → literal `"filePath"`; literal path → parse error | only a full `#expr#` works |
| `cfcookie` value, `cfmail` subject | ❌ mis-parsed as expression | documented in the note; not asserted |

Telling case: `<cfparam default="/apps/#x#/cfg">` interpolates, but `<cfargument default="/apps/#x#/cfg">` (identical value) does not.

## Where it diverges

`crates/cfml-compiler/src/tag_parser.rs` dispatches a per-tag arm, and the arms emit attribute values through different helpers:

- **Correct:** `cfparam` / `cfqueryparam` / custom-tag attrs use `format_attr_value()`, which splits a quoted value into literal + `#expr#` segments → `"lit" & (expr) & "lit"`.
- **Affected:** `cfthrow`, `cfargument`, `cffile` (`parse_cffile_tag`) use `strip_hashes()` + ad-hoc re-quoting, which drops the `#` delimiters so the segment is re-emitted as flat literal text. (`'#x#'` survives only because `strip_hashes` preserves hashes inside an inner string literal.)

Routing these through `format_attr_value()` — as `cfparam` already does — is the natural direction.

## Test

`tests/tags/test_tag_attribute_interpolation.cfm` (registered in `tests/runner.cfm`) + a compatibility note. Control cases (`cfset`/`cfparam`) pass today; the `cfthrow`/`cfargument`/`cffile` cases are expected to fail until tag-attribute interpolation is uniform.

**Verified against Lucee 7.0.2.106: 10/10 assertions pass.** On current upstream: 3/10.

This captures the behavior without prescribing an implementation.