### PR TITLE
test(core): typed return type on a top-level cfscript function (Lucee parity)

### DIFF
--- a/tests/core/test_typed_toplevel_function_return_type.cfm
+++ b/tests/core/test_typed_toplevel_function_return_type.cfm
@@ -1,0 +1,38 @@
+<cfscript>
+suiteBegin("Core: typed return type on a top-level cfscript function");
+
+// On Lucee 5/6/7, Adobe ColdFusion, and BoxLang, a top-level (non-component)
+// cfscript function may carry a return-type annotation -- `struct function f()`
+// -- exactly like a component method. RustCFML 0.92.0 misparses the leading
+// type token at the top level as a bare expression STATEMENT, so
+// `struct function f(){...}` throws "Variable 'struct' is undefined" at runtime.
+//
+// The same declaration INSIDE a component works, and an UNTYPED top-level
+// function works -- both are exercised here as controls so the test can't pass
+// for the wrong reason. Every type keyword regresses identically
+// (struct/array/string/numeric/boolean/query/any/void).
+//
+// Surfaced booting the Wheels framework: vendor/wheels/public/helpers.cfm:293
+// declares `struct function $returnInternalDocumentation(...)`, and many view
+// helper .cfm files declare typed top-level functions.
+//
+// On RustCFML this surfaces as a runtime ERROR at the first typed declaration
+// (so tests/runner.cfm reports `ERROR | ... | Variable 'struct' is undefined`),
+// not as assertion failures.
+
+// --- CONTROL: untyped top-level fn works on BOTH engines (wiring guard) ---
+// (A typed return type INSIDE a component also works on RustCFML 0.92.0 -- the
+// regression is specific to TOP-LEVEL function declarations.)
+function plainTop() { return {a: 1}; }
+assertTrue("control: untyped top-level fn returns a struct", isStruct(plainTop()));
+
+// --- GAP: typed return types on TOP-LEVEL functions ---
+struct  function makeStruct() { return {a: 1}; }
+array   function makeArray()  { return [1, 2, 3]; }
+string  function makeString() { return "hi"; }
+assertTrue("struct-typed top-level fn returns a struct", isStruct(makeStruct()));
+assertTrue("array-typed top-level fn returns an array", isArray(makeArray()));
+assert("string-typed top-level fn returns its value", makeString(), "hi");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -317,6 +317,12 @@ try { include "core/test_isinstanceof_interface_chain.cfm"; } catch (any e) { wr
 //     the first `.` ("Expected RParen, found Dot"). Parse-only (Lucee enforces
 //     the type at call time, so the test never calls with a mismatched value).
 try { include "core/test_dotted_param_type.cfm"; } catch (any e) { writeOutput("ERROR | core/test_dotted_param_type.cfm | " & e.message & chr(10)); }
+//   - typed_toplevel_function_return_type: a TOP-LEVEL (non-component) cfscript
+//     function may carry a return-type annotation (`struct function f()`), like
+//     a component method. RustCFML misparses the leading type token at the top
+//     level as a bare expression statement ("Variable 'struct' is undefined").
+//     Surfaced booting Wheels (vendor/wheels/public/helpers.cfm:293).
+try { include "core/test_typed_toplevel_function_return_type.cfm"; } catch (any e) { writeOutput("ERROR | core/test_typed_toplevel_function_return_type.cfm | " & e.message & chr(10)); }
 //   - for_increment_compound: the for-loop increment clause accepts compound
 //     assignment (for (i=1; i<=10; i+=2)). RustCFML used to reject it
 //     ("Expected RParen, found PlusEqual"). Used in vendor/wheels/model/bulk.cfc.


### PR DESCRIPTION
## Cross-engine gap: typed return type on a top-level cfscript function

On Lucee 5/6/7, Adobe ColdFusion, and BoxLang, a **top-level** (non-component) cfscript function may carry a return-type annotation — `struct function f()` — exactly like a component method. RustCFML 0.92.0 misparses the leading type token at the top level as a bare *expression statement*, so the declaration throws at runtime:

```cfml
struct function f(){ return {a:1}; }   // RustCFML: Runtime Error: Variable 'struct' is undefined
```

Every type keyword regresses identically — `struct`, `array`, `string`, `numeric`, `boolean`, `query`, `any`, `void`.

### Scope of the regression (the two controls in the test)
| context | RustCFML 0.92.0 |
|---------|-----------------|
| `struct function f()` at top level of a `.cfm` | ❌ throws |
| `struct function f()` **inside a component** | ✅ works |
| **untyped** `function f()` at top level | ✅ works |

So the parser handles the type annotation for component methods but not for top-level function declarations.

### Why it matters
Surfaced booting the Wheels framework. `vendor/wheels/public/helpers.cfm:293` declares:

```cfml
struct function $returnInternalDocumentation(required array documentScope, required array ignore) { ... }
```

and many view-helper `.cfm` files declare typed top-level functions. This is general CFML — typed top-level functions are common — not Wheels-specific.

### Verification
- **Lucee:** 4/4 pass (control + struct/array/string typed top-level fns).
- **RustCFML 0.92.0:** runtime error at the first typed declaration. **Longstanding** — fails identically on 0.65.0 and 0.92.0.

On RustCFML this manifests as a **runtime** error (caught by the runner's `try/catch` → `ERROR | ... | Variable 'struct' is undefined`), so it registers safely in `tests/runner.cfm` without aborting the suite.
