### PR TITLE
Add CFML test for cffinally tag body

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -168,6 +168,7 @@ try { include "tags/test_tags_cfhttp_interpolation.cfm"; } catch (any e) { write
 try { include "tags/test_tags_cfhttpparam_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttpparam_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_string_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_string_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_attribute_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_attribute_interpolation.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cffinally_tag_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cffinally_tag_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfzip.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfzip.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_tld.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_tld.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_whitespace.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_whitespace.cfm | " & e.message & chr(10)); }

--- a/tests/tags/CffinallyAfterThrowFixture.cfc
+++ b/tests/tags/CffinallyAfterThrowFixture.cfc
@@ -1,0 +1,23 @@
+<!---
+    Gap fixture: a tag-form <cftry>/<cfcatch>/<cffinally> on the exception path.
+    The try body throws, the catch handles it, and the finally must still run
+    (Lucee/ACF parity): run() returns "try,catch,finally". Same parse-time root
+    cause and fixture rationale as CffinallyHappyPathFixture; this case
+    additionally pins that <cffinally> runs after a caught exception.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset var steps = [] />
+        <cftry>
+            <cfset arrayAppend(steps, "try") />
+            <cfthrow message="boom" />
+            <cfcatch type="any">
+                <cfset arrayAppend(steps, "catch") />
+            </cfcatch>
+            <cffinally>
+                <cfset arrayAppend(steps, "finally") />
+            </cffinally>
+        </cftry>
+        <cfreturn arrayToList(steps) />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CffinallyControlFixture.cfc
+++ b/tests/tags/CffinallyControlFixture.cfc
@@ -1,0 +1,20 @@
+<!---
+    Control fixture: a tag-form <cftry>/<cfcatch> with NO <cffinally>, written
+    with normal multi-line formatting (whitespace/newlines between the tags).
+    RustCFML already parses this, so it is the regression guard proving the
+    fixture wiring (createObject + run) and the try/catch transpilation are
+    sound. A failure on the sibling cffinally fixtures therefore isolates to the
+    <cffinally> block specifically, not to <cftry> handling in general.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset var steps = [] />
+        <cftry>
+            <cfset arrayAppend(steps, "try") />
+            <cfcatch type="any">
+                <cfset arrayAppend(steps, "catch") />
+            </cfcatch>
+        </cftry>
+        <cfreturn arrayToList(steps) />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CffinallyHappyPathFixture.cfc
+++ b/tests/tags/CffinallyHappyPathFixture.cfc
@@ -1,0 +1,27 @@
+<!---
+    Gap fixture: a tag-form <cftry>/<cfcatch>/<cffinally> on the no-exception
+    path, written with normal multi-line formatting. The <cffinally> body must
+    parse AND run (Lucee/ACF parity): run() returns "try,finally".
+
+    On RustCFML the whitespace between </cfcatch> and <cffinally> was emitted as
+    __writeText(...) in the structural gap of the generated try statement
+    ("} __writeText(); finally {"), so any normally-formatted try/catch/finally
+    failed to PARSE. The parse failure surfaces at createObject() time as
+    "Could not find the component", which is why this lives in a fixture (an
+    inline parse error escapes try/catch and would abort the runner).
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset var steps = [] />
+        <cftry>
+            <cfset arrayAppend(steps, "try") />
+            <cfcatch type="any">
+                <cfset arrayAppend(steps, "catch") />
+            </cfcatch>
+            <cffinally>
+                <cfset arrayAppend(steps, "finally") />
+            </cffinally>
+        </cftry>
+        <cfreturn arrayToList(steps) />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/test_cffinally_tag_body.cfm
+++ b/tests/tags/test_cffinally_tag_body.cfm
@@ -1,0 +1,65 @@
+<cfscript>
+suiteBegin("Tags: cffinally tag body");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    The tag form <cftry> ... <cfcatch> ... <cffinally> ... </cftry> transpiles
+    to a CFScript try/catch/finally. On Lucee 5/6/7, Adobe ColdFusion, and
+    BoxLang the finally block parses and always runs (after normal completion
+    and after a caught exception).
+
+    On RustCFML the whitespace (newlines/indentation) between </cfcatch> and
+    <cffinally> -- and between a <cftry> body and <cffinally> -- was emitted as
+    __writeText(...) into the structural gap of the generated try statement,
+    producing "} __writeText(); finally {" which fails to parse. Only a
+    single-line form with no inter-tag whitespace happened to work; every
+    normally-formatted try/catch/finally did not compile.
+
+    Because that is a hard PARSE error (and a parse error escapes try/catch and
+    would abort the whole runner), the cases live in runtime-instantiated
+    fixture CFCs -- the same pattern as test_tag_attribute_interpolation.cfm /
+    test_component_declaration_attributes.cfm. An unparseable fixture makes
+    createObject() throw "Could not find the component"; loadRun() catches that
+    and returns the message, so the gap shows as a clean failed assertion rather
+    than taking down the run. The fixtures are deliberately multi-line: a
+    single-line fixture would parse even on the unfixed engine and hide the gap.
+
+    Why it matters for Moopa: code/moopa/lib/cloudflare_stream.cfc (uploadCaptionVtt)
+    uses a <cffinally> block to delete its temp upload file; the parse failure
+    made /moopa/lib/cloudflare_stream "not found".
+    ============================================================
+--->
+
+<cfscript>
+// Instantiate a fixture and run run(); returns the step trace when the fixture
+// parsed and ran, or a diagnostic string when it did not (so a parse failure
+// becomes a clean assertion mismatch rather than an aborted suite).
+function loadRun(required string name) {
+    try {
+        var o = createObject("component", arguments.name);
+        if (!isObject(o)) {
+            return "NOT-A-COMPONENT";
+        }
+        return o.run();
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// --- control: try/catch with no finally already parses (regression guard) ----
+
+assert("control: multi-line try/catch (no finally) parses and runs",
+    loadRun("CffinallyControlFixture"), "try");
+
+// --- gaps: try/catch/finally with normal multi-line formatting ---------------
+
+assert("try/catch/finally (no exception) parses and runs finally",
+    loadRun("CffinallyHappyPathFixture"), "try,finally");
+assert("try/catch/finally (caught exception) runs catch then finally",
+    loadRun("CffinallyAfterThrowFixture"), "try,catch,finally");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a cross-engine CFML test for the tag form `<cftry>` / `<cfcatch>` / `<cffinally>` with normal multi-line formatting, pinning that the `finally` block parses and always runs (no-exception path and caught-exception path).

## Why

A normally-formatted try/catch/finally fails to **parse** on RustCFML: the whitespace/newlines between `</cfcatch>` and `<cffinally>` (and between a `<cftry>` body and `<cffinally>`) are emitted as `__writeText(...)` into the structural gap of the generated try statement, producing `} __writeText(); finally {`. Only a single-line form with no inter-tag whitespace happens to work — i.e. essentially all real-world code is affected.

## Shape

Hard parse error → escapes `try/catch`, would abort the runner → the cases live in runtime-instantiated fixture CFCs. The control (try/catch with no finally) parses today and guards the fixture wiring; the `finally` fixtures are **expected to fail on current upstream** until the inter-block whitespace is suppressed. Fixtures are deliberately multi-line (a single-line form would hide the gap).

Test-only; no engine change. Motivated by Moopa's `cloudflare_stream.cfc` `<cffinally>` cleanup block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)