### PR TITLE
test(core): invoke() should spread an argumentCollection key in its argument struct

### DIFF
--- a/tests/core/InvokeArgCollTarget.cfc
+++ b/tests/core/InvokeArgCollTarget.cfc
@@ -1,0 +1,16 @@
+// Target for the invoke() argumentCollection-spread test.
+component {
+	public string function target(string name = "DEFAULT", string path = "P0") {
+		return "name=" & arguments.name & " path=" & arguments.path;
+	}
+
+	// Reports which keys actually landed in the arguments scope.
+	public string function argKeyList() {
+		return structKeyList(arguments);
+	}
+
+	// True only if the literal key "argumentCollection" leaked through unspread.
+	public boolean function hasLiteralArgumentCollectionKey() {
+		return structKeyExists(arguments, "argumentCollection");
+	}
+}

--- a/tests/core/test_invoke_argumentcollection_spread.cfm
+++ b/tests/core/test_invoke_argumentcollection_spread.cfm
@@ -1,0 +1,72 @@
+<cfscript>
+suiteBegin("Core: invoke() spreads an `argumentCollection` key in its argument struct");
+
+// ============================================================
+// Background  (companion to test_invoke_canonical_forms.cfm)
+// ============================================================
+// `argumentCollection` is a SPECIAL key on every CFML argument-passing
+// surface. When the argument struct handed to the positional BIF
+// invoke(objectOrName, method, argStruct) contains an `argumentCollection`
+// key, Lucee 5/6/7 and Adobe ColdFusion spread the INNER struct into the
+// callee's arguments scope — the same contract as fn(argumentCollection = st)
+// and cfinvoke's argumentCollection attribute. Declared params named by inner
+// keys receive those values, params the inner struct does not name keep their
+// declared defaults, and the literal key "argumentCollection" itself never
+// appears in the callee's arguments scope.
+//
+// RustCFML 0.100.0 does not special-case the key — the inner struct is
+// silently dropped (it neither spreads nor lands as a literal named arg):
+//
+//   function target(string name = "DEFAULT", string path = "P0") {...}
+//   invoke(o, "target", { argumentCollection = { name = "posts" } })
+//     Lucee 5.4.8.2    -> "name=posts path=P0"     (inner struct spread)
+//     RustCFML 0.100.0 -> "name=DEFAULT path=P0"   (inner struct dropped)
+//
+// The plain 3-arg struct form (the CONTROL below) already agrees on both
+// engines; only the nested-key spread diverges.
+//
+// Wheels rides this contract on every request: $doubleCheckedLock() forwards
+// its executeArgs as `$invoke(method = ..., argumentCollection = executeArgs)`
+// (vendor/wheels/Global.cfc:41) and $invoke() pushes that struct through the
+// engine's dynamic-invoke machinery (Global.cfc:289-320). Controller class
+// resolution ($controller -> $doubleCheckedLock -> $createControllerClass)
+// runs on this path, so an engine that drops the key hands the resolver EMPTY
+// arguments and silently turns every user controller action into a no-op.
+// ============================================================
+
+fixture = createObject("component", "InvokeArgCollTarget");
+
+// --- CONTROL: plain 3-arg struct form binds declared params on BOTH engines ---
+// Guards the wiring: if this fails, dynamic invocation itself is broken,
+// not the argumentCollection special-casing under test.
+assert("CONTROL: plain arg struct binds declared params",
+	invoke(fixture, "target", { name = "posts", path = "/x" }),
+	"name=posts path=/x");
+
+// --- the gap: a nested argumentCollection key must be SPREAD ---
+assert("argumentCollection key is spread; unnamed param keeps its declared default",
+	invoke(fixture, "target", { argumentCollection = { name = "posts" } }),
+	"name=posts path=P0");
+
+assert("argumentCollection key naming every param binds them all",
+	invoke(fixture, "target", { argumentCollection = { name = "posts", path = "/admin" } }),
+	"name=posts path=/admin");
+
+assert("spread also applies when invoking by component NAME",
+	invoke("InvokeArgCollTarget", "target", { argumentCollection = { name = "posts" } }),
+	"name=posts path=P0");
+
+// The spread populates the callee's arguments scope even when the method
+// declares no params at all (Lucee reports key "name"; keying on presence,
+// not order/case, per the named_args_no_numeric_alias conventions).
+spreadKeys = invoke(fixture, "argKeyList", { argumentCollection = { name = "posts" } });
+assertTrue("spread reaches the arguments scope of a paramless method",
+	listFindNoCase(spreadKeys, "name") gt 0);
+
+// And the special key itself must NOT leak through as a literal argument —
+// pins the fix shape: spread the inner struct, don't bind the key by name.
+assertFalse("no literal 'argumentCollection' key leaks into the callee",
+	invoke(fixture, "hasLiteralArgumentCollectionKey", { argumentCollection = { name = "posts" } }));
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -340,6 +340,14 @@ try { include "core/test_script_fn_post_paren_attr.cfm"; } catch (any e) { write
 //     function-call form invoke(component=..)/cfinvoke(..) is intentionally NOT
 //     tested: Lucee rejects it at compile time, so it is not a portable contract.
 try { include "core/test_invoke_canonical_forms.cfm"; } catch (any e) { writeOutput("ERROR | core/test_invoke_canonical_forms.cfm | " & e.message & chr(10)); }
+//   - invoke_argumentcollection_spread: the argument struct passed to the
+//     positional invoke() BIF must special-case an `argumentCollection` key
+//     and spread the INNER struct into the callee's arguments scope (the same
+//     contract as fn(argumentCollection=st) / cfinvoke). RustCFML drops the
+//     key, so declared params keep their defaults. Surfaced booting Wheels:
+//     $doubleCheckedLock -> $invoke controller-class resolution received
+//     empty args, silently turning every user controller action into a no-op.
+try { include "core/test_invoke_argumentcollection_spread.cfm"; } catch (any e) { writeOutput("ERROR | core/test_invoke_argumentcollection_spread.cfm | " & e.message & chr(10)); }
 //   - reserved_word_identifiers / quoted_catch_type: follow-on to PR #32 — `new`
 //     as a method name, `extends`/`implements` as parameter names, and a quoted
 //     string catch type (`catch ("My.Type" e)`) are all soft constructs on


### PR DESCRIPTION
## Cross-engine gap: invoke() drops an `argumentCollection` key in its argument struct

`argumentCollection` is a special key on every CFML argument-passing surface. When the argument struct handed to the positional BIF `invoke(objectOrName, method, argStruct)` contains an `argumentCollection` key, Lucee spreads the **inner** struct into the callee's `arguments` scope — the same contract as `fn(argumentCollection = st)` and cfinvoke's `argumentCollection` attribute. RustCFML does not special-case the key: the inner struct is silently dropped (it neither spreads nor lands as a literal named argument), so declared params keep their defaults.

```cfml
function target(string name = "DEFAULT", string path = "P0") {
    return "name=" & arguments.name & " path=" & arguments.path;
}
invoke(o, "target", { argumentCollection = { name = "posts" } })
```

| engine | result |
|--------|--------|
| RustCFML 0.101.0 | `"name=DEFAULT path=P0"` ← inner struct dropped |
| Lucee 5.4.8.2 | `"name=posts path=P0"` (spread; unnamed param keeps its declared default) |

The plain 3-arg struct form `invoke(o, "target", { name = "posts", path = "/x" })` already agrees on both engines and is asserted as a control.

### What the test asserts

- **CONTROL:** the plain 3-arg struct form binds declared params (passes on both engines — wiring guard).
- A nested `argumentCollection` key is **spread**: the declared param it names receives the inner value, the param it does not name keeps its declared default.
- An inner struct naming every param binds them all.
- The spread also applies when invoking by component NAME (string first argument).
- The spread populates the callee's `arguments` scope even for a method with no declared params (presence-keyed via `listFindNoCase`, never order- or case-sensitive).
- The literal key `"argumentCollection"` itself must NOT leak into the callee — pins the fix shape (spread the inner struct, don't bind the key by name). Already true on both engines.

### Why it matters

Wheels rides this contract on every request. `$doubleCheckedLock()` forwards its `executeArgs` as `$invoke(method = ..., argumentCollection = executeArgs)`, and `$invoke()` pushes that struct through the engine's dynamic-invoke machinery. Controller class resolution (`$controller` → `$doubleCheckedLock` → `$createControllerClass`) runs on this path — an engine that drops the key hands the resolver EMPTY arguments, and every user controller action silently becomes a no-op. This was the single gap that made all user controller actions no-ops when booting the Wheels blog tutorial app.

This is a runtime gap (wrong values, no parse error), so the test is registered in `tests/runner.cfm`, placed immediately after `test_invoke_canonical_forms.cfm`. The new fixture `tests/core/InvokeArgCollTarget.cfc` lives next to the test.

### Verification

- **RustCFML 0.101.0** (release binary, full `tests/runner.cfm`): suite completes 3614/3618 across 435 suites — the only 4 failures are this test's spread assertions (`got: [name=DEFAULT path=P0]` / empty arguments scope); the control + literal-key guard pass.
- **Lucee 5.4.8.2** (CommandBox): all 6 assertions PASS — `SUMMARY: 6/6 passed / ALL TESTS PASSED`.
