### PR TITLE
test(core): single-token string interpolation should preserve the value type

### DIFF
--- a/tests/core/test_single_part_interpolation_preserves_type.cfm
+++ b/tests/core/test_single_part_interpolation_preserves_type.cfm
@@ -1,0 +1,54 @@
+<cfscript>
+suiteBegin("Core: single-part string interpolation preserves the value type");
+
+// ============================================================
+// Background
+// ============================================================
+// On Lucee 5/6/7, Adobe ColdFusion, and BoxLang, a quoted string whose
+// ENTIRE content is a single interpolation token -- "#expr#" -- is a
+// special case: it does NOT stringify the value, it yields the VALUE
+// ITSELF with its type preserved. So `a = "#someStruct#"` leaves `a`
+// a struct, `a = "#someArray#"` leaves `a` an array, etc.
+//
+// As soon as the literal has ANY other part (a leading/trailing
+// character, or a second token) it degrades to ordinary string
+// concatenation/stringification on every engine -- that is the CONTROL
+// below and must pass on BOTH RustCFML and Lucee.
+//
+// RustCFML 0.92.0 stringifies even the single-token form, so
+// isStruct(a) / isArray(a) are false where Lucee reports true. This
+// suite documents that gap; the struct and array assertions are the
+// discriminators, the controls guard the test wiring.
+// ============================================================
+
+// ---- single-token interpolation preserves a STRUCT ----
+srcStruct = {x: 1, y: 2};
+oneStruct = "#srcStruct#";
+assertTrue("single-token '##struct##' stays a struct", isStruct(oneStruct));
+
+// ---- single-token interpolation preserves an ARRAY ----
+srcArray = [10, 20, 30];
+oneArray = "#srcArray#";
+assertTrue("single-token '##array##' stays an array", isArray(oneArray));
+
+// ---- single-token interpolation preserves a NUMBER as numeric ----
+srcNum = 42;
+oneNum = "#srcNum#";
+assertTrue("single-token '##number##' stays numeric", isNumeric(oneNum));
+
+// ============================================================
+// CONTROL -- multi-part interpolation stringifies/concatenates on BOTH
+// engines. These must pass everywhere; they guard the test wiring.
+// ============================================================
+twoTokens = "#1##2#";                 // adjacent tokens, no separator
+assert("two adjacent tokens concatenate to a string", twoTokens, "12");
+
+dashed = "#1#-#2#";                    // tokens with a literal separator
+assert("tokens with a separator concatenate to a string", dashed, "1-2");
+
+leading = "x#srcNum#";                 // leading literal char forces a string
+assertTrue("a leading literal char yields a plain string", isSimpleValue(leading));
+assert("...and stringifies the value", leading, "x42");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -359,6 +359,12 @@ try { include "core/test_param_dotted_lhs.cfm"; } catch (any e) { writeOutput("E
 //     possible since structs are reference types) must terminate rather than
 //     overflow the native stack.
 try { include "core/test_as_string_cycle_safety.cfm"; } catch (any e) { writeOutput("ERROR | core/test_as_string_cycle_safety.cfm | " & e.message & chr(10)); }
+//   - single_part_interpolation_preserves_type: a quoted literal that is exactly
+//     one interpolation token ("#expr#") yields the VALUE with its type intact
+//     (struct stays a struct, array stays an array) rather than stringifying.
+//     Multi-part literals still concatenate. Surfaced while booting Wheels
+//     (contentFor/section plumbing round-trips single-token values).
+try { include "core/test_single_part_interpolation_preserves_type.cfm"; } catch (any e) { writeOutput("ERROR | core/test_single_part_interpolation_preserves_type.cfm | " & e.message & chr(10)); }
 //   - lock_finally_semantics: try/finally + lock { } must run the finally on a
 //     `return` (release the lock) and re-propagate exceptions thrown inside.
 try { include "core/test_lock_finally_semantics.cfm"; } catch (any e) { writeOutput("ERROR | core/test_lock_finally_semantics.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Cross-engine gap: single-token string interpolation should preserve the value type

On Lucee 5/6/7, Adobe ColdFusion, and BoxLang, a quoted string whose **entire** content is a single interpolation token — `"#expr#"` — is a special case: it does **not** stringify the value, it yields the value *itself* with its type intact. So `a = "#someStruct#"` leaves `a` a struct; `a = "#someArray#"` leaves `a` an array.

RustCFML 0.92.0 stringifies even this single-token form:

| expression | RustCFML 0.92.0 | Lucee (correct) |
|------------|-----------------|-----------------|
| `s = {x:1}; isStruct("#s#")` | `false` | `true` |
| `a = [1,2]; isArray("#a#")` | `false` | `true` |

As soon as the literal has any *other* part (a leading/trailing char, or a second token) it degrades to ordinary concatenation on every engine — asserted here as controls (`"#1##2#"` → `"12"`, `"#1#-#2#"` → `"1-2"`, `"x#n#"` → `"x42"`), so the test can't pass for the wrong reason.

### Why it matters
Surfaced booting the Wheels framework: the view layer round-trips single-token interpolations through its `contentFor`/section plumbing, and the unexpected stringification corrupts struct/array payloads. General language-semantics gap, not Wheels-specific.

### Suggested fix shape (codegen)
When an interpolated-string node has exactly one part and no surrounding literal text, emit that part's expression **directly** (preserving its runtime type) instead of wrapping it in `String("") & <expr>`. Multi-part nodes keep the concat path.

### Verification
- **RustCFML 0.92.0:** the 2 struct/array assertions FAIL; the numeric check + 4 controls PASS (5/7).
- **Lucee 7:** all 7 PASS.
