### PR TITLE
test(types): query["col"][row] bracket-column cell access should return the cell (Lucee parity)

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -54,6 +54,7 @@ try { include "types/test_nested_writeback.cfm"; } catch (any e) { writeOutput("
 try { include "types/test_query.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query.cfm | " & e.message & chr(10)); }
 try { include "types/test_query_column.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_column.cfm | " & e.message & chr(10)); }
 try { include "types/test_query_reference.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_reference.cfm | " & e.message & chr(10)); }
+try { include "types/test_query_bracket_column_access.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_bracket_column_access.cfm | " & e.message & chr(10)); }
 try { include "types/test_binary.cfm"; } catch (any e) { writeOutput("ERROR | types/test_binary.cfm | " & e.message & chr(10)); }
 try { include "types/test_hash_in_strings.cfm"; } catch (any e) { writeOutput("ERROR | types/test_hash_in_strings.cfm | " & e.message & chr(10)); }
 try { include "comments/test_hash_in_comments.cfm"; } catch (any e) { writeOutput("ERROR | comments/test_hash_in_comments.cfm | " & e.message & chr(10)); }

--- a/tests/types/test_query_bracket_column_access.cfm
+++ b/tests/types/test_query_bracket_column_access.cfm
@@ -1,0 +1,38 @@
+<cfscript>
+suiteBegin("Types: query bracket-column cell access (Lucee parity)");
+
+// query["columnName"][rowNumber] (bracket-column + index) must return the cell
+// value, exactly like query.columnName[rowNumber] (dot form). On Lucee 5/6/7,
+// Adobe ColdFusion, and BoxLang both forms return the cell. RustCFML returns an
+// EMPTY value for the bracket form while the dot form works.
+//
+// This matters because frameworks read query cells via the bracket form when
+// the column name is dynamic (held in a variable). Wheels' ORM column
+// processing does exactly this (vendor/wheels/Model.cfc:
+// local.columns["column_name"][local.i]) — so every introspected column comes
+// back blank, and the model can't build its property map.
+//
+// A datasource is intentionally NOT used: queryNew() reproduces the gap with no
+// DB dependency, so the test is portable and deterministic.
+
+q = queryNew(
+	"column_name,type_name",
+	"varchar,varchar",
+	[ ["id", "INTEGER"], ["title", "TEXT"] ]
+);
+
+// --- CONTROL: dot-form cell access works on BOTH engines (guards the wiring) ---
+assert("control: dot q.column_name[1]", q.column_name[1], "id");
+assert("control: dot q.column_name[2]", q.column_name[2], "title");
+
+// --- GAP: bracket-column + index must return the same cell value ---
+assert("bracket q['column_name'][1]", q["column_name"][1], "id");
+assert("bracket q['column_name'][2]", q["column_name"][2], "title");
+assert("bracket q['type_name'][1]", q["type_name"][1], "INTEGER");
+
+// --- the realistic framework shape: a dynamic (variable) column-name key ---
+colKey = "column_name";
+assert("bracket dynamic-key q[colKey][2]", q[colKey][2], "title");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Cross-engine gap: `query["col"][row]` bracket-column cell access returns empty

`query["columnName"][rowNumber]` (bracket-column + index) must return the cell value, exactly like `query.columnName[rowNumber]` (dot form). On Lucee 5/6/7, Adobe ColdFusion, and BoxLang both forms work. RustCFML returns an **empty** value for the bracket form, while the dot form works.

```cfml
q = queryNew("column_name,type_name", "varchar,varchar", [["id","INTEGER"],["title","TEXT"]]);

q.column_name[1]       // "id"   on both engines
q["column_name"][1]    // ""     on RustCFML   /   "id" on Lucee
q["column_name"][2]    // ""     on RustCFML   /   "title" on Lucee
```

### Why it matters
Frameworks read query cells via the **bracket** form whenever the column name is dynamic (held in a variable). Wheels' ORM column processing does exactly this:

```cfml
// vendor/wheels/Model.cfc
local.columnName = local.columns["column_name"][local.i];
```

With the bracket form returning blanks, every introspected column comes back empty → the model can't build its property map → no model works. This is the current wall for running the Wheels ORM on RustCFML.

### Verification
- **RustCFML 0.98.0:** the 4 bracket-form assertions FAIL (`got: []`); the 2 dot-form controls PASS (2/6).
- **Lucee:** all 5 pass.

The test uses `queryNew()` (no datasource) so it's portable and deterministic. Dot-form controls guard the wiring. Verified red across 0.90.x→0.98.0; dot form has always worked.
