### PR TITLE
test(core): named-arg call to a declared-param fn should leak no numeric alias key

### DIFF
--- a/tests/core/test_named_args_no_numeric_alias.cfm
+++ b/tests/core/test_named_args_no_numeric_alias.cfm
@@ -1,0 +1,76 @@
+<cfscript>
+suiteBegin("Core: named-arg call to a declared-param fn leaks no numeric alias key");
+
+// A named-argument call to a function that DECLARES parameters must populate
+// the arguments scope by NAME only. RustCFML 0.92.0 leaks a spurious numeric
+// positional-alias key into the arguments scope when a named argument lands in
+// a declared positional slot:
+//
+//   function cf(any position="last", any overwrite="false"){ return StructKeyList(arguments); }
+//   cf(body="X", overwrite=true)
+//     RustCFML 0.92.0 -> "overwrite,2,body,position"   (spurious "2")
+//     Lucee 7         -> "position,overwrite,body"      (no numeric key)
+//
+// The bug poisons any code that iterates / counts / serializes the arguments
+// scope after such a call (StructCount is inflated, for-in sees a bogus "2",
+// argument-forwarding round-trips a junk key). Wheels' option-forwarding
+// helpers do exactly this all over the framework.
+//
+// Assertions key on PRESENCE / ABSENCE, never on order: Lucee uppercases keys
+// and reorders the scope, so any order-sensitive assert would be a false
+// failure on a conforming engine.
+
+// --- helper that reports the shape of its own arguments scope by name only ---
+function probeArgs(any position = "last", any overwrite = "false") {
+    var result = {
+        hasNumericKey = false,
+        has2          = structKeyExists(arguments, "2"),
+        hasBody       = structKeyExists(arguments, "body"),
+        hasOverwrite  = structKeyExists(arguments, "overwrite"),
+        hasPosition   = structKeyExists(arguments, "position")
+    };
+    for (var k in arguments) {
+        if (isNumeric(k)) {
+            result.hasNumericKey = true;
+        }
+    }
+    return result;
+}
+
+shape = probeArgs(body = "X", overwrite = true);
+
+// No purely-numeric key may exist in the arguments scope.
+assertFalse("arguments scope has NO purely-numeric key", shape.hasNumericKey);
+assertFalse("arguments scope has no key named '2'", shape.has2);
+
+// The named arguments are present under their own names.
+assertTrue("named arg 'overwrite' present by name", shape.hasOverwrite);
+assertTrue("extra named arg 'body' present by name", shape.hasBody);
+// 'position' was declared but not passed -> present via its declared default.
+assertTrue("declared 'position' present (default applied)", shape.hasPosition);
+
+// Cross-check via StructKeyList: still no numeric token in the key list.
+function keyListProbe(any position = "last", any overwrite = "false") {
+    return structKeyList(arguments);
+}
+keys = keyListProbe(body = "X", overwrite = true);
+assertFalse("StructKeyList contains no '2' token",
+    listFindNoCase(keys, "2") gt 0);
+assertTrue("StructKeyList contains 'body'",
+    listFindNoCase(keys, "body") gt 0);
+assertTrue("StructKeyList contains 'overwrite'",
+    listFindNoCase(keys, "overwrite") gt 0);
+assertTrue("StructKeyList contains 'position'",
+    listFindNoCase(keys, "position") gt 0);
+
+// --- CONTROL: paramless fn called with all named args (already correct on
+//     both engines). Guards the wiring so a regression in the named-arg path
+//     can't masquerade as the gap under test. ---
+function paramless() {
+    return structCount(arguments);
+}
+assert("CONTROL: paramless fn, two named args -> StructCount == 2",
+    paramless(alpha = 1, sort = 2), 2);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -350,6 +350,13 @@ try { include "core/test_switch_fallthrough.cfm"; } catch (any e) { writeOutput(
 try { include "core/test_application_scope_persist.cfm"; } catch (any e) { writeOutput("ERROR | core/test_application_scope_persist.cfm | " & e.message & chr(10)); }
 try { include "core/test_session_scope_persist.cfm"; } catch (any e) { writeOutput("ERROR | core/test_session_scope_persist.cfm | " & e.message & chr(10)); }
 try { include "core/test_application_metadata.cfm"; } catch (any e) { writeOutput("ERROR | core/test_application_metadata.cfm | " & e.message & chr(10)); }
+//   - named_args_no_numeric_alias: a named-argument call to a function that
+//     DECLARES params must populate the arguments scope by name only. When a
+//     named arg lands in a declared positional slot, RustCFML leaks a spurious
+//     numeric key (e.g. "2"), inflating StructCount and poisoning for-in /
+//     option-forwarding. Surfaced while booting Wheels (contentFor section
+//     detection reads StructKeyList(arguments)).
+try { include "core/test_named_args_no_numeric_alias.cfm"; } catch (any e) { writeOutput("ERROR | core/test_named_args_no_numeric_alias.cfm | " & e.message & chr(10)); }
 //   - param_dotted_lhs: the cfscript `param` shorthand must accept a dotted /
 //     scoped lvalue (`param arguments.obj.key = default`), not just a bare
 //     identifier. Surfaced while booting WireBox (Injector.cfc uses


### PR DESCRIPTION
## Cross-engine gap: named-arg call to a declared-param fn leaks a numeric alias key

A named-argument call to a function that **declares** parameters must populate the `arguments` scope by name only. RustCFML 0.92.0 leaks a spurious purely-numeric positional-alias key into the scope when a named argument lands in (or alongside) a declared positional slot.

```cfml
function cf(any position="last", any overwrite="false") { return StructKeyList(arguments); }
cf(body="X", overwrite=true)
```

| engine | `StructKeyList(arguments)` |
|--------|-----------------------------|
| RustCFML 0.92.0 | `"overwrite,2,body,position"` ← spurious `"2"` |
| Lucee 7 | `"position,overwrite,body"` |

The junk numeric key inflates `StructCount`, makes a `for (k in arguments)` loop see a bogus `"2"`, and round-trips through any argument-forwarding helper.

### Why it matters
Surfaced booting the Wheels framework: `contentFor()` detects which section to write by reading `StructKeyList(arguments)` / `arguments` keys, and the phantom `"2"` derails section selection — the layout body comes out empty. Wheels' option-forwarding helpers do this scope-introspection pervasively.

The **paramless** case (`g(){...}` called `g(alpha=1, sort=2)`) is already correct on both engines and is asserted here as a control, isolating the regression to the declared-positional-slot path.

### Verification
- **RustCFML 0.92.0:** the 3 numeric-key assertions FAIL; the 4 name-presence checks + paramless control + 2 more PASS (7/10).
- **Lucee:** all 10 PASS.

Assertions are presence/absence only — Lucee uppercases and reorders the `arguments` scope, so no order-sensitive check is used.
