### PR TITLE
Add CFML test for null as a bare struct-literal key

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -48,6 +48,7 @@ try { include "types/test_array.cfm"; } catch (any e) { writeOutput("ERROR | typ
 try { include "types/test_array_append_grow.cfm"; } catch (any e) { writeOutput("ERROR | types/test_array_append_grow.cfm | " & e.message & chr(10)); }
 try { include "types/test_array_reference_semantics.cfm"; } catch (any e) { writeOutput("ERROR | types/test_array_reference_semantics.cfm | " & e.message & chr(10)); }
 try { include "types/test_struct.cfm"; } catch (any e) { writeOutput("ERROR | types/test_struct.cfm | " & e.message & chr(10)); }
+try { include "types/test_struct_literal_null_key.cfm"; } catch (any e) { writeOutput("ERROR | types/test_struct_literal_null_key.cfm | " & e.message & chr(10)); }
 try { include "types/test_struct_reference_semantics.cfm"; } catch (any e) { writeOutput("ERROR | types/test_struct_reference_semantics.cfm | " & e.message & chr(10)); }
 try { include "types/test_ordered_struct_literals.cfm"; } catch (any e) { writeOutput("ERROR | types/test_ordered_struct_literals.cfm | " & e.message & chr(10)); }
 try { include "types/test_nested_writeback.cfm"; } catch (any e) { writeOutput("ERROR | types/test_nested_writeback.cfm | " & e.message & chr(10)); }

--- a/tests/types/test_struct_literal_null_key.cfm
+++ b/tests/types/test_struct_literal_null_key.cfm
@@ -1,0 +1,30 @@
+<cfscript>
+suiteBegin("Struct literal: null as a bare key name");
+
+// Lucee/ACF treat a bare `null` (and other keyword literals) directly before
+// a key separator in a struct literal as the KEY NAME "null", not as the
+// null value literal. cfqueryparam relies on this: its attribute struct is
+// `{value: ..., cfsqltype: ..., null: true}`, so losing the key silently
+// drops null= handling.
+
+// --- gap: bare `null` key with colon separator ---
+s = { value: "", cfsqltype: "varchar", null: true };
+assert("bare null key: struct has 3 keys", structCount(s), 3);
+assertTrue("bare null key exists", structKeyExists(s, "null"));
+assertTrue("bare null key value is true", (s["null"] ?: false) eq true);
+
+// --- gap: bare `null` key with equals separator (cfqueryparam attribute style) ---
+s2 = { value = "", null = true };
+assertTrue("bare null key (equals separator) exists", structKeyExists(s2, "null"));
+assertTrue("bare null key (equals separator) value", (s2["null"] ?: false) eq true);
+
+// --- control: quoted "null" key works today ---
+s3 = { value: "", "null": true };
+assertTrue("quoted null key exists (control)", structKeyExists(s3, "null"));
+
+// --- control: a struct literal without the keyword key is unaffected ---
+s4 = { value: "x", cfsqltype: "varchar" };
+assert("plain literal key count (control)", structCount(s4), 2);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Pins that a bare `null` directly before a key separator (`:` or `=`) in a struct literal names the **key** `"null"` — matching Lucee/ACF — rather than being parsed as the null value literal.

## Why

RustCFML currently parses `{ value: "", null: true }` with an **empty-string key** in place of `null`, so the entry is unreachable by name and `structKeyExists(s, "null")` is false.

This silently breaks `cfqueryparam`: the tag compiles its attributes into exactly this struct shape (`{value: ..., cfsqltype: ..., null: true}`), so `null="true"` vanishes and the param binds `""` instead of SQL NULL. Found running Moopa on RustCFML: the route-registry sync inserts a route endpoint with `created_by` NULL when no session user exists — the lost flag bound `""` into a uuid column and aborted application startup.

## Coverage

- **gaps** (expected-fail on current upstream): bare `null` key with `:` separator (key exists + value is true), and with `=` separator (the cfqueryparam attribute style).
- **controls** (pass today): quoted `"null"` key; a plain literal without keyword keys.

## Where the fix goes (for reference; not included here)

`crates/cfml-compiler/src/parser.rs`, `parse_struct_literal`: when the current token is a keyword literal (`null` — and `true`/`false` deserve the same treatment) and the next token is `Colon`/`Equal`, consume it as a string-literal KEY instead of letting `parse_expression` produce the value literal.

Test-only; no engine change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)