### PR TITLE
Add cross-engine test for getMetadata() fullname key

### DIFF
--- a/tests/oop/test_metadata.cfm
+++ b/tests/oop/test_metadata.cfm
@@ -14,6 +14,11 @@ assertNotNull("getMetadata returns value", md);
 assertTrue("metadata is struct", isStruct(md));
 assertTrue("metadata has name", structKeyExists(md, "name"));
 
+// getMetadata() must also expose `fullname` — the fully-qualified component path
+// (distinct from the unqualified `name`). Lucee and Adobe both return it.
+assertTrue("metadata has fullname", structKeyExists(md, "fullname"));
+assertTrue("fullname includes the component name", findNoCase("Greeter", md.fullname ?: "") > 0);
+
 // getMetadata on Dog (has extends)
 d = createObject("component", "oop.Dog").init();
 dmd = getMetadata(d);


### PR DESCRIPTION
`getMetaData(component)` should expose a **`fullname`** key — the fully-qualified component path — alongside the unqualified `name`. Lucee and Adobe both return it; on v0.53.1 RustCFML returns `name` (and `fullExtends`) but no `fullname`:

```
md = getMetaData(createObject("component","oop.Greeter"));
structKeyExists(md, "name")     // both: true
structKeyExists(md, "fullname") // Lucee: true ("...oop.Greeter")  | RustCFML 0.53.1: false
md.fullname                     // Lucee: the dotted path           | RustCFML 0.53.1: null
```

Real-world context (in case it helps prioritise): this is the current blocker for booting the Wheels framework's router. `Mapper.cfc` does `local.componentName = getMetaData(componentInstance).FULLNAME` and then uses it (`findNoCase("wheels.mapper", componentName)`) to decide which methods to mix in. With `fullname` absent the value is null, the mix-in guard fails, and the route DSL methods (`get`/`post`/`resources`/`root`) never get integrated — so the Mapper ends up with no `get` and routing can't initialise. (Reflection itself works well — `getMetaData().functions`, `.name`, method extraction and copy-invoke all behave correctly; it's specifically the missing `fullname` key.)

Added to the existing metadata OOP suite. Verified failing on the v0.53.1 release binary and passing on Lucee.