### PR TITLE
Add cross-engine test for script cfquery statement body

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -240,6 +240,7 @@ try { include "native/test_cfc_extends_rust.cfm"; } catch (any e) { writeOutput(
 try { include "core/test_local_at_template_scope.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_at_template_scope.cfm | " & e.message & chr(10)); }
 try { include "oop/test_metadata_name_value.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_metadata_name_value.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_script_syntax_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_script_syntax_body.cfm | " & e.message & chr(10)); }
+try { include "tags/test_script_cfquery_statement_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_script_cfquery_statement_body.cfm | " & e.message & chr(10)); }
 try { include "functions/test_expandpath_trailing_slash.cfm"; } catch (any e) { writeOutput("ERROR | functions/test_expandpath_trailing_slash.cfm | " & e.message & chr(10)); }
 try { include "core/test_forin_member_loop_var.cfm"; } catch (any e) { writeOutput("ERROR | core/test_forin_member_loop_var.cfm | " & e.message & chr(10)); }
 try { include "core/test_forin_keyword_member_access.cfm"; } catch (any e) { writeOutput("ERROR | core/test_forin_keyword_member_access.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_script_cfquery_statement_body.cfm
+++ b/tests/tags/test_script_cfquery_statement_body.cfm
@@ -1,0 +1,36 @@
+<cfscript>
+suiteBegin("Tags: Script cfquery statement body");
+
+// The script-form cfquery(...) { ... } body may contain CFML statements
+// (assignments, loops, conditionals) interleaved with SQL and cfqueryparam.
+// This is the standard idiom for building dynamic queries on Lucee, Adobe CF
+// 2018+, and BoxLang — e.g. Wheels' database adapter builds every query this
+// way (databaseAdapters/Base.cfc).
+//
+// The body is kept inside a never-called function so the test needs no
+// datasource: we are only verifying that the statement body PARSES. Reaching
+// the assertion below means the file compiled. (The sibling
+// test_tags_script_syntax_body.cfm covers cfsavecontent/cflock/transaction;
+// this covers the cfquery case. The same parse behaviour applies to a script
+// cfhttp(...) { ... } body.)
+
+function buildDynamicQuery() {
+    cfquery(name = "q") {
+        local.sql = "";
+        for (local.i = 1; local.i <= 3; local.i++) {
+            if (local.i > 1) {
+                local.sql &= " UNION ";
+            }
+            local.sql &= "SELECT " & local.i;
+        }
+        writeOutput(local.sql);
+    }
+}
+
+assertTrue(
+    "script cfquery(...) with a statement body parses",
+    isCustomFunction(buildDynamicQuery)
+);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
The script-form `cfquery(...) { ... }` body can contain CFML statements (assignments, loops, conditionals) interleaved with SQL and `cfqueryparam` — the standard idiom for building dynamic queries on Lucee, Adobe CF 2018+, and BoxLang. On v0.54.0 RustCFML parses the body as a struct literal and rejects the first statement:

```
function f() { cfquery(name="q") { local.sql = ""; ... } }
  RustCFML 0.54.0 → Parse error: Expected RBrace, found Semicolon
  Lucee/Adobe/BoxLang → parses fine
```

Verified parse-only on both engines (body kept in a never-called function, so no datasource is needed): RustCFML errors at the first `;`-terminated statement; Lucee parses it. An empty `cfquery(...){}` body parses on RustCFML, so the brace block itself is accepted — it's specifically statement content inside it that's rejected (the body is treated as a struct literal rather than a statement block).

Real-world context: Wheels' database adapter builds *every* query with this form (`databaseAdapters/Base.cfc`), so it blocks DB-backed apps. This is distinct from #55 (which is about runtime `cfhttpparam` collection); here it's the parse of the statement body. The sibling `test_tags_script_syntax_body.cfm` already covers the tags that do parse (`cfsavecontent`/`cflock`/`transaction`); this adds the `cfquery` case. The same struct-literal-vs-statement-block ambiguity also affects script `cfhttp(...) { ... }` bodies.