### PR TITLE
Add cross-engine test for component return-type CFC resolution

### DIFF
--- a/tests/oop/ComponentReturnType.cfc
+++ b/tests/oop/ComponentReturnType.cfc
@@ -1,0 +1,13 @@
+component {
+
+    // A function may declare a `component` return type. This must not affect
+    // whether the CFC itself can be resolved / instantiated.
+    public component function init() {
+        return this;
+    }
+
+    public string function ping() {
+        return "pong";
+    }
+
+}

--- a/tests/oop/test_component_return_type.cfm
+++ b/tests/oop/test_component_return_type.cfm
@@ -1,0 +1,14 @@
+<cfscript>
+suiteBegin("OOP: component return type");
+
+// A function may declare a `component` return type (e.g. `public component
+// function init()`). The return-type annotation describes the value the
+// function returns; it must not affect whether the CFC itself can be resolved
+// or instantiated. Lucee, Adobe CF, and BoxLang all instantiate such a CFC
+// normally. (Wheels' Seeder.cfc declares `public component function init()`.)
+o = createObject("component", "oop.ComponentReturnType");
+assertTrue("CFC with a `component` return-type function is an object", isObject(o));
+assert("its methods are callable", o.ping(), "pong");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -111,6 +111,7 @@ try { include "members/test_number_members.cfm"; } catch (any e) { writeOutput("
 
 // --- OOP ---
 try { include "oop/test_components.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_components.cfm | " & e.message & chr(10)); }
+try { include "oop/test_component_return_type.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_return_type.cfm | " & e.message & chr(10)); }
 try { include "oop/test_inheritance.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inheritance.cfm | " & e.message & chr(10)); }
 try { include "oop/test_inherited_helpers.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inherited_helpers.cfm | " & e.message & chr(10)); }
 try { include "oop/test_interfaces.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_interfaces.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
A function may declare a **`component` return type** (e.g. `public component function init()`). The annotation just describes what the function returns — it must not affect whether the CFC itself can be resolved/instantiated. On v0.65.0 RustCFML fails to resolve any CFC that contains such a function:

```
component { public component function init() { return this; }  public string function ping(){ return "pong"; } }

createObject("component","ComponentReturnType")
  Lucee / Adobe / BoxLang → object (ping() → "pong")
  RustCFML 0.65.0         → Runtime Error: Could not find the component [ComponentReturnType]
```

Verified with a control: the identical CFC with `public any function init()` resolves fine on RustCFML, so it's specifically the `component` return-type token that breaks resolution (not a path/lookup issue). Lucee resolves both.

Real-world context: this is one of the last workarounds for booting the Wheels framework — `vendor/wheels/Seeder.cfc` declares `public component function init()`, and the whole CFC becomes unresolvable on RustCFML until the return type is changed. (Thanks again for the #70 fix — Wheels now boots through dispatch and serves real HTTP responses; this is one of the few remaining engine differences.) Added as a small dedicated suite under tests/oop/.