### PR TITLE
Add cross-engine tests for reReplace capture-group backreferences

### DIFF
--- a/tests/stdlib/test_string_functions_regex.cfm
+++ b/tests/stdlib/test_string_functions_regex.cfm
@@ -12,6 +12,17 @@ assertTrue("reFindNoCase letters", reFindNoCase("[A-Z]+", "hello") > 0);
 assert("reReplace first", reReplace("abc123def", "[0-9]+", "NUM"), "abcNUMdef");
 assert("reReplace all", reReplace("abc123def456", "[0-9]+", "NUM", "all"), "abcNUMdefNUM");
 
+// --- reReplace capture-group backreferences ---
+// The replacement string may reference captured groups with \1..\9. Standard CFML
+// (Lucee/Adobe/BoxLang) substitutes the captured text; a literal "\1" must not survive.
+assert("reReplace backref single", reReplace("foo123bar", "([0-9]+)", "[\1]"), "foo[123]bar");
+assert("reReplace backref swap", reReplace("John Smith", "(\w+) (\w+)", "\2 \1"), "Smith John");
+assert("reReplace backref all", reReplace("a1b2c3", "([a-z])([0-9])", "\2\1", "all"), "1a2b3c");
+// Case-modifier escapes in the replacement: \u/\l upper/lower the next char, \U/\L the rest.
+assert("reReplace backref upper-first", reReplace("hello", "(h)(ello)", "\u\1\2"), "Hello");
+assert("reReplace backref title-case all", reReplace("route-tester", "(^|-)([a-z])", "\u\2", "all"), "RouteTester");
+assert("reReplace backref upper-rest", reReplace("abc", "(.*)", "\U\1"), "ABC");
+
 // --- reReplaceNoCase ---
 assert("reReplaceNoCase all", reReplaceNoCase("Hello World", "[a-z]+", "X", "all"), "X X");
 


### PR DESCRIPTION
Extends the existing `String Functions: Regex` suite with assertions for capture-group backreferences in the `reReplace` replacement string — a path the suite did not yet cover (it only exercised literal replacements like `"NUM"`).

On v0.52.3, `reReplace` matches correctly but does **not** substitute backreferences — the literal escape survives into the output:

| Call | v0.52.3 | Lucee / Adobe / BoxLang |
|------|---------|--------------------------|
| `reReplace("foo123bar", "([0-9]+)", "[\1]")` | `foo[\1]bar` | `foo[123]bar` |
| `reReplace("John Smith", "(\w+) (\w+)", "\2 \1")` | `\2 \1` | `Smith John` |
| `reReplace("a1b2c3", "([a-z])([0-9])", "\2\1", "all")` | `\2\1\2\1\2\1` | `1a2b3c` |
| `reReplace("route-tester", "(^|-)([a-z])", "\u\2", "all")` | `\u\2\u\2` | `RouteTester` |

The match side is fine — `reFind`/`reMatch`/scope=`all` all work — so this is isolated to backreference (and `\u`/`\l`/`\U`/`\L` case-modifier) substitution in the replacement.

This one shows up a lot in real code: URL-rewrite rules, slug/title-case helpers, and route-pattern compilation all lean on `\1`-style replacements. The assertions here encode the standard CFML behaviour so the gap is easy to track. Verified failing on the v0.52.3 release binary and passing on Lucee.