### PR TITLE
Add CFML test for cfquery double-quoted SQL identifier

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -154,6 +154,7 @@ try { include "tags/test_tags_cfcache.cfm"; } catch (any e) { writeOutput("ERROR
 try { include "tags/test_tags_cfstoredproc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfstoredproc.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfqueryparam_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfqueryparam_attribute_collection.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfqueryparam_interpolated_value.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_interpolated_value.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cfquery_quoted_identifier.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfquery_quoted_identifier.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfquery_control_tags.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_mapping_path.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_function_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_function_form.cfm | " & e.message & chr(10)); }

--- a/tests/tags/CfqueryQuotedIdentControlFixture.cfc
+++ b/tests/tags/CfqueryQuotedIdentControlFixture.cfc
@@ -1,0 +1,17 @@
+<!---
+    Control fixture: a <cfquery> whose body uses only single-quoted SQL string
+    literals (no double-quoted identifiers). RustCFML already parses this, so it
+    guards the cfquery-in-fixture wiring. The query is guarded by <cfif false>
+    so it is compiled but never executed (no datasource needed); this test is
+    about PARSE-time handling of the SQL body.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfif false>
+            <cfquery name="local.q" datasource="probe">
+                SELECT a FROM t WHERE status = 'open'
+            </cfquery>
+        </cfif>
+        <cfreturn "ok" />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CfqueryQuotedIdentFixture.cfc
+++ b/tests/tags/CfqueryQuotedIdentFixture.cfc
@@ -1,0 +1,20 @@
+<!---
+    Gap fixture: a <cfquery> whose body contains double-quoted SQL identifiers
+    (AS "where", AS "myCol"). The SQL body is emitted as a double-quoted CFML
+    string with embedded " escaped as \" (backslash); CFML does not treat \" as
+    an escaped quote (a quote is escaped by doubling it, ""), so the embedded
+    quote terminated the string early and the component failed to PARSE. The
+    failure surfaces at createObject() time as "Could not find the component",
+    hence the runtime-instantiated fixture. The query is guarded by <cfif false>
+    so it is compiled but never executed.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfif false>
+            <cfquery name="local.q" datasource="probe">
+                SELECT a AS "where", b AS "myCol" FROM t WHERE status = 'open'
+            </cfquery>
+        </cfif>
+        <cfreturn "ok" />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/test_cfquery_quoted_identifier.cfm
+++ b/tests/tags/test_cfquery_quoted_identifier.cfm
@@ -1,0 +1,59 @@
+<cfscript>
+suiteBegin("Tags: cfquery double-quoted SQL identifier");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    A <cfquery> body is SQL, and SQL allows double-quoted identifiers
+    (e.g. SELECT pg_get_expr(...) AS "where"). Postgres uses them for reserved
+    words and case-sensitive names. On Lucee/ACF the cfquery body is treated as
+    SQL text with only #...# interpolated, so a double-quoted identifier is fine.
+
+    RustCFML emits the cfquery body as a double-quoted CFScript string and
+    escaped an embedded " as \" (backslash). CFScript strings do not treat \" as
+    an escaped quote -- a double quote is escaped by DOUBLING it ("") -- so the
+    embedded quote terminated the string literal early and the leftover text
+    parsed as stray tokens. Any cfquery whose SQL contains a double-quoted
+    identifier failed to PARSE.
+
+    Parse-class gap (escapes try/catch, would abort the runner), so the cases
+    live in runtime-instantiated fixtures. The control (single-quoted SQL string
+    literal only) parses today and guards the fixture wiring; the gap fixture is
+    expected to fail on current upstream until embedded quotes are doubled. The
+    query is guarded by <cfif false> so it is compiled but never executed.
+
+    Why it matters for Moopa: code/apps/hub/lib/schemaSync.cfc (getTableIndexes)
+    selects COALESCE(pg_get_expr(...), '') AS "where".
+    ============================================================
+--->
+
+<cfscript>
+// Instantiate a fixture and run run(); returns "ok" when the fixture parsed and
+// ran, or a diagnostic string when it did not (so a parse failure becomes a
+// clean assertion mismatch rather than an aborted suite).
+function loadRun(required string name) {
+    try {
+        var o = createObject("component", arguments.name);
+        if (!isObject(o)) {
+            return "NOT-A-COMPONENT";
+        }
+        return o.run();
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// --- control: single-quoted SQL string literal already parses ----------------
+
+assert("control: cfquery with single-quoted SQL string parses",
+    loadRun("CfqueryQuotedIdentControlFixture"), "ok");
+
+// --- gap: double-quoted SQL identifier in the cfquery body -------------------
+
+assert("cfquery with double-quoted SQL identifier parses",
+    loadRun("CfqueryQuotedIdentFixture"), "ok");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a cross-engine CFML test pinning that a `<cfquery>` body containing a double-quoted SQL identifier (e.g. `... AS "where"`) parses.

## Why

A `<cfquery>` body is SQL, and SQL allows double-quoted identifiers (Postgres uses them for reserved words / case-sensitive names). On Lucee/ACF the body is treated as SQL text with only `#...#` interpolated, so this is fine.

RustCFML emits the cfquery body as a double-quoted CFScript string and escapes an embedded `"` as `\"` (backslash). CFScript strings do not treat `\"` as an escaped quote — a double quote is escaped by **doubling** it (`""`) — so the embedded quote terminates the string literal early and the leftover SQL parses as stray tokens. Any cfquery whose SQL contains a double-quoted identifier fails to **parse** (`Expected RParen, found <ident>`).

## Shape

Parse-class gap → escapes `try/catch`, would abort the runner → cases live in runtime-instantiated fixture CFCs. The control (single-quoted SQL string literal only) parses today and guards the fixture wiring; the gap fixture is **expected to fail on current upstream** until embedded quotes are doubled. The query is guarded by `<cfif false>` so it is compiled but never executed (no datasource).

Test-only; no engine change. Motivated by Moopa's `schemaSync.cfc` `getTableIndexes` (`COALESCE(pg_get_expr(...), '') AS "where"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)