### PR TITLE
Add cross-engine test for tags inside a block comment

### DIFF
--- a/tests/comments/BlockCommentTags.cfc
+++ b/tests/comments/BlockCommentTags.cfc
@@ -1,0 +1,15 @@
+component {
+
+    /*
+     * Documentation example of the tag form — this is a comment, NOT markup.
+     * The literal tags below must be ignored by the lexer; the component must
+     * compile to a normal CFC. (Closed tags only.)
+     *
+     *   <cfset example = 1>
+     *   <cfoutput>#example#</cfoutput>
+     */
+    public string function ping() {
+        return "pong";
+    }
+
+}

--- a/tests/comments/test_tags_in_block_comment.cfm
+++ b/tests/comments/test_tags_in_block_comment.cfm
@@ -1,0 +1,16 @@
+<cfscript>
+suiteBegin("Comments: tags inside a block comment (component body)");
+
+// A /* */ block comment in a script-component body must be opaque: literal CFML
+// tags inside it (<cfset>, <cfoutput>) are documentation, not markup — they must
+// not be lexed or executed, and the component must still compile to a normal CFC.
+// Lucee, Adobe CF, and BoxLang all treat the comment interior as inert. (Closed
+// tags only — an UNCLOSED tag inside a comment is a separate cross-engine hazard.)
+//
+// Wheels' Test.cfc documents <cfset>/<cfoutput> usage inside such a comment, so
+// this affects real framework code.
+o = createObject("component", "comments.BlockCommentTags");
+assert("component with closed tags in a /* */ comment compiles and runs", o.ping(), "pong");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -55,6 +55,7 @@ try { include "types/test_query_column.cfm"; } catch (any e) { writeOutput("ERRO
 try { include "types/test_binary.cfm"; } catch (any e) { writeOutput("ERROR | types/test_binary.cfm | " & e.message & chr(10)); }
 try { include "types/test_hash_in_strings.cfm"; } catch (any e) { writeOutput("ERROR | types/test_hash_in_strings.cfm | " & e.message & chr(10)); }
 try { include "comments/test_hash_in_comments.cfm"; } catch (any e) { writeOutput("ERROR | comments/test_hash_in_comments.cfm | " & e.message & chr(10)); }
+try { include "comments/test_tags_in_block_comment.cfm"; } catch (any e) { writeOutput("ERROR | comments/test_tags_in_block_comment.cfm | " & e.message & chr(10)); }
 
 // --- Standard Library ---
 try { include "stdlib/test_string_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_string_functions.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
A `/* ... */` block comment in a **script-component body** must be opaque: literal CFML tags inside it (`<cfset>`, `<cfoutput>`) are documentation, not markup. Lucee, Adobe CF, and BoxLang ignore the comment interior and compile the component normally. On v0.55.0 RustCFML lexes and **executes** the tags inside the comment (the component file flips to template-echo mode), so the CFC doesn't load as a normal component:

```
component {
  /* <cfset x = 1>  <cfoutput>#x#</cfoutput> */
  function ping() { return "pong"; }
}

createObject("component","BlockCommentTags").ping()
  Lucee / Adobe / BoxLang → "pong"
  RustCFML 0.55.0         → component is mangled (tags in the comment get run); ping() does not return "pong"
```

Verified: reproduces identically on 0.50.0 → 0.55.0 (long-standing, not a recent regression); in plain `<cfscript>` the comment is correctly suppressed — it's specifically the **component-body** parse path. Closed tags only here on purpose (an *unclosed* tag in a comment is a separate hazard). Real-world: Wheels' `Test.cfc` documents `<cfset>`/`<cfoutput>` usage inside a `/* */` doc comment, which makes the whole file echo+execute on RustCFML. Added to the existing comments suite alongside `test_hash_in_comments.cfm`.