### PR TITLE
Add CFML test for cflog/cfmail tag-attribute interpolation

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -168,6 +168,7 @@ try { include "tags/test_tags_cfhttp_interpolation.cfm"; } catch (any e) { write
 try { include "tags/test_tags_cfhttpparam_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttpparam_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_string_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_string_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_attribute_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_attribute_interpolation.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cflog_cfmail_attribute_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cflog_cfmail_attribute_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfzip.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfzip.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_tld.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_tld.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_whitespace.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_whitespace.cfm | " & e.message & chr(10)); }

--- a/tests/tags/CflogTagAttrInterpControlFixture.cfc
+++ b/tests/tags/CflogTagAttrInterpControlFixture.cfc
@@ -1,0 +1,15 @@
+<!---
+    Control fixture: a <cflog> tag whose quoted `text` attribute is a SINGLE
+    bare interpolation (#expr#) with no surrounding literal text. RustCFML
+    already parses this shape, so it is the regression guard that proves the
+    fixture wiring (createObject + emit) is sound. A failure on the sibling
+    CflogTagAttrInterpFixture therefore isolates to the literal-text-mixed-with-
+    interpolation case, not to cflog tag handling in general.
+--->
+<cfcomponent output="false">
+    <cffunction name="emit" returntype="string" output="false">
+        <cfset var who = "world" />
+        <cflog file="rustcfml_attr_interp_probe" text="#who#" type="information" />
+        <cfreturn "ok" />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CflogTagAttrInterpFixture.cfc
+++ b/tests/tags/CflogTagAttrInterpFixture.cfc
@@ -1,0 +1,25 @@
+<!---
+    Gap fixture: a <cflog> tag whose quoted `text` attribute combines literal
+    text with one or more #expr# interpolations (leading literal, an interior
+    segment, a function-call segment, and a trailing literal). This is the exact
+    shape Moopa's code/moopa/internal/routing/access_policy.cfc uses:
+
+        <cflog type="information" file="security_check"
+               text="Security check for route #...# and endpoint #...# took #getTickCount() - start_time#ms">
+
+    On Lucee 5/6/7, Adobe CF, and BoxLang the engine evaluates each #...# segment
+    and preserves the literal text before, between, and after them. On RustCFML
+    the cflog tag preprocessor still routes the attribute through strip_hashes(),
+    which only handles a value that is ENTIRELY one #expr#; a mixed value emits
+    malformed script and the component fails to PARSE. The parse failure surfaces
+    at createObject() time as "Could not find the component", which is why this
+    construct lives in a runtime-instantiated fixture rather than inline (an
+    inline parse error escapes try/catch and would abort the whole runner).
+--->
+<cfcomponent output="false">
+    <cffunction name="emit" returntype="string" output="false">
+        <cfset var who = "world" />
+        <cflog file="rustcfml_attr_interp_probe" text="hello #who# at #ucase(who)# end" type="information" />
+        <cfreturn "ok" />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CfmailTagAttrInterpControlFixture.cfc
+++ b/tests/tags/CfmailTagAttrInterpControlFixture.cfc
@@ -1,0 +1,18 @@
+<!---
+    Control fixture: a <cfmail> tag whose quoted attributes are SINGLE bare
+    interpolations (#expr#) with no surrounding literal text. RustCFML already
+    parses this shape. The <cfmail> is guarded by <cfif false> so it is compiled
+    but never executed -- cfmail with no SMTP server throws at RUNTIME on every
+    engine, and this test is about PARSE-time behavior, not delivery. This
+    fixture proves the cfmail-in-fixture wiring is sound so a failure on the
+    sibling CfmailTagAttrInterpFixture isolates to the mixed literal+#expr# case.
+--->
+<cfcomponent output="false">
+    <cffunction name="emit" returntype="string" output="false">
+        <cfset var who = "world" />
+        <cfif false>
+            <cfmail to="#who#" from="#who#" subject="#who#">body</cfmail>
+        </cfif>
+        <cfreturn "ok" />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CfmailTagAttrInterpFixture.cfc
+++ b/tests/tags/CfmailTagAttrInterpFixture.cfc
@@ -1,0 +1,22 @@
+<!---
+    Gap fixture: a <cfmail> tag whose quoted attributes combine literal text with
+    #expr# interpolations (the subject mixes a leading literal, an interior
+    segment, a function-call segment, and a trailing literal). Same root cause as
+    the cflog gap: the cfmail tag preprocessor routes attributes through
+    strip_hashes() instead of format_attr_value(), so a mixed value emits
+    malformed script and the component fails to PARSE.
+
+    The <cfmail> is guarded by <cfif false> so it is compiled but never executed
+    (cfmail with no SMTP server throws at runtime on every engine; this test
+    isolates PARSE-time behavior). The parse failure surfaces at createObject()
+    time as "Could not find the component", hence the fixture rather than inline.
+--->
+<cfcomponent output="false">
+    <cffunction name="emit" returntype="string" output="false">
+        <cfset var who = "world" />
+        <cfif false>
+            <cfmail to="a@b.c" from="c@d.e" subject="hello #who# at #ucase(who)# end">body</cfmail>
+        </cfif>
+        <cfreturn "ok" />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/test_cflog_cfmail_attribute_interpolation.cfm
+++ b/tests/tags/test_cflog_cfmail_attribute_interpolation.cfm
@@ -1,0 +1,77 @@
+<cfscript>
+suiteBegin("Tags: cflog / cfmail tag-attribute interpolation");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    A quoted tag-attribute value must evaluate #...# interpolation while
+    preserving the literal text before, between, and after each interpolated
+    segment, on Lucee 5/6/7, Adobe ColdFusion, and BoxLang. The sibling suite
+    test_tag_attribute_interpolation.cfm pins this for cfthrow / cfargument /
+    cffile / cfparam, and its header asserts the rule holds "regardless of which
+    tag the attribute belongs to."
+
+    Two tags slipped through that cross-tag claim: the <cflog> and <cfmail> TAG
+    forms. Their attribute values are still routed through strip_hashes(), which
+    only handles a value that is ENTIRELY a single #expr#. A value that mixes
+    literal text with interpolation (e.g. text="hello #who# end") emits malformed
+    script, so the containing template fails to PARSE.
+
+    This is NOT the same failure mode as the cfthrow cases: cfthrow's old path
+    still compiled (it just emitted the wrong, un-interpolated string), so those
+    gaps could be pinned inline with <cftry> and a value assertion. A
+    cflog/cfmail mixed-interpolation value is a hard PARSE error, and a parse
+    error escapes try/catch and would abort the whole runner. So -- as with
+    test_component_declaration_attributes.cfm and test_mapping_include.cfm -- the
+    offending tags live in runtime-instantiated FIXTURE CFCs. An unparseable
+    fixture makes createObject() throw "Could not find the component"; loadEmit()
+    catches that and returns the message, so the gap shows as a clean failed
+    assertion instead of taking down the run.
+
+    Why it matters for Moopa: code/moopa/internal/routing/access_policy.cfc logs
+      <cflog type="information" file="security_check"
+             text="Security check for route #...# and endpoint #...# took #getTickCount() - start_time#ms">
+    On RustCFML that file fails to parse, so /moopa/internal/routing/access_policy
+    is "not found", moo_route cannot construct, and every secured route 500s.
+
+    Scope: these assertions verify PARSE + execution (the failure mode is a
+    compile error). They intentionally do not read back the logged text or sent
+    message -- log/mail destinations differ across engines, and the existing
+    merged cflog test (test_tags_cfscript_statements.cfm) sets the same bar.
+    ============================================================
+--->
+
+<cfscript>
+// Instantiate a fixture and run emit(); returns the sentinel "ok" when the
+// fixture parsed and ran, or a diagnostic string when it did not (so a parse
+// failure becomes a clean assertion mismatch rather than an aborted suite).
+function loadEmit(required string name) {
+    try {
+        var o = createObject("component", arguments.name);
+        if (!isObject(o)) {
+            return "NOT-A-COMPONENT";
+        }
+        return o.emit();
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// --- controls: shapes RustCFML already parses (regression guards) ------------
+
+assert("control: cflog single bare interpolation attribute parses and runs",
+    loadEmit("CflogTagAttrInterpControlFixture"), "ok");
+assert("control: cfmail single bare interpolation attributes parse",
+    loadEmit("CfmailTagAttrInterpControlFixture"), "ok");
+
+// --- gaps: literal text mixed with interpolation in a tag attribute ----------
+
+assert("cflog text: literal + interpolation + function-call segment parses",
+    loadEmit("CflogTagAttrInterpFixture"), "ok");
+assert("cfmail subject: literal + interpolation + function-call segment parses",
+    loadEmit("CfmailTagAttrInterpFixture"), "ok");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a cross-engine CFML test pinning that the `<cflog>` and `<cfmail>` **tag** forms interpolate `#...#` segments in a quoted attribute that also contains literal text (e.g. `text="hello #who# end"`).

## Why

The merged tag-attribute interpolation work (#62) applied uniform `#...#` interpolation to `cfthrow`/`cfargument`/`cffile`/`cfparam`, and its test asserts the rule holds "regardless of which tag." But the `<cflog>` and `<cfmail>` tag arms still route attribute values through `strip_hashes`, which only handles a value that is *entirely* one `#expr#`. A mixed literal+interpolation value emits malformed script and fails to **parse**.

The previously merged cflog test (#44) only exercised the CFScript `log`/`cflog()` statement forms, which use a different parse path — so the tag-form gap was never covered.

## Shape

Because this is a hard parse error (not just wrong output as with `cfthrow`), and parse errors escape `try/catch` and would abort the runner, the cases live in runtime-instantiated fixture CFCs — the same pattern as `test_component_declaration_attributes.cfm` / `test_mapping_include.cfm`. Controls (single bare `#expr#`) parse today and guard the fixture wiring; the gap fixtures are **expected to fail on current upstream** until `cflog`/`cfmail` attributes route through `format_attr_value`.

Test-only; no engine change. Motivated by Moopa's `access_policy.cfc` `<cflog ... text="...#...#...ms">`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)