### PR TITLE
Add cross-engine test for single-arg createObject() shorthand

### DIFF
--- a/tests/oop/test_components.cfm
+++ b/tests/oop/test_components.cfm
@@ -38,5 +38,12 @@ assertTrue("isStruct on component", isStruct(g));
 assertTrue("greet method exists", structKeyExists(g, "greet"));
 assertTrue("getGreeting method exists", structKeyExists(g, "getGreeting"));
 
+// Single-argument createObject() shorthand.
+// createObject("path") is shorthand for createObject("component","path") and must
+// return an instantiated component, identical to the two-arg form used above.
+gShort = createObject("oop.Greeter");
+assertTrue("single-arg createObject returns an object", isObject(gShort));
+assert("single-arg createObject instance is usable", gShort.init().greet("World"), "Hello, World!");
+
 suiteEnd();
 </cfscript>


### PR DESCRIPTION
Adds two assertions to the `Components` suite for the **single-argument** `createObject("path")` shorthand, reusing the existing `oop.Greeter` CFC.

`createObject("oop.Greeter")` is shorthand for `createObject("component", "oop.Greeter")` and should return an instantiated component. On v0.52.3 the single-arg form returns **null** (silently — `isObject()` is false, and a bogus path returns null with no error), whereas the two-arg form already tested in this suite works:

| Call | v0.52.3 | Lucee |
|------|---------|-------|
| `createObject("component","oop.Greeter")` | object ✅ | object ✅ |
| `createObject("oop.Greeter")` | `null` (isObject=false) | object ✅ |
| `createObject("DoesNotExist")` (single-arg) | `null`, no error | throws "can't find component" |

The two-arg control in this same suite stays green, so the test isolates the gap to the single-arg code path. The single-arg result silently propagating as `null` is easy to miss (no error at the call site), which is what makes it worth a test. Verified failing on the v0.52.3 release binary and passing on Lucee.