### PR TITLE
Add CFML test for cfhttp timeout attribute interpolation

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -165,6 +165,7 @@ try { include "tags/test_tags_cfthread.cfm"; } catch (any e) { writeOutput("ERRO
 try { include "tags/test_tags_cfthread_concurrency.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfthread_concurrency.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfscript_statements.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfscript_statements.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfhttp_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttp_interpolation.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cfhttp_timeout_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttp_timeout_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfhttpparam_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttpparam_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_string_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_string_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_attribute_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_attribute_interpolation.cfm | " & e.message & chr(10)); }

--- a/tests/tags/CfhttpTimeoutControlFixture.cfc
+++ b/tests/tags/CfhttpTimeoutControlFixture.cfc
@@ -1,0 +1,16 @@
+<!---
+    Control fixture: <cfhttp> with a literal numeric timeout (timeout="5").
+    RustCFML already parses this, so it is the regression guard proving the
+    cfhttp-in-fixture wiring is sound. The request is guarded by <cfif false>
+    so it is compiled but never executed (no network call); this test is about
+    PARSE-time handling of the timeout attribute, not delivery.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfargument name="timeout" default="5" />
+        <cfif false>
+            <cfhttp url="http://127.0.0.1/probe" method="GET" result="local.r" timeout="5"></cfhttp>
+        </cfif>
+        <cfreturn "ok" />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CfhttpTimeoutInterpFixture.cfc
+++ b/tests/tags/CfhttpTimeoutInterpFixture.cfc
@@ -1,0 +1,19 @@
+<!---
+    Gap fixture: <cfhttp> with an interpolated timeout (timeout="#arguments.timeout#").
+    Every other cfhttp string attribute (url, method, charset, ...) interpolates,
+    but `timeout` was emitted verbatim, leaving literal "#...#" in the generated
+    script ("timeout: #arguments.timeout#") so the component failed to PARSE. The
+    failure surfaces at createObject() time as "Could not find the component",
+    hence the runtime-instantiated fixture (an inline parse error escapes
+    try/catch and would abort the runner). The request is guarded by <cfif false>
+    so it is compiled but never executed.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfargument name="timeout" default="5" />
+        <cfif false>
+            <cfhttp url="http://127.0.0.1/probe" method="GET" result="local.r" timeout="#arguments.timeout#"></cfhttp>
+        </cfif>
+        <cfreturn "ok" />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/test_cfhttp_timeout_interpolation.cfm
+++ b/tests/tags/test_cfhttp_timeout_interpolation.cfm
@@ -1,0 +1,56 @@
+<cfscript>
+suiteBegin("Tags: cfhttp timeout interpolation");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    A quoted <cfhttp> attribute value may carry #...# interpolation. The merged
+    cfhttp interpolation work routes url/method/charset/username/password/
+    useragent/proxyserver through the interpolation path, but `timeout` was
+    emitted verbatim into the generated cfhttp({ ... }) call. So
+    timeout="#arguments.timeout#" produced "timeout: #arguments.timeout#" --
+    literal hashes in CFScript -- and the template failed to PARSE. A literal
+    timeout (timeout="60") happened to work because it has no hashes.
+
+    Because that is a hard parse error (escapes try/catch, would abort the
+    runner), the cases live in runtime-instantiated fixture CFCs. The control
+    (literal timeout) parses today and guards the fixture wiring; the
+    interpolated fixture is expected to fail on current upstream until `timeout`
+    is interpolated like every other cfhttp attribute. The cfhttp call is guarded
+    by <cfif false> so it is compiled but never executed (no network).
+
+    Why it matters for Moopa: code/moopa/lib/cloudflare_stream.cfc (isPlaybackReady)
+    issues <cfhttp ... timeout="#arguments.timeout#">.
+    ============================================================
+--->
+
+<cfscript>
+// Instantiate a fixture and run run(); returns "ok" when the fixture parsed and
+// ran, or a diagnostic string when it did not (so a parse failure becomes a
+// clean assertion mismatch rather than an aborted suite).
+function loadRun(required string name) {
+    try {
+        var o = createObject("component", arguments.name);
+        if (!isObject(o)) {
+            return "NOT-A-COMPONENT";
+        }
+        return o.run();
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// --- control: literal timeout already parses (regression guard) --------------
+
+assert("control: cfhttp with literal timeout parses",
+    loadRun("CfhttpTimeoutControlFixture"), "ok");
+
+// --- gap: interpolated timeout -----------------------------------------------
+
+assert("cfhttp with interpolated timeout attribute parses",
+    loadRun("CfhttpTimeoutInterpFixture"), "ok");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a cross-engine CFML test pinning that `<cfhttp timeout="#expr#">` interpolates, like every other cfhttp attribute.

## Why

The merged cfhttp interpolation work routes `url`/`method`/`charset`/`username`/`password`/`useragent`/`proxyserver` through the interpolation path, but `timeout` is emitted verbatim into the generated `cfhttp({ ... })` call. So `timeout="#arguments.timeout#"` produces `timeout: #arguments.timeout#` (literal hashes in CFScript) and fails to **parse**. A literal `timeout="60"` works because it has no hashes.

## Shape

Parse-class gap → runtime-instantiated fixtures. The control (literal timeout) parses today and guards the fixture wiring; the interpolated fixture is **expected to fail on current upstream** until `timeout` is interpolated like the other cfhttp attributes. The cfhttp call is guarded by `<cfif false>` so it is compiled but never executed (no network).

Test-only; no engine change. Motivated by Moopa's `cloudflare_stream.cfc` `isPlaybackReady` (`<cfhttp ... timeout="#arguments.timeout#">`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)