### PR TITLE
test(stdlib): ListRest should return the literal remainder (Lucee parity)

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -70,6 +70,7 @@ try { include "stdlib/test_struct_higher_order.cfm"; } catch (any e) { writeOutp
 try { include "stdlib/test_math_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_math_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_date_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_date_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_list_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_list_functions.cfm | " & e.message & chr(10)); }
+try { include "stdlib/test_list_rest_literal_remainder.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_list_rest_literal_remainder.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_list_higher_order.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_list_higher_order.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_query_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_query_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_query_higher_order.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_query_higher_order.cfm | " & e.message & chr(10)); }

--- a/tests/stdlib/test_list_rest_literal_remainder.cfm
+++ b/tests/stdlib/test_list_rest_literal_remainder.cfm
@@ -1,0 +1,52 @@
+<cfscript>
+// ListRest must return the LITERAL substring from element 2 onward —
+// preserving interior/trailing empty elements AND the original delimiter
+// characters. RustCFML (0.92.0) instead collapses empty elements and
+// normalizes the delimiter to a single canonical char.
+//
+// Verified against Lucee 7 (the compatibility reference):
+//   listRest(Reverse("/home/index"),"/") -> "emoh/"   (RustCFML: "emoh")
+//   listRest("a/b/","/")                 -> "b/"       (RustCFML: "b")
+//   listRest("a/b;c/","/;")              -> "b;c/"     (RustCFML: "b/c")
+//   listRest("a,,b,,c")                  -> "b,,c"     (RustCFML: "b,c")
+//
+// Sibling list fns (ListFirst/ListLast/ListLen) intentionally KEEP the
+// empty-collapsing semantics — they are asserted here only as controls
+// (same answer on both engines) to guard the test wiring.
+suiteBegin("ListRest literal remainder (Lucee parity)");
+
+// --- The Wheels-relevant case: Reverse() + ListRest on a path ---
+// A trailing original delimiter must survive in the returned remainder.
+assert(
+    "listRest preserves trailing delim after reverse",
+    listRest(Reverse("/home/index"), "/"),
+    "emoh/"
+);
+
+// --- Trailing empty element preserved ---
+assert("listRest keeps trailing empty element", listRest("a/b/", "/"), "b/");
+
+// --- Original delimiter chars preserved (no normalization to first delim) ---
+// Multi-char delimiter set "/;" — Lucee returns the literal remainder with
+// the SAME delimiter chars the input used, not all rewritten to "/".
+assert("listRest keeps original delimiter chars", listRest("a/b;c/", "/;"), "b;c/");
+
+// --- Interior empty elements preserved ---
+assert("listRest keeps interior empty elements", listRest("a,,b,,c"), "b,,c");
+
+// --- Baseline (no empties, single delim): identical on both engines ---
+assert("listRest basic remainder", listRest("a,b,c"), "b,c");
+
+// --- Single element -> empty remainder (identical on both engines) ---
+assert("listRest single element", listRest("a"), "");
+
+// ============================================================
+// CONTROLS — pass on BOTH RustCFML and Lucee (guard the wiring).
+// Siblings keep empty-collapsing; do NOT assert divergent behavior here.
+// ============================================================
+assert("control: listLen collapses empties", listLen("a/b/", "/"), 2);
+assert("control: listFirst", listFirst("a/b/", "/"), "a");
+assert("control: listLast collapses trailing empty", listLast("a/b/", "/"), "b");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Cross-engine gap: `ListRest` should return the literal remainder

On Lucee 5/6/7, Adobe ColdFusion, and BoxLang, `ListRest` returns the **literal substring from element 2 onward** — preserving interior/trailing empty elements *and* the original delimiter characters from the source string. RustCFML 0.92.0 instead collapses empty elements and normalizes the delimiter set to a single canonical char.

| call | RustCFML 0.92.0 | Lucee (correct) |
|------|-----------------|-----------------|
| `listRest(Reverse("/home/index"), "/")` | `"emoh"` | `"emoh/"` |
| `listRest("a/b/", "/")` | `"b"` | `"b/"` |
| `listRest("a/b;c/", "/;")` | `"b/c"` | `"b;c/"` |
| `listRest("a,,b,,c")` | `"b,c"` | `"b,,c"` |

Sibling list fns (`ListFirst`/`ListLast`/`ListLen`) correctly **keep** their empty-collapsing semantics and agree on both engines — the test asserts those as controls so it can't pass for the wrong reason.

### Why it matters
Surfaced while booting the Wheels framework on RustCFML: view-path resolution does `Reverse(path)` then `ListRest(...,"/")` to peel a segment, and the dropped trailing delimiter corrupts the reconstructed path. It's a general correctness gap, not Wheels-specific.

### Suggested fix shape (stdlib)
`ListRest(list, delims)` = the original string starting at the first character of element 2: skip any leading delimiter run, skip element 1, skip the single delimiter run that follows it, then return the remainder of the **original** string verbatim (no re-join, no delimiter rewrite). That naturally preserves interior/trailing empties and mixed delimiter chars. (`includeEmptyFields`/4th-arg behavior unaffected — this is the default 2/3-arg path.)

### Verification
- **RustCFML 0.92.0:** 4 divergent assertions FAIL, 2 baseline + 3 sibling controls PASS.
- **Lucee 7:** all 9 PASS.

Test registered in the stdlib list cluster of `tests/runner.cfm`.
