### PR TITLE
Add CFML test for component methods named like builtins

### DIFF
--- a/tests/oop/BuiltinNameMethodFixture.cfc
+++ b/tests/oop/BuiltinNameMethodFixture.cfc
@@ -1,0 +1,29 @@
+<!---
+    Fixture: a component that defines methods whose names collide with built-in
+    functions (canonicalize, reverse) alongside an ordinary method. On
+    Lucee/ACF this is legal -- a method named like a builtin is callable via
+    obj.method(); object method dispatch takes precedence over the builtin.
+
+    On RustCFML v0.75.0+ (commit cc6279a, "Lucee-parity reject of builtin
+    redefinition") the DefineFunction op throws / drops any non-"__" function
+    whose name is a builtin, which over-reaches to COMPONENT METHODS -- so these
+    methods do not register and obj.canonicalize()/obj.reverse() fail with
+    "Component has no function with name [...]". The `plain` sibling is here to
+    detect whether a builtin-named method poisons the whole component.
+--->
+<cfcomponent output="false">
+    <cffunction name="canonicalize" access="public" returntype="string" output="false">
+        <cfargument name="u" type="string" required="true" />
+        <cfreturn "canon:" & arguments.u />
+    </cffunction>
+
+    <cffunction name="reverse" access="public" returntype="string" output="false">
+        <cfargument name="u" type="string" required="true" />
+        <cfreturn "rev:" & arguments.u />
+    </cffunction>
+
+    <cffunction name="plain" access="public" returntype="string" output="false">
+        <cfargument name="u" type="string" required="true" />
+        <cfreturn "plain:" & arguments.u />
+    </cffunction>
+</cfcomponent>

--- a/tests/oop/ControlMethodFixture.cfc
+++ b/tests/oop/ControlMethodFixture.cfc
@@ -1,0 +1,11 @@
+<!---
+    Control fixture: a component with only ordinary (non-builtin-named) methods.
+    Proves the fixture/createObject wiring is sound, so a failure on
+    BuiltinNameMethodFixture isolates to the builtin-name collision.
+--->
+<cfcomponent output="false">
+    <cffunction name="ping" access="public" returntype="string" output="false">
+        <cfargument name="u" type="string" required="true" />
+        <cfreturn "ping:" & arguments.u />
+    </cffunction>
+</cfcomponent>

--- a/tests/oop/test_component_method_builtin_name.cfm
+++ b/tests/oop/test_component_method_builtin_name.cfm
@@ -1,0 +1,59 @@
+<cfscript>
+suiteBegin("OOP: component method named like a builtin");
+
+// ============================================================
+// Background
+// ============================================================
+// On Lucee and Adobe ColdFusion a component may define a method whose name
+// collides with a built-in function (e.g. canonicalize, reverse, len, find).
+// Object method dispatch takes precedence, so obj.canonicalize(x) calls the
+// COMPONENT METHOD, not the builtin. This is extremely common in frameworks --
+// Moopa's route_url.cfc defines canonicalize() and the whole routing layer
+// calls variables.routeUrl.canonicalize(url).
+//
+// RustCFML enforces a Lucee-parity rule that a top-level user function cannot
+// redefine a builtin (correct: `function abs(){}` at script top level throws on
+// Lucee). But that rule over-reaches to COMPONENT METHODS: the DefineFunction op
+// rejects/drops any non-"__" function whose name is a builtin, so a CFC method
+// named like a builtin never registers and obj.canonicalize() fails with
+// "Component has no function with name [canonicalize]". Lucee allows it.
+//
+// WHAT TO FIX
+// -----------
+// crates/cfml-vm/src/lib.rs, the DefineFunction op handler. The builtin-collision
+// guard ("The name [X] is already used by a built in Function") must apply ONLY
+// to top-level function declarations, NOT to component methods. A method defined
+// inside a CFC must register and be dispatchable via obj.name() even when its
+// name matches a builtin. (Top-level redefinition should still throw -- see the
+// existing tests/core/test_builtin_shadowing.cfm, which this does not change.)
+// ============================================================
+
+function callMethod(required string fixture, required string method, required string arg) {
+    try {
+        var o = createObject("component", arguments.fixture);
+        if (!isObject(o)) {
+            return "NOT-A-COMPONENT";
+        }
+        return invoke(o, arguments.method, { u = arguments.arg });
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// --- control: ordinary method name already works ---
+assert("control: ordinary method dispatches",
+    callMethod("ControlMethodFixture", "ping", "x"), "ping:x");
+
+// --- gap: methods whose names collide with builtins must still dispatch ---
+assert("component method named 'canonicalize' (a builtin) dispatches",
+    callMethod("BuiltinNameMethodFixture", "canonicalize", "x"), "canon:x");
+
+assert("component method named 'reverse' (a builtin) dispatches",
+    callMethod("BuiltinNameMethodFixture", "reverse", "x"), "rev:x");
+
+// a builtin-named method must not poison sibling methods on the same component
+assert("ordinary sibling method on the same component still dispatches",
+    callMethod("BuiltinNameMethodFixture", "plain", "x"), "plain:x");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -113,6 +113,7 @@ try { include "members/test_number_members.cfm"; } catch (any e) { writeOutput("
 
 // --- OOP ---
 try { include "oop/test_components.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_components.cfm | " & e.message & chr(10)); }
+try { include "oop/test_component_method_builtin_name.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_method_builtin_name.cfm | " & e.message & chr(10)); }
 try { include "oop/test_component_return_type.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_return_type.cfm | " & e.message & chr(10)); }
 try { include "oop/test_inheritance.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inheritance.cfm | " & e.message & chr(10)); }
 try { include "oop/test_inherited_helpers.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inherited_helpers.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## What

Pins that a **component method** whose name collides with a built-in function (`canonicalize`, `reverse`, …) registers and dispatches via `obj.method()` — as on Lucee/ACF, where object method dispatch takes precedence over the builtin.

## Why — regression

`cc6279a` ("Lucee-parity reject of builtin redefinition", v0.75.0) added a correct rule: a **top-level** user function cannot redefine a builtin (`function abs(){}` throws on Lucee). But the guard in the `DefineFunction` op (`crates/cfml-vm/src/lib.rs`) fires for **any** non-`__` function named like a builtin — including **component methods**. So a CFC method named `canonicalize` never registers, and worse, it **poisons the whole component** (sibling ordinary methods stop dispatching too).

This regressed real apps: Moopa's `route_url.cfc` defines `canonicalize()` and the entire routing layer calls `routeUrl.canonicalize(url)` — every routed request 500s with *"Component [route_url] has no function with name [canonicalize]"*. Renaming isn't viable (any of ~hundreds of builtin names could collide).

`tests/core/test_builtin_shadowing.cfm` (added in the same commit) only covers top-level UDF redefinition and local closures — it never exercises component methods, which is the gap.

## Coverage

- `canonicalize` and `reverse` component methods must dispatch (expected-fail today).
- a builtin-named method must **not** poison a sibling ordinary method on the same component (expected-fail today — shows the blast radius).
- control: an ordinary method dispatches (passes today).

## What to fix

`crates/cfml-vm/src/lib.rs`, the `DefineFunction` op handler: scope the *"The name [X] is already used by a built in Function"* guard to **top-level** function declarations only — a function defined as a component method must register and be dispatchable via `obj.name()` even when its name matches a builtin. Top-level redefinition should still throw (existing `test_builtin_shadowing.cfm` stays green).

Test-only; no engine change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)