### PR TITLE
Add CFML test for cfhttp multipart=true encoding

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -165,6 +165,7 @@ try { include "tags/test_tags_cfthread.cfm"; } catch (any e) { writeOutput("ERRO
 try { include "tags/test_tags_cfthread_concurrency.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfthread_concurrency.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfscript_statements.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfscript_statements.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfhttp_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttp_interpolation.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tags_cfhttp_multipart.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttp_multipart.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfhttpparam_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttpparam_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_string_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_string_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_attribute_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_attribute_interpolation.cfm | " & e.message & chr(10)); }

--- a/tests/tags/cfhttp_multipart_target.cfm
+++ b/tests/tags/cfhttp_multipart_target.cfm
@@ -1,0 +1,7 @@
+<cfsetting enablecfoutputonly="true" />
+<!---
+    Target for test_tags_cfhttp_multipart.cfm. Echoes the inbound request's
+    Content-Type and the received form field so the caller can assert how the
+    cfhttp request was encoded (multipart/form-data vs urlencoded).
+--->
+<cfoutput>ct=#cgi.content_type ?: ""#;a=#form.a ?: "(missing)"#</cfoutput>

--- a/tests/tags/test_tags_cfhttp_multipart.cfm
+++ b/tests/tags/test_tags_cfhttp_multipart.cfm
@@ -1,0 +1,72 @@
+<cfscript>
+suiteBegin("Tags: cfhttp multipart");
+
+// ============================================================
+// Background
+// ============================================================
+// <cfhttp multipart="true"> must encode its form data as multipart/form-data
+// (rather than application/x-www-form-urlencoded), and <cfhttpparam type="file">
+// must attach a file part. On Lucee/ACF this is how a multipart upload is sent.
+//
+// On RustCFML the `multipart` attribute is dropped by the tag preprocessor (it
+// is not among the attributes the cfhttp handler passes through), and the cfhttp
+// builtin has no multipart path nor `type="file"` handling -- it only builds an
+// application/x-www-form-urlencoded body from formfield params. So a multipart
+// request is silently sent as urlencoded and any file param is discarded.
+//
+// This is a behavioral (not parse) gap, so -- like the other cfhttp round-trip
+// tests -- it runs only when served (cgi.server_port present) and POSTs to a
+// local target that echoes the inbound Content-Type. When run without a server
+// it skips. The control assertion (a urlencoded POST whose form field arrives)
+// proves the round-trip wiring; the multipart assertion is expected to fail on
+// current upstream until multipart encoding is implemented.
+//
+// Why it matters for Moopa: code/moopa/lib/cloudflare_stream.cfc uploadCaptionVtt
+// uploads WebVTT via <cfhttp ... multipart="true"> with <cfhttpparam type="file">.
+// ============================================================
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+if (skip) {
+    assertTrue("cfhttp multipart skipped (no cgi.server_port)", true);
+} else {
+    baseUrl = "http://127.0.0.1:" & serverPort;
+    target = "/tests/tags/cfhttp_multipart_target.cfm";
+    plainError = "";
+    multipartError = "";
+}
+</cfscript>
+
+<cfif NOT skip>
+    <!--- control: a plain POST — form field round-trips as urlencoded (works today) --->
+    <cftry>
+        <cfhttp url="#baseUrl##target#" method="POST" result="plainResult">
+            <cfhttpparam type="formfield" name="a" value="hello" />
+        </cfhttp>
+        <cfcatch type="any"><cfset plainError = cfcatch.message></cfcatch>
+    </cftry>
+
+    <!--- gap: multipart="true" must send multipart/form-data --->
+    <cftry>
+        <cfhttp url="#baseUrl##target#" method="POST" result="multipartResult" multipart="true">
+            <cfhttpparam type="formfield" name="a" value="hello" />
+        </cfhttp>
+        <cfcatch type="any"><cfset multipartError = cfcatch.message></cfcatch>
+    </cftry>
+
+    <cfscript>
+        assert("control: plain POST form field round-trips",
+            (plainError == "" && structKeyExists(variables, "plainResult"))
+                ? (findNoCase("a=hello", plainResult.filecontent) GT 0) : false,
+            true);
+        assert("cfhttp multipart=true sends multipart/form-data",
+            (multipartError == "" && structKeyExists(variables, "multipartResult"))
+                ? (findNoCase("multipart/form-data", multipartResult.filecontent) GT 0) : false,
+            true);
+    </cfscript>
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a cross-engine round-trip test pinning that `<cfhttp multipart="true">` sends its form data as `multipart/form-data` rather than `application/x-www-form-urlencoded`.

## Why

On RustCFML this is a two-layer gap:
- The tag preprocessor **drops** the `multipart` attribute — it is not among the attributes the cfhttp handler passes into the generated `cfhttp({ ... })` call.
- The `cfhttp` builtin (`fn_cfhttp`) has **no multipart path** and ignores `cfhttpparam type="file"` (`_ => {}`); it only builds an `application/x-www-form-urlencoded` body from `formfield` params.

So `<cfhttp multipart="true">` (with `<cfhttpparam type="file">`) is silently sent urlencoded and the file part is discarded. Verified by round-trip: the target echoes `ct=application/x-www-form-urlencoded` even with `multipart="true"`.

## Shape

Behavioral test, mirroring `test_tags_cfhttp_interpolation.cfm`: skips when there is no `cgi.server_port`; otherwise POSTs to a small local target (`cfhttp_multipart_target.cfm`) that echoes the inbound `Content-Type` and form field. The **control** (a plain POST whose form field round-trips) passes today and guards the wiring; the **multipart** assertion is **expected to fail on current upstream** until multipart/form-data encoding (and `type="file"` parts) are implemented.

Test-only; no engine change (the fix is a sizable cfhttp feature). Motivated by Moopa's `code/moopa/lib/cloudflare_stream.cfc` `uploadCaptionVtt` (`<cfhttp ... multipart="true">` with `<cfhttpparam type="file">`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)