### PR TITLE
test(core): named-argument calls keep the arguments scope array-addressable (ArrayLen + arguments[1])

### DIFF
--- a/tests/core/test_named_args_array_view.cfm
+++ b/tests/core/test_named_args_array_view.cfm
@@ -1,0 +1,114 @@
+<cfscript>
+suiteBegin("Core: named-argument calls keep the arguments scope array-addressable");
+
+// On Lucee/ACF the arguments scope is a hybrid array/struct for NAMED calls
+// too, not just positional ones:
+//
+//   function s() { return ArrayLen(arguments) & "|" & arguments[1]; }
+//   s(name = "x")
+//     Lucee 5.4.8.2    -> "1|x"
+//     RustCFML 0.105.0 -> "0|" (ArrayLen == 0, arguments[1] is null)
+//
+// Positional calls index fine on RustCFML; only the ARRAY view of named calls
+// is missing. The STRUCT view (StructCount / structKeyExists / StructKeyList)
+// is already correct on both engines for named calls — asserted below as
+// controls so a regression there can't masquerade as this gap.
+//
+// For a function that DECLARES params, numeric indexing follows DECLARATION
+// order, independent of the order the named args were written at the call
+// site (verified on Lucee 5.4.8.2: d(second="B", first="A") -> ArrayLen == 2,
+// arguments[1] == "A", arguments[2] == "B"). On RustCFML 0.105.0 the declared
+// slots ARE numerically readable, but ArrayLen still reports 0.
+//
+// Real-world impact: Wheels' config setter $set() (vendor/wheels/Global.cfc)
+// is a PARAMLESS function that branches on the array view of its own
+// arguments scope:
+//
+//   public void function $set() {
+//       if (ArrayLen(arguments) > 1) { ...per-function settings... }
+//       else { application[appKey][StructKeyList(arguments)] = arguments[1]; }
+//   }
+//
+// Every Wheels config call is set(name = value) — a single NAMED argument. On
+// RustCFML arguments[1] returned null for that call shape, so every setting
+// was silently written as an empty value: set(dataSourceName = "wheels-dev")
+// left application.wheels.dataSourceName == "" and the entire ORM introspected
+// the wrong (default in-memory) database. No error anywhere — just a config
+// store full of blanks.
+
+// --- paramless probe: reports the shape of its own arguments scope ---
+function aavParamlessProbe() {
+    var view = {
+        arrayLen    = arrayLen(arguments),
+        structCount = structCount(arguments),
+        keys        = structKeyList(arguments),
+        first       = "(unreadable)"
+    };
+    try {
+        view.first = isNull(arguments[1]) ? "(null)" : arguments[1];
+    } catch (any e) {
+        view.first = "(error: " & e.message & ")";
+    }
+    return view;
+}
+
+// 1. The Wheels $set() shape: ONE named argument to a paramless function.
+aavNamed = aavParamlessProbe(dataSourceName = "wheels-dev");
+assert("paramless fn, one named arg -> ArrayLen(arguments) == 1",
+    aavNamed.arrayLen, 1);
+assert("paramless fn, one named arg -> arguments[1] is the value",
+    aavNamed.first, "wheels-dev");
+// struct view of the same call (CONTROL — already correct on both engines)
+assert("CONTROL: struct view of the named call -> StructCount == 1",
+    aavNamed.structCount, 1);
+assertTrue("CONTROL: struct view of the named call sees the key by name",
+    listFindNoCase(aavNamed.keys, "dataSourceName") gt 0);
+
+// 2. TWO named arguments: the exact ArrayLen(arguments) > 1 branch test that
+//    $set() uses to distinguish per-function settings from a global setting.
+aavNamedTwo = aavParamlessProbe(a = "x", b = "y");
+assert("paramless fn, two named args -> ArrayLen(arguments) == 2",
+    aavNamedTwo.arrayLen, 2);
+assert("CONTROL: struct view of the two-named call -> StructCount == 2",
+    aavNamedTwo.structCount, 2);
+
+// 3. Positional control (already correct on RustCFML — guards the wiring so a
+//    broken probe can't masquerade as the gap under test).
+aavPositional = aavParamlessProbe("wheels-dev");
+assert("CONTROL: positional call -> ArrayLen(arguments) == 1",
+    aavPositional.arrayLen, 1);
+assert("CONTROL: positional call -> arguments[1] is the value",
+    aavPositional.first, "wheels-dev");
+
+// --- declared-params probe: numeric index = declaration order ---
+function aavDeclaredProbe(any first, any second) {
+    var view = {
+        arrayLen = arrayLen(arguments),
+        slot1    = "(unreadable)",
+        slot2    = "(unreadable)"
+    };
+    try {
+        view.slot1 = isNull(arguments[1]) ? "(null)" : arguments[1];
+    } catch (any e) {
+        view.slot1 = "(error: " & e.message & ")";
+    }
+    try {
+        view.slot2 = isNull(arguments[2]) ? "(null)" : arguments[2];
+    } catch (any e) {
+        view.slot2 = "(error: " & e.message & ")";
+    }
+    return view;
+}
+
+// 4. Named args written OUT OF declaration order: the array view still counts
+//    the slots and indexes them in declaration order.
+aavDeclared = aavDeclaredProbe(second = "B", first = "A");
+assert("declared-params fn, named out-of-order -> ArrayLen(arguments) == 2",
+    aavDeclared.arrayLen, 2);
+assert("arguments[1] is the FIRST DECLARED param's value (declaration order)",
+    aavDeclared.slot1, "A");
+assert("arguments[2] is the SECOND DECLARED param's value (declaration order)",
+    aavDeclared.slot2, "B");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -365,6 +365,16 @@ try { include "core/test_application_metadata.cfm"; } catch (any e) { writeOutpu
 //     option-forwarding. Surfaced while booting Wheels (contentFor section
 //     detection reads StructKeyList(arguments)).
 try { include "core/test_named_args_no_numeric_alias.cfm"; } catch (any e) { writeOutput("ERROR | core/test_named_args_no_numeric_alias.cfm | " & e.message & chr(10)); }
+//   - named_args_array_view: the arguments scope of a NAMED-argument call must
+//     stay array-addressable (hybrid array/struct) exactly like a positional
+//     call — ArrayLen(arguments) counts the args and arguments[1] reads the
+//     first declared slot / first value. RustCFML returned ArrayLen == 0 for
+//     every named call (and null for arguments[1] on paramless fns), so
+//     Wheels' paramless config setter $set() — which branches on
+//     ArrayLen(arguments) > 1 and reads arguments[1] — silently wrote every
+//     setting as an empty value and the ORM introspected the wrong (default
+//     in-memory) database.
+try { include "core/test_named_args_array_view.cfm"; } catch (any e) { writeOutput("ERROR | core/test_named_args_array_view.cfm | " & e.message & chr(10)); }
 //   - param_dotted_lhs: the cfscript `param` shorthand must accept a dotted /
 //     scoped lvalue (`param arguments.obj.key = default`), not just a bare
 //     identifier. Surfaced while booting WireBox (Injector.cfc uses


### PR DESCRIPTION
## Cross-engine gap: named-argument calls lose the array view of the arguments scope

On Lucee/ACF the `arguments` scope is a hybrid array/struct for NAMED calls too, not just positional ones. On RustCFML the array view only exists for positional calls:

```cfml
function s() { return ArrayLen(arguments) & "|" & arguments[1]; }
s(name = "x");
```

| engine | `ArrayLen(arguments)` | `arguments[1]` | `StructCount(arguments)` |
|--------|----------------------|----------------|--------------------------|
| RustCFML 0.105.0 | **0** | **null** | 1 |
| Lucee 5.4.8.2 | 1 | `"x"` | 1 |

The gap has two layers:

- **paramless functions** (no declared params): a named call loses BOTH `ArrayLen` (reports 0) and numeric indexing (`arguments[1]` is null) — only the struct view survives.
- **declared-param functions**: the numeric slots ARE readable (and correctly follow declaration order — `d(second="B", first="A")` gives `arguments[1] == "A"` on both engines), but `ArrayLen(arguments)` still reports 0.

The struct view (`StructCount` / `structKeyExists` / `StructKeyList`) is correct on both engines for named calls — pinned as controls.

### What the test asserts

- paramless fn + ONE named arg → `ArrayLen(arguments) == 1` and `arguments[1]` is the value (the exact Wheels `$set()` shape)
- paramless fn + TWO named args → `ArrayLen(arguments) == 2` (the `ArrayLen(arguments) > 1` branch test `$set()` dispatches on)
- declared-params fn + named args written out of declaration order → `ArrayLen == 2`, with `arguments[1]` / `arguments[2]` following DECLARATION order, not call-site order (verified on Lucee before asserting)
- CONTROLS (pass on both engines): positional-call `ArrayLen`/indexing, struct view of named calls (`StructCount`, key present by name), declared-slot numeric reads

`arguments[1]` for the two-named paramless call is intentionally NOT asserted: with the probe's inputs, insertion order and key order are indistinguishable, so it is not a verified cross-engine contract.

### Why it matters for Wheels

Wheels' config setter is a paramless function that branches on the array view of its own arguments scope (`vendor/wheels/Global.cfc`):

```cfml
public void function $set() {
    if (ArrayLen(arguments) > 1) { ...per-function settings... }
    else { application[appKey][StructKeyList(arguments)] = arguments[1]; }
}
```

Every Wheels config call is `set(name = value)` — a single named argument. On RustCFML `arguments[1]` returned null for that shape, so the entire boot configuration was silently written as blanks: `set(dataSourceName = "wheels-dev")` left `application.wheels.dataSourceName == ""` and the ORM introspected the wrong (default in-memory) database. No error at the write site — the failure surfaces three layers away as "table not found" during model introspection. Root-caused while laddering the Wheels ORM to a full MVC round trip.

### Verification

- **RustCFML 0.105.0** (release binary): the suite fails exactly the 4 gap assertions (7/11 — `ArrayLen == 0` for all three named-call shapes, `arguments[1]` null for the paramless named call); all 7 controls PASS. Identical 7/11 with `RUSTCFML_JIT=0` and `RUSTCFML_JIT_THRESHOLD=1` — interpreter semantics, not JIT-specific. Re-verified on 0.105.0 after the v0.104/0.105 QoQ rework; unaffected.
- **Lucee 5.4.8.2** (CommandBox): all 11 PASS.
- Full `tests/runner.cfm` on this branch (RustCFML 0.105.0): **3619/3623 across 435 suites** — the only 4 failures are this suite's array-view assertions; no abort.
- Runtime gap (wrong values / silent nulls, no parse error) → registered in the core block of `tests/runner.cfm`.