### PR TITLE
Add cross-engine test for local scope frame isolation

### DIFF
--- a/tests/core/test_local_scope_frame_isolation.cfm
+++ b/tests/core/test_local_scope_frame_isolation.cfm
@@ -1,0 +1,51 @@
+<cfscript>
+suiteBegin("Core: local scope frame isolation");
+
+// `local.X` is per-CALL scope — identical to `var X`. Each function invocation
+// gets its OWN `local` scope, so a callee's `local.x = ...` MUST NOT alter a
+// caller's `local.x` of the same name. Lucee, Adobe CF, and BoxLang all isolate
+// `local` per call frame (and treat `local.x` and `var x` identically).
+//
+// The existing single-frame cases in compat_engine/test_scope_behavior.cfm cover
+// `local.x == var x` WITHIN one frame; these cover isolation ACROSS frames.
+
+// (1) The gap: a callee's same-named local.x leaks into the caller's frame.
+function frameIsoCallee() {
+    local.x = 99;
+    return local.x;
+}
+function frameIsoCaller() {
+    local.x = "ORIGINAL";
+    frameIsoCallee();
+    return local.x;
+}
+assert("callee local.x does not clobber caller local.x", frameIsoCaller(), "ORIGINAL");
+
+// (2) Control: the `var x` form (isolated on every engine) — guards the wiring.
+function frameIsoCalleeVar() {
+    var x = 99;
+    return x;
+}
+function frameIsoCallerVar() {
+    var x = "ORIGINAL";
+    frameIsoCalleeVar();
+    return x;
+}
+assert("callee var x does not clobber caller var x", frameIsoCallerVar(), "ORIGINAL");
+
+// (3) Real-world shape: a helper assigned into the caller must not corrupt the
+// caller's same-named local. Mirrors framework code where a builder uses
+// `local.rv` and a callee it invokes (e.g. a getter) also uses `local.rv`.
+function frameIsoHelper() {
+    local.rv = "HELPER";
+    return local.rv;
+}
+function frameIsoBuild() {
+    local.rv = {a: 1};
+    local.other = frameIsoHelper();
+    return isStruct(local.rv) ? "struct-preserved" : ("CLOBBERED:" & local.rv);
+}
+assert("callee local.rv does not clobber caller local.rv struct", frameIsoBuild(), "struct-preserved");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -15,6 +15,7 @@ try { include "config/test_app_datasources.cfm"; } catch (any e) { writeOutput("
 try { include "core/test_variables.cfm"; } catch (any e) { writeOutput("ERROR | core/test_variables.cfm | " & e.message & chr(10)); }
 try { include "core/test_access_identifiers.cfm"; } catch (any e) { writeOutput("ERROR | core/test_access_identifiers.cfm | " & e.message & chr(10)); }
 try { include "core/test_function_scope_capture.cfm"; } catch (any e) { writeOutput("ERROR | core/test_function_scope_capture.cfm | " & e.message & chr(10)); }
+try { include "core/test_local_scope_frame_isolation.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_scope_frame_isolation.cfm | " & e.message & chr(10)); }
 try { include "core/test_closure_env_leak.cfm"; } catch (any e) { writeOutput("ERROR | core/test_closure_env_leak.cfm | " & e.message & chr(10)); }
 try { include "core/test_compound_assignment.cfm"; } catch (any e) { writeOutput("ERROR | core/test_compound_assignment.cfm | " & e.message & chr(10)); }
 try { include "core/test_undeclared_named_args.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undeclared_named_args.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
`local.X` is per-call scope — identical to `var X`. Each function invocation gets its own `local` scope, so a callee's `local.x = ...` must not alter a caller's `local.x` of the same name. On RustCFML the explicit-prefix form leaks across frames:

```
function callee(){ local.x = 99;          return local.x; }
function caller(){ local.x = "ORIGINAL";  callee();        return local.x; }

caller()
  Lucee / Adobe / BoxLang → "ORIGINAL"   (each frame has its own local)
  RustCFML v0.72.0        → 99           (callee's local.x clobbered the caller's)
```

The boundary is precise (verified on v0.72.0 and v0.65.0 — longstanding, not new in the stable-table rewrite):

- **`var x`** form is correctly frame-isolated → returns `"ORIGINAL"`. ✓
- **distinct** local names (`local.y` vs `local.x`) don't collide → `"ORIGINAL"`. ✓
- only **same-named `local.X`** across caller/callee collides. 🐛

Since `var x` and `local.x` are the same scope in CFML, the two should behave identically; today only `var x` is isolated. The existing `compat_engine/test_scope_behavior.cfm` "Local Scope (LDEV-0112)" suite covers `local.x == var x` *within* one frame — this adds the *across-frame* isolation case it doesn't reach. Test (2) is a `var`-form control that passes on every engine and guards the assertion wiring; tests (1) and (3) are expected to fail on current upstream until `local.X` gets per-frame storage.

Real-world context: this is the last engine-side blocker for booting the Wheels framework. Wheels uses the `local.rv` convention in hundreds of functions; a builder's `local.rv` (the request params struct) is silently overwritten when it calls a helper (`$get()`) that also uses `local.rv`, so dispatch never sees the real params. Renaming isn't feasible at that scale and wouldn't durably hold. Caught via 4-point instrumentation of the real dispatch chain — the params struct was struct-valued through `$createParams` until a `local.obf = $get(...)` call flipped the caller's `local.rv`.