### PR TITLE
test(core): cross-case struct write should update the key in place, not fork a second key

### DIFF
--- a/tests/core/test_struct_key_case_parity.cfm
+++ b/tests/core/test_struct_key_case_parity.cfm
@@ -1,0 +1,96 @@
+<cfscript>
+suiteBegin("Core: struct keys are case-insensitive on WRITE — cross-case writes update in place");
+
+// CFML structs are case-insensitive containers: a write through ANY casing of
+// an existing key must update that key IN PLACE. RustCFML 0.103.0 falls back
+// across case on READS (s.zip finds a key created as s["ZIP"]), but a
+// differently-cased WRITE forks the key — the same logical key ends up stored
+// twice with two independent values:
+//
+//   s = {a: 1}; s["A"] = 99;
+//     RustCFML 0.103.0 -> structCount=2, keys "a,A", s.a=1, s["A"]=99
+//     Lucee 5.4 / 7    -> structCount=1, every casing reads 99
+//
+// Target behavior (maintainer-stated: case preservation by default, Lucee
+// parity always): ONE key — the first-written casing wins the key list, and
+// later cross-case writes update the value without re-casing the stored key.
+//
+// The fork poisons any set-one-case / read-another-case flow: url/form params,
+// query columnList lookups, option/config struct merging — Wheels does all of
+// these constantly, so a forked key silently reads back a stale value.
+//
+// Note on key-CASING asserts: Lucee 5.x UPPERCASES unquoted struct-literal /
+// dot-notation keys ({count: 1} stores COUNT) while bracket-created keys
+// preserve their casing on every Lucee line. Exact-casing asserts below are
+// therefore limited to bracket-created keys; literal-created keys are only
+// asserted case-insensitively (CFML == is case-insensitive for strings).
+
+// --- cross-case BRACKET write onto a literal-created key (the fork) ---
+forkA = {a: 1};
+forkA["A"] = 99;
+assert("cross-case bracket write keeps ONE key (StructCount)",
+    structCount(forkA), 1);
+assert("StructKeyList holds exactly one element after cross-case write",
+    listLen(structKeyList(forkA)), 1);
+assert("the single surviving key is 'a' (case-insensitive compare)",
+    structKeyList(forkA), "a");
+assert("dot read returns the cross-case-written value", forkA.a, 99);
+assert("bracket read (lower) returns the cross-case-written value", forkA["a"], 99);
+assert("bracket read (upper) returns the cross-case-written value", forkA["A"], 99);
+
+// --- cross-case DOT write onto a bracket-created key ---
+forkB = structNew();
+forkB["zip"] = "30303";
+forkB.ZIP = "90210";
+assert("cross-case dot write keeps ONE key (StructCount)",
+    structCount(forkB), 1);
+assert("StructKeyList after cross-case dot write is just 'zip'",
+    structKeyList(forkB), "zip");
+assertTrue("first-written casing preserved EXACTLY in StructKeyList",
+    compare(structKeyList(forkB), "zip") == 0);
+assert("dot read (lower) sees the dot-written value", forkB.zip, "90210");
+assert("bracket read (first-written casing) sees the dot-written value",
+    forkB["zip"], "90210");
+assert("bracket read (write casing) sees the dot-written value",
+    forkB["ZIP"], "90210");
+
+// --- cross-case DOT write onto a literal-created key ---
+forkC = {a: 1};
+forkC.A = 99;
+assert("cross-case dot write onto literal key keeps ONE key",
+    structCount(forkC), 1);
+assert("dot read (original casing) returns the updated value", forkC.a, 99);
+
+// --- delete coherence after a cross-case write ---
+// On a conforming engine the cross-case write left ONE key, so deleting it
+// (under the original casing) empties the struct. A forked key survives.
+forkD = {name: "alpha"};
+forkD["NAME"] = "beta";
+structDelete(forkD, "name");
+assert("after cross-case write + structDelete, struct is EMPTY",
+    structCount(forkD), 0);
+
+// --- CONTROLS (already correct on both engines) ---
+// Cross-case READ fallback works; guards against a fix that breaks lookups.
+ctrlRead = {zip: "30303"};
+assert("CONTROL: cross-case dot read falls back", ctrlRead.ZIP, "30303");
+assert("CONTROL: cross-case bracket read falls back", ctrlRead["ZIP"], "30303");
+assertTrue("CONTROL: structKeyExists is case-insensitive",
+    structKeyExists(ctrlRead, "ZIP"));
+
+// Same-case writes round-trip through one key.
+ctrlWrite = {count: 1};
+ctrlWrite.count = 2;
+ctrlWrite["count"] = 3;
+assert("CONTROL: same-case writes keep one key", structCount(ctrlWrite), 1);
+assert("CONTROL: same-case write round-trips", ctrlWrite.count, 3);
+
+// structDelete is case-insensitive even without a prior cross-case write.
+ctrlDelete = {foo: 1, bar: 2};
+structDelete(ctrlDelete, "FOO");
+assert("CONTROL: structDelete is case-insensitive", structCount(ctrlDelete), 1);
+assertFalse("CONTROL: deleted key gone under its original casing",
+    structKeyExists(ctrlDelete, "foo"));
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -389,6 +389,12 @@ try { include "core/test_logical_short_circuit.cfm"; } catch (any e) { writeOutp
 //   - getFunctionCalledName: a UDF injected under multiple aliases reports the
 //     alias it was called by — the primitive WireBox delegation dispatches on.
 try { include "core/test_get_function_called_name.cfm"; } catch (any e) { writeOutput("ERROR | core/test_get_function_called_name.cfm | " & e.message & chr(10)); }
+//   - struct_key_case_parity: struct keys are case-insensitive on WRITE, not
+//     just read — a differently-cased write must update the existing key in
+//     place (one key; first-written casing wins the key list), never fork a
+//     second physical key. Surfaced booting Wheels (params / option structs
+//     written under one casing and read under another).
+try { include "core/test_struct_key_case_parity.cfm"; } catch (any e) { writeOutput("ERROR | core/test_struct_key_case_parity.cfm | " & e.message & chr(10)); }
 //   - delegate annotation metadata: bare + arbitrary-named property annotations
 //     are captured, and component-level annotations surface top-level in
 //     getComponentMetadata (Lucee parity) — the surface WireBox delegation reads.


### PR DESCRIPTION
## Cross-engine gap: a differently-cased struct WRITE forks the key instead of updating in place

CFML structs are case-insensitive containers. RustCFML already falls back across case on READS (`u.zip` finds a key created as `u["ZIP"]`), but a write through a different casing of an existing key creates a **second physical key** — the same logical key stored twice with two independent values:

```cfml
s = {a: 1};
s["A"] = 99;
```

| engine | `structCount(s)` | `structKeyList(s)` | `s.a` | `s["A"]` |
|--------|------------------|--------------------|-------|----------|
| RustCFML 0.105.0 | **2** | `"a,A"` | **1** | 99 |
| Lucee 5.4.8.2 | 1 | one key | 99 | 99 |

All three write paths fork, not just bracket-onto-literal:

```cfml
t = structNew();
t["zip"] = "30303";
t.ZIP = "90210";
// RustCFML: structCount=2, keys "zip,ZIP", t["zip"]="30303" (stale)
// Lucee:    structCount=1, keys "zip" (first-written casing preserved), every casing reads "90210"
```

Delete coherence breaks too: after a cross-case write, `structDelete(d, "name")` on RustCFML removes only the exactly-matching key and leaves the forked `NAME` behind; on Lucee the struct is empty.

Target behavior (the stated goal: **case preservation by default, Lucee parity always**): one key — the first-written casing wins the key list, and later cross-case writes update the value in place without re-casing the stored key.

### What the test asserts

- `structCount == 1` and a single-element `structKeyList` after a cross-case write, on all three write paths (bracket→literal key, dot→bracket key, dot→literal key)
- the last-written value is readable through every casing (dot, bracket original-case, bracket write-case)
- first-written casing is preserved **exactly** in `structKeyList` — asserted only for a bracket-created key. Lucee 5.x uppercases unquoted struct-literal / dot keys at creation (`{count:1}` stores `COUNT`), so an exact-casing assert on a literal-created key would be a false failure on a conforming engine; those keys are asserted case-insensitively instead.
- `structDelete` under the original casing after a cross-case write leaves the struct EMPTY
- CONTROLS (pass on both engines): cross-case read fallback, case-insensitive `structKeyExists`, same-case write round-trip, case-insensitive `structDelete`

### Why it matters

Set-one-case / read-another-case is everywhere in Wheels: url/form params merged into `params`, query `columnList` lookups, option/config struct merging (`structAppend` over caller-supplied option structs). With a forked key the read-side case-fallback finds the **stale** first key and silently returns the old value — no error, wrong data, the worst failure mode for a framework boot.

### Verification

- **RustCFML 0.105.0** (release binary, full `tests/runner.cfm` on this branch): suite completes 3621/3634 across 435 suites — the only 13 failures are this test's cross-case-write assertions (forked counts/keys/stale values as shown above); the 7 controls + 2 casing-matched-read consistency pins PASS. Identical 9/22 result with `RUSTCFML_JIT=0` and `RUSTCFML_JIT_THRESHOLD=1` — interpreter semantics, not JIT-specific.
- **Lucee 5.4.8.2** (CommandBox): all 22 PASS.
- Runtime gap (wrong values, no parse error) → registered in the core block of `tests/runner.cfm`.
