### PR TITLE
test(core): `param` should be usable as an ordinary identifier (soft keyword)

### DIFF
--- a/tests/core/test_param_as_identifier.cfm
+++ b/tests/core/test_param_as_identifier.cfm
@@ -1,0 +1,67 @@
+<cfscript>
+suiteBegin("Core: `param` usable as an ordinary identifier");
+
+// ============================================================
+// Background  (follow-on to test_param_dotted_lhs.cfm / PR #32 / #77 by bpamiri)
+// ============================================================
+// `param` is a SOFT keyword on Lucee 5/6/7, Adobe ColdFusion 2018-2025, and
+// BoxLang: reserved only for the cfscript `param <type> name = default;`
+// statement, but otherwise a legal ordinary identifier. RustCFML 0.92.0 instead
+// treats a statement that *starts* with the token `param` as a cfparam
+// statement unconditionally, so using `param` as an assignment target
+// (`param = "x"`) or a struct loop variable that is then written to
+// (`param['default'] = ...`) is a PARSE error.
+//
+// Disambiguation Lucee uses: `param` followed by a type/identifier is the
+// cfparam statement (`param cfgA.timeout = 30`, covered by
+// test_param_dotted_lhs.cfm); `param` followed directly by `=` or `[` is an
+// ordinary assignment to a variable named `param`. Sibling soft keywords
+// (`name`, `type`, `default`) are already accepted as identifiers on RustCFML;
+// only `param` regresses.
+//
+// Wheels relies on exactly this. vendor/wheels/public/helpers.cfm:460 iterates
+// the parsed parameter list with `param` as the loop variable and writes back
+// into it:
+//
+//     for (param in local.rv["parameters"]) {
+//         ...
+//         param['default'] = application.wheels.functions[...][param.name];
+//     }
+//
+// Because the failure is a PARSE error, the whole file errors out on RustCFML
+// (the runner's try/catch reports ERROR, not a FAIL count) — that is the
+// documented red form for this gap.
+// ============================================================
+
+// --- CONTROL: same shape with a non-keyword loop var passes on BOTH engines ---
+// Guards the test wiring: if this fails, the assertion harness itself is broken,
+// not the `param` keyword handling.
+controlParams = [ {name="a", "default"="x"}, {name="b", "default"="y"} ];
+controlOut = "";
+for (item in controlParams) {
+	item['default'] = uCase(item['default']);
+	controlOut = controlOut & item.name & "=" & item['default'] & ";";
+}
+assert("control: loop var `item` writes back (wiring guard)", controlOut, "a=X;b=Y;");
+
+// --- `param` as a plain assignment target and bare read ---
+param = "soft-keyword-as-var";
+assert("`param` is a legal assignment target and reads back", param, "soft-keyword-as-var");
+
+// --- `param` as a for-in struct loop variable, written to inside the loop ---
+// This is the verbatim vendor/wheels/public/helpers.cfm shape.
+parsedParams = [ {name="a", "default"="x"}, {name="b", "default"="y"} ];
+joined = "";
+for (param in parsedParams) {
+	if (structKeyExists(param, "default")) {
+		param['default'] = uCase(param['default']);
+	}
+	joined = joined & param.name & "=" & param['default'] & ";";
+}
+assert("`param` loop var with write-back (helpers.cfm shape)", joined, "a=X;b=Y;");
+
+// --- `param` survives as a readable value after the loop ---
+assert("`param` still readable after the loop", param.name, "b");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Cross-engine gap: `param` should be usable as an ordinary identifier

`param` is a **soft keyword** on Lucee 5/6/7, Adobe ColdFusion 2018–2025, and BoxLang. It introduces the cfscript `param <type> name = default;` statement *only* when followed by a type/identifier — but it is a perfectly legal ordinary identifier otherwise. RustCFML 0.92.0 commits to the cfparam grammar on **any** statement-leading `param`, so these are parse errors:

```cfml
param = "x";                 // Parse error: Expected identifier (found Equal)
param['default'] = uCase(x); // Parse error: Expected identifier (found LBracket)
```

### Disambiguation (matches the existing `test_param_dotted_lhs.cfm`)
- `param` followed by a **type/identifier** → cfparam statement (`param cfgA.timeout = 30`) — already handled.
- `param` followed directly by **`=` or `[`** → ordinary assignment to a variable named `param`.

Sibling soft keywords (`name`, `type`, `default`) are already accepted as identifiers on RustCFML; only `param` regresses.

### Why it matters
`vendor/wheels/public/helpers.cfm:460` iterates the parsed parameter list with `param` as the loop variable and writes back into it — the verbatim shape exercised by the test:

```cfml
for (param in local.rv["parameters"]) {
    ...
    param['default'] = application.wheels.functions[local.rv.name][param.name];
}
```

This currently blocks the Wheels documentation/introspection path during boot.

### Verification
- **Lucee** (`box task run`): all forms pass — `param="x"` assigns, the `for (param in ...)` loop with `param['default']=uCase(...)` write-back yields `a=X;b=Y;`, `param.name` after the loop is `b`.
- **RustCFML 0.92.0:** parse error at the first `param = "..."` (line 48).

### ⚠️ Note on runner registration (differs from my other 3 test PRs)
Unlike the assertion-level gaps, this manifests as a **parse error**, and RustCFML resolves a literal-path `include` at compile time — so an uncaught include-time parse error **aborts the entire runner** (a surrounding `try/catch` does not catch it; verified on 0.92.0). I therefore left this test **out of `tests/runner.cfm`** so the PR doesn't break the suite on the current engine. Suggested placement once the parser fix lands — right after the `test_param_dotted_lhs.cfm` line:

```cfml
//   - param_as_identifier: `param` is a SOFT keyword — cfparam only when
//     followed by a type/identifier; an ordinary assignment target when
//     followed by `=` or `[`. Surfaced booting Wheels (helpers.cfm:460).
try { include "core/test_param_as_identifier.cfm"; } catch (any e) { writeOutput("ERROR | core/test_param_as_identifier.cfm | " & e.message & chr(10)); }
```
