### PR TITLE
Add CFML test for cfqueryparam-style queryExecute param structs

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -157,6 +157,7 @@ try { include "tags/test_tags_cfmail.cfm"; } catch (any e) { writeOutput("ERROR 
 try { include "tags/test_tags_cfcache.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfcache.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfstoredproc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfstoredproc.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfqueryparam_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfqueryparam_attribute_collection.cfm | " & e.message & chr(10)); }
+try { include "tags/test_queryexecute_param_structs.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_queryexecute_param_structs.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfqueryparam_interpolated_value.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_interpolated_value.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfquery_quoted_identifier.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfquery_quoted_identifier.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfquery_control_tags.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_queryexecute_param_structs.cfm
+++ b/tests/tags/test_queryexecute_param_structs.cfm
@@ -1,0 +1,62 @@
+<cfscript>
+suiteBegin("queryExecute: cfqueryparam-style param structs");
+
+// Lucee accepts a cfqueryparam-style struct ({value, cfsqltype, null, ...})
+// wherever a queryExecute parameter is expected - positional array entries
+// and named-struct entries alike - and binds the struct's VALUE (or NULL
+// when null=true). Binding the stringified struct itself is never correct.
+
+tmpfile = getTempDirectory() & "/rustcfml_qe_pstruct_" & createUUID() & ".sqlite";
+ds = "sqlite://" & tmpfile;
+skip = false;
+
+try {
+    queryExecute("CREATE TABLE t (id INTEGER, name TEXT)", [], { datasource: ds });
+    queryExecute("INSERT INTO t VALUES (1, 'alpha'), (2, 'beta')", [], { datasource: ds });
+} catch (any e) {
+    skip = true;
+    assertTrue("queryExecute param structs skipped (no sqlite): " & e.message, true);
+}
+</cfscript>
+
+<cfif NOT skip>
+
+<cfscript>
+// --- control: positional param struct already binds the value ---
+r = queryExecute("SELECT name FROM t WHERE id = ?",
+    [{value: 1, cfsqltype: "cf_sql_integer"}], { datasource: ds });
+assert("positional param struct binds value (control)", r.recordCount, 1);
+assert("positional param struct row (control)", r.name[1] ?: "", "alpha");
+
+// --- gap: NAMED param struct must bind the value, not the struct ---
+r2 = queryExecute("SELECT name FROM t WHERE id = :p",
+    {p: {value: 2, cfsqltype: "cf_sql_integer"}}, { datasource: ds });
+assert("named param struct binds value", r2.recordCount, 1);
+assert("named param struct row", r2.name[1] ?: "", "beta");
+
+// --- control: null=true with a QUOTED key binds SQL NULL today ---
+r3 = queryExecute("SELECT (?) IS NULL AS isn FROM t WHERE id = 1",
+    [{value: "", cfsqltype: "cf_sql_varchar", "null": true}], { datasource: ds });
+assertTrue("quoted null key binds SQL NULL (control)", r3.isn[1] ?: false);
+
+// --- gap: null=true with the BARE key (what cfqueryparam compiles to) ---
+// Overlaps the struct-literal null-key test on purpose: the cfquery tag's
+// null="true" only works when both the literal key and the binding hold.
+r4 = queryExecute("SELECT (?) IS NULL AS isn FROM t WHERE id = 1",
+    [{value: "", cfsqltype: "cf_sql_varchar", null: true}], { datasource: ds });
+assertTrue("bare null key binds SQL NULL", r4.isn[1] ?: false);
+</cfscript>
+
+<!--- gap: cfquery tag null="true" end-to-end (compiles to a param struct) --->
+<cfquery name="qn" datasource="#ds#">
+    SELECT (<cfqueryparam value="" cfsqltype="cf_sql_varchar" null="true" />) IS NULL AS isn FROM t WHERE id = 1
+</cfquery>
+<cfscript>
+assertTrue("cfquery tag null='true' binds SQL NULL", qn.isn[1] ?: false);
+
+try { fileDelete(tmpfile); } catch (any e) {}
+</cfscript>
+
+</cfif>
+
+<cfscript>suiteEnd();</cfscript>


### PR DESCRIPTION
## What

Pins that a cfqueryparam-style struct (`{value, cfsqltype, null, ...}`) is accepted wherever a `queryExecute` parameter is expected — positional array entries and named-struct entries alike — and binds the struct's **value** (or SQL NULL when `null=true`), matching Lucee. The `cfquery` tag's `null="true"` is covered end-to-end since the tag compiles to exactly this struct form.

## Why

RustCFML currently binds the **stringified struct** for named params: on sqlite the lookup matches nothing (0 rows); on postgres the prepared statement fails with `error serializing parameter 0` (the text `{value: ..., cfsqltype: ...}` can't bind to a typed column). Found running Moopa on RustCFML: every `db.save` INSERT goes through this form, so the first new route endpoint after an upgrade aborted application startup.

A diagnostic note for the postgres path: the surfaced message is just `error serializing parameter 0` — the underlying cause (`cannot bind "..." as PostgreSQL uuid: ...`) is in the error's `source()` chain and currently dropped, which makes this gap expensive to trace. Chaining it would help independent of the fix.

## Coverage

Uses the `sqlite://` tempfile + graceful-skip pattern from `test_cfqueryparam_interpolated_value.cfm` (skips on engines without the sqlite scheme, e.g. Lucee under CommandBox).

- **controls** (pass today): positional param struct (the array path already flattens these); `null=true` via a *quoted* `"null"` key.
- **gaps** (expected-fail on current upstream): named param struct (binds 0 rows instead of the value, 2 asserts); `null=true` via the *bare* `null` key (overlaps the struct-literal null-key test on purpose — `cfquery`'s `null="true"` only works when both hold); `<cfqueryparam null="true">` end-to-end through the `cfquery` tag.

## Where the fixes go (for reference; not included here)

- postgres: `crates/cfml-stdlib/src/pg_sql.rs`, `prepare_pg_statements` — unwrap the param struct per entry in both the `Array` and `Struct` branches (honouring `null`), instead of `query_column_scalar().clone()` on the raw struct.
- sqlite: `crates/cfml-stdlib/src/builtins.rs`, `build_sqlite_params` named branch — same unwrap before `cfml_to_sqlite` (the positional path already flattens via the shared pre-processing; mysql's named branch likely needs the same).

Test-only; no engine change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)