### PR TITLE
Add cross-engine test for clean undeclared-named-arg scope

### DIFF
--- a/tests/oop/test_component_method_named_args.cfm
+++ b/tests/oop/test_component_method_named_args.cfm
@@ -17,5 +17,14 @@ assertThrows("mixing positional + named UDF args is rejected", function() {
     adder("A", c="C", b="B");
 });
 
+// Undeclared named arguments must populate the arguments scope BY NAME ONLY.
+// A function with no declared parameters, called with named args, should have an
+// arguments scope containing exactly those named keys — no spurious positional
+// (numeric) entries. So StructCount(arguments) == the number of named args passed.
+function argScopeCount() { return StructCount(arguments); }
+assert("undeclared named args yield exactly n keys", argScopeCount(alpha="1", beta="2"), 2);
+function argScopeKeys() { return listSort(structKeyList(arguments), "textnocase"); }
+assert("undeclared named args are keyed by name only", argScopeKeys(alpha="1", beta="2"), "alpha,beta");
+
 suiteEnd();
 </cfscript>


### PR DESCRIPTION
Per our Slack chat — documenting the residual of the named-args fix as a cross-engine test.

The #57 fix correctly **preserves the names** of undeclared named args (they're reachable by name now — great, it's what unblocked the Wheels boot). The residual: the `arguments` scope also picks up spurious positional/numeric keys alongside the named ones. For `n` named args you get `2n` extra numeric entries:

```
function f(){ return StructCount(arguments) & " : " & listSort(structKeyList(arguments),"textnocase"); }
f(alpha="1", beta="2")
  RustCFML 0.53.1 → 6 : 1,2,3,4,alpha,beta
  Lucee           → 2 : alpha,beta
```

Reads-by-name work fine, so nothing is unreachable — but `StructCount(arguments)` is inflated and `for...in arguments` / copy-args-to-struct patterns pick up the phantom numeric keys, and it compounds through `argumentCollection` forwarding. This test asserts the clean name-only scope (added to the existing named-args OOP suite). Verified failing on the v0.53.1 release binary and passing on Lucee.