### PR TITLE
Add CFML test for application-scope object method in custom tag

### DIFF
--- a/docs/compatibility-notes/application-scope-object-in-custom-tag.md
+++ b/docs/compatibility-notes/application-scope-object-in-custom-tag.md
@@ -1,0 +1,65 @@
+# Calling an Application-Scope Object's Method From a Custom Tag
+
+Lucee-compatible behavior is that a CFC instance stored in the `application`
+scope (typically created in `onApplicationStart`) remains fully usable
+everywhere, including inside a custom tag (`cf_*` / `cfmodule`). Calling its
+methods must work the same as from a regular page.
+
+Apps rely on this constantly — services are kept in the application scope and
+called from view/control tags. The shape that exposed the gap:
+
+```cfml
+<!-- Application.cfc -->
+function onApplicationStart() {
+    application.lib.db = createObject("component", "/app/lib/db").init();
+}
+
+<!-- a custom tag, e.g. <cf_route> -->
+<cfset svc = application.lib.db.getService("moo_route") />
+```
+
+## Observed gap on current upstream (v0.52.1)
+
+In **serve mode**, calling a method on a component read from the `application`
+scope **inside a custom tag** throws:
+
+```
+Variable is not a function or function 'getService' is not defined
+```
+
+even though the component is intact (its keys include the method, and the same
+call from a regular page succeeds). Characterized:
+
+| Context | result |
+| --- | --- |
+| Regular page: `application.svc.ping()` | ✅ works |
+| Inside `cfmodule`/`cf_` custom tag: `application.svc.ping()` | ❌ "ping is not defined" |
+| Inside custom tag, nested: `application.lib.db.getService(...)` | ❌ |
+| Inside custom tag, locally created `createObject(...).ping()` | ✅ works |
+| CLI mode (any of the above) | ✅ works |
+
+Two further clues toward the cause:
+
+- It is **serve-mode only** — the component is set in one lifecycle frame
+  (`onApplicationStart`) and the failing call happens in another (the
+  custom-tag frame). The CLI path, which evaluates in a single flat frame,
+  works.
+- Passing the component into the tag as an **attribute**
+  (`<cf_probe svc="#application.svc#">`) makes the in-tag call work — evaluating
+  the component at the call site binds it. This points at the method-reference
+  binding being lost when the component is loaded *inside* the custom-tag frame
+  (cf. the v0.52.1 "bind CFC method references at the load site" /
+  "identity-guard method_this_writeback for chained CFC calls" work).
+
+## Test
+
+`tests/lifecycle/application_scope_custom_tag/` is a fixture app whose
+`onApplicationStart` puts a CFC in the application scope; its `index.cfm` prints
+`page=<result>;tag=<result>;`, calling the object's method directly (control)
+and from inside a `cfmodule` custom tag. `tests/lifecycle/test_application_scope_custom_tag.cfm`
+drives it over HTTP (skipping under the CLI runner, like the other lifecycle
+tests). The control passes today; the custom-tag case is expected to fail until
+the binding is preserved in custom-tag frames.
+
+Verified against Lucee 7.0.2.106: the fixture returns `page=pong;tag=pong;`
+(both succeed).

--- a/tests/lifecycle/application_scope_custom_tag/Application.cfc
+++ b/tests/lifecycle/application_scope_custom_tag/Application.cfc
@@ -1,0 +1,7 @@
+component {
+    this.name = "rustcfml_appscope_customtag";
+    function onApplicationStart() {
+        application.svc = createObject("component", "Svc").init();
+        return true;
+    }
+}

--- a/tests/lifecycle/application_scope_custom_tag/Svc.cfc
+++ b/tests/lifecycle/application_scope_custom_tag/Svc.cfc
@@ -1,0 +1,4 @@
+component {
+    function init() { return this; }
+    function ping() { return "pong"; }
+}

--- a/tests/lifecycle/application_scope_custom_tag/callsvc.cfm
+++ b/tests/lifecycle/application_scope_custom_tag/callsvc.cfm
@@ -1,0 +1,1 @@
+<cfif thisTag.executionMode EQ "start"><cftry><cfset result = application.svc.ping() /><cfoutput>#result#</cfoutput><cfcatch><cfoutput>FAILED:#cfcatch.message#</cfoutput></cfcatch></cftry></cfif>

--- a/tests/lifecycle/application_scope_custom_tag/index.cfm
+++ b/tests/lifecycle/application_scope_custom_tag/index.cfm
@@ -1,0 +1,1 @@
+<cfsavecontent variable="tagOut"><cfmodule template="callsvc.cfm"></cfsavecontent><cfoutput>page=#application.svc.ping()#;tag=#trim(tagOut)#;</cfoutput>

--- a/tests/lifecycle/test_application_scope_custom_tag.cfm
+++ b/tests/lifecycle/test_application_scope_custom_tag.cfm
@@ -1,0 +1,35 @@
+<cfscript>
+suiteBegin("Lifecycle: application-scope object method in custom tag");
+
+// A CFC instance stored in the application scope (set in onApplicationStart)
+// must remain callable from anywhere — including inside a custom tag. This is
+// how a typical app exposes services and calls them from view/control tags
+// (e.g. <cf_route> calling application.lib.db.getService("...")).
+//
+// This is a serve-mode lifecycle behavior, so it runs only when the suite is
+// driven over HTTP (cgi.server_port present) and is skipped under the CLI
+// runner. The fixture's index.cfm prints:
+//   page=<result>;tag=<result>;
+// where `page` calls the application-scoped object directly (control) and
+// `tag` makes the same call from inside a cfmodule custom tag.
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+
+if (serverPort == "" || serverPort == "0") {
+    assertTrue("application-scope custom-tag lifecycle skipped (no cgi.server_port)", true);
+} else {
+    targetPath = "/tests/lifecycle/application_scope_custom_tag/index.cfm";
+    http url="http://127.0.0.1:#serverPort##targetPath#" method="GET" result="probeResult";
+    body = trim(probeResult.filecontent);
+
+    assert("custom-tag fixture status", probeResult.statuscode, "200 OK");
+    // Control: a regular page can call the application-scoped object's method.
+    assertTrue("regular page calls application-scope object method (control)",
+        findNoCase("page=pong;", body) GT 0);
+    // The behavior under test: the same call from inside a custom tag.
+    assertTrue("custom tag calls application-scope object method",
+        findNoCase("tag=pong;", body) GT 0);
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -164,6 +164,7 @@ try { include "includes/test_named_args_includes.cfm"; } catch (any e) { writeOu
 // --- Lifecycle / server request fixtures ---
 try { include "lifecycle/test_application_mapping_coverage.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_mapping_coverage.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_load_errors.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_load_errors.cfm | " & e.message & chr(10)); }
+try { include "lifecycle/test_application_scope_custom_tag.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_scope_custom_tag.cfm | " & e.message & chr(10)); }
 try { include "server/test_front_controller_fallback.cfm"; } catch (any e) { writeOutput("ERROR | server/test_front_controller_fallback.cfm | " & e.message & chr(10)); }
 
 // --- Java Shims ---


### PR DESCRIPTION
## Summary

A CFC instance stored in the `application` scope (set in `onApplicationStart`) must stay callable everywhere, including inside a custom tag (`cf_*` / `cfmodule`). On current upstream (v0.52.1), in **serve mode**, calling such a method from inside a custom tag throws even though the component is intact:

```
Variable is not a function or function 'getService' is not defined
```

Real shape that surfaced it — a front-controller view tag calling a service held in the application scope:

```cfml
// Application.cfc
function onApplicationStart() {
    application.lib.db = createObject("component","/app/lib/db").init();
}
// inside <cf_route> (a custom tag)
<cfset svc = application.lib.db.getService("moo_route") />   // throws
```

## Observed behavior

| Context | result |
| --- | --- |
| Regular page: `application.svc.ping()` | ✅ works |
| Inside `cfmodule`/`cf_` custom tag: `application.svc.ping()` | ❌ "ping is not defined" |
| Inside custom tag, nested `application.lib.db.getService(...)` | ❌ |
| Inside custom tag, locally created `createObject(...).ping()` | ✅ works |
| CLI mode (all of the above) | ✅ works |

Clues toward the cause:
- **Serve-mode only** — the object is set in one lifecycle frame (`onApplicationStart`) and the failing call is in another (the custom-tag frame); the single-frame CLI path works.
- Passing the component into the tag as an **attribute** (`<cf_probe svc="#application.svc#">`) makes the in-tag call work — evaluating it at the call site binds it. Points at the method-reference binding being lost when the component is loaded *inside* the custom-tag frame (cf. v0.52.1 "bind CFC method references at the load site" / "identity-guard method_this_writeback for chained CFC calls").

## Test

- Fixture app `tests/lifecycle/application_scope_custom_tag/` — `onApplicationStart` puts a CFC in the application scope; `index.cfm` prints `page=<result>;tag=<result>;`, calling the method directly (control) and from inside a `cfmodule` custom tag.
- `tests/lifecycle/test_application_scope_custom_tag.cfm` drives it over HTTP and skips under the CLI runner (same pattern as `test_application_mapping_coverage.cfm`).

The control passes today; the custom-tag case is expected to fail until the binding is preserved in custom-tag frames.

**Verified against Lucee 7.0.2.106:** fixture returns `page=pong;tag=pong;` (both succeed). On current upstream serve mode: `page=pong;tag=FAILED…`.