### PR TITLE
test(core): undeclared callee must get a fresh, empty local — caller's local invisible to absence-checks/reads

### DIFF
--- a/tests/core/AbsenceLeakFixture.cfc
+++ b/tests/core/AbsenceLeakFixture.cfc
@@ -1,0 +1,34 @@
+component {
+
+	// Undeclared callee: must get a fresh, empty `local` regardless of the
+	// caller's same-named local.rv.
+	public struct function innerProbe() {
+		var r = {
+			seesRv   = StructKeyExists(local, "rv"),
+			rvIsNull = isNull(local.rv),
+			leaked   = ""
+		};
+		if (r.seesRv) r.leaked = toString(local.rv);
+		return r;
+	}
+
+	public struct function outerProbe() {
+		local.rv = false;
+		return innerProbe();
+	}
+
+	// The Wheels $callback() default-true tail: returns true unless THIS
+	// body set local.rv (it never does here).
+	public boolean function callbackTail() {
+		if (!StructKeyExists(local, "rv")) {
+			local.rv = true;
+		}
+		return local.rv;
+	}
+
+	public boolean function invokeWithAccumulator() {
+		local.rv = false; // caller's own working flag, same conventional name
+		return callbackTail();
+	}
+
+}

--- a/tests/core/test_local_scope_absence_leak.cfm
+++ b/tests/core/test_local_scope_absence_leak.cfm
@@ -1,0 +1,96 @@
+<cfscript>
+suiteBegin("Core: caller's local is invisible to an undeclared callee (absence checks)");
+
+// `local` is per-CALL: every invocation gets a fresh, EMPTY local scope. A
+// callee that never declares `local.rv` must not be able to SEE a caller's
+// `local.rv` — not via StructKeyExists(local, "rv"), not via isNull(local.rv),
+// not via a read. Lucee, Adobe CF, and BoxLang all agree.
+//
+// This is the READ/absence-check residual of the per-frame `local.X` fix that
+// shipped in v0.92.0 (PR #77, test_local_scope_frame_isolation.cfm). The
+// DECLARATION side is fixed — a callee's `local.x = ...` no longer clobbers
+// the caller — but a callee that never declares the name still sees the
+// caller's slot when it only reads or absence-checks:
+//
+//   function innerFn() { return StructKeyExists(local, "rv"); }
+//   function outerFn() { local.rv = false; return innerFn(); }
+//   outerFn()
+//     RustCFML 0.105.0 -> true  (and local.rv reads the caller's false;
+//                                isNull(local.rv) says false)
+//     Lucee 5.4.8.2    -> false (fresh empty local; isNull(local.rv) -> true)
+//
+// Why it matters for Wheels: the framework's pervasive default-true tail
+//
+//   if (!StructKeyExists(local, "rv")) { local.rv = true; }
+//   return local.rv;
+//
+// ($callback() in vendor/wheels/model/callbacks.cfc; the same absence-check
+// on local.rv appears in 8 framework files) read the CALLER's local.rv=false
+// through this leak, so every model callback chain "returned false" and
+// save() aborted before its INSERT — silently, with no error anywhere.
+//
+// Covered: the template-level shape, the component-method shape (Wheels
+// mixins are methods on one CFC), and a declares-first CONTROL that pins the
+// already-fixed #77 contract so the two cannot be conflated.
+
+// --- (1) Template-level: undeclared callee gets a fresh, empty local ---
+function absenceLeakInner() {
+	var r = {
+		seesRv   = StructKeyExists(local, "rv"),
+		rvIsNull = isNull(local.rv),
+		leaked   = ""
+	};
+	if (r.seesRv) r.leaked = toString(local.rv);
+	return r;
+}
+function absenceLeakOuter() {
+	local.rv = false;
+	return absenceLeakInner();
+}
+shape = absenceLeakOuter();
+assertFalse("template: StructKeyExists(local,'rv') is false in undeclared callee", shape.seesRv);
+assertTrue("template: isNull(local.rv) is true in undeclared callee", shape.rvIsNull);
+assert("template: caller's value is not readable through local.rv", shape.leaked, "");
+
+// --- (2) The exact Wheels default-true tail (the silent save()-killer) ---
+function absenceLeakCallbackTail() {
+	// verbatim shape of the $callback() tail
+	if (!StructKeyExists(local, "rv")) {
+		local.rv = true;
+	}
+	return local.rv;
+}
+function absenceLeakChainRunner() {
+	local.rv = false; // the caller's own accumulator, same conventional name
+	return absenceLeakCallbackTail();
+}
+assertTrue("template: default-true tail returns true (caller's false not inherited)",
+	absenceLeakChainRunner());
+
+// --- (3) CONTROL: a callee that DECLARES local.rv first owns its slot and
+//     the caller keeps hers — the v0.92.0 / PR #77 contract. Green on both
+//     engines; guards the wiring and pins that THIS test is about reads. ---
+function absenceLeakDeclaredInner() {
+	local.rv = "CALLEE";
+	return "sees=" & StructKeyExists(local, "rv") & "|val=" & local.rv;
+}
+function absenceLeakDeclaredOuter() {
+	local.rv = false;
+	var got = absenceLeakDeclaredInner();
+	return got & "|callerRv=" & toString(local.rv);
+}
+assert("CONTROL: declaring callee sees its own value; caller's survives",
+	absenceLeakDeclaredOuter(), "sees=true|val=CALLEE|callerRv=false");
+
+// --- (4) Component-method shape: caller and callee are methods on the same
+//     CFC, exactly how Wheels mixins run ($invokeMethod -> $callback) ---
+o = createObject("component", "AbsenceLeakFixture");
+cshape = o.outerProbe();
+assertFalse("component: StructKeyExists(local,'rv') is false in undeclared callee method", cshape.seesRv);
+assertTrue("component: isNull(local.rv) is true in undeclared callee method", cshape.rvIsNull);
+assert("component: caller's value is not readable through local.rv", cshape.leaked, "");
+assertTrue("component: default-true tail returns true across methods",
+	o.invokeWithAccumulator());
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -255,6 +255,18 @@ try { include "native/test_cfc_extends_rust.cfm"; } catch (any e) { writeOutput(
 //     which degrades to a non-object silently instead of aborting. Both
 //     modes fail their assertions without taking down the run.
 try { include "core/test_local_at_template_scope.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_at_template_scope.cfm | " & e.message & chr(10)); }
+//   - local_scope_absence_leak: a callee that never declares `local.rv` must
+//     get a fresh, EMPTY local — StructKeyExists(local, "rv") false and
+//     isNull(local.rv) true even when the caller holds a same-named local.rv.
+//     READ-side residual of the v0.92.0 per-frame fix (PR #77,
+//     test_local_scope_frame_isolation.cfm): declarations are isolated, but
+//     absence-checks/reads still see the caller's slot. Surfaced booting
+//     Wheels: the $callback() default-true tail
+//     `if (!StructKeyExists(local, "rv")) { local.rv = true; }` inherited the
+//     caller's false, so every model callback chain failed and save() aborted
+//     before its INSERT, silently. Runtime-level (wrong values, no parse
+//     error), so registration is safe.
+try { include "core/test_local_scope_absence_leak.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_scope_absence_leak.cfm | " & e.message & chr(10)); }
 try { include "oop/test_metadata_name_value.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_metadata_name_value.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_script_syntax_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_script_syntax_body.cfm | " & e.message & chr(10)); }
 try { include "functions/test_expandpath_trailing_slash.cfm"; } catch (any e) { writeOutput("ERROR | functions/test_expandpath_trailing_slash.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

`local` is per-call: every invocation gets a fresh, **empty** local scope. v0.92.0 (PR #77) fixed the declaration side — a callee's `local.x = ...` no longer clobbers the caller — but the **read side still leaks**: a callee that never declares `local.rv` can still see the caller's `local.rv` via `StructKeyExists(local, "rv")`, `isNull(local.rv)`, and plain reads.

```cfm
function innerFn() { return StructKeyExists(local, "rv"); }
function outerFn() { local.rv = false; return innerFn(); }
writeOutput(outerFn());
```

| Engine | `outerFn()` | `isNull(local.rv)` in callee |
|---|---|---|
| RustCFML 0.105.0 | `true` (and `local.rv` reads the caller's `false`) | `false` |
| Lucee 5.4.8.2 | `false` | `true` |

Same result template-level and component-method-level, and in all three execution modes (default, `RUSTCFML_JIT=0`, `RUSTCFML_JIT_THRESHOLD=1`).

## What the test asserts

`tests/core/test_local_scope_absence_leak.cfm` + fixture `tests/core/AbsenceLeakFixture.cfc`:

1. **Template-level**: an undeclared callee sees `StructKeyExists(local, "rv") == false`, `isNull(local.rv) == true`, and cannot read any caller value through `local.rv`.
2. **The exact Wheels default-true tail** — `if (!StructKeyExists(local, "rv")) { local.rv = true; } return local.rv;` — returns `true` even when the caller holds `local.rv = false`.
3. **CONTROL (green on both engines)**: a callee that *declares* `local.rv` first owns its own slot and the caller's value survives — pins the already-fixed #77 contract (`test_local_scope_frame_isolation.cfm`) so the declaration and read contracts can't be conflated.
4. **Component-method shape**: the same probes as methods on one CFC — exactly how Wheels mixins run.

On RustCFML 0.105.0: 1/9 pass (only the CONTROL). On Lucee: 9/9.

## Why it matters for Wheels

This was the silent ORM-save killer in the Wheels boot ladder. Wheels' `$callback()` (`vendor/wheels/model/callbacks.cfc`) ends with the default-true tail above, and the same `StructKeyExists(local, "rv")` absence-check appears in 8 framework files. `$callback()`'s caller also keeps a `local.rv` accumulator (the framework's universal return-value convention), so on RustCFML the tail inherited the caller's `local.rv = false` through the leak: every model callback chain "returned false", and `save()` aborted before issuing its INSERT — no error, no INSERT, nothing to debug from. Fixing the absence-check/read side completes per-frame `local` and unblocks the model callback chain (and every other default-true fallback in the framework).

## Verification

- **RED** — RustCFML 0.105.0 (release binary): `1/9 passed (8 failed)`; identical under default JIT, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`. The 8 failures are exactly the absence-check/read assertions; the declares-first CONTROL passes, confirming the v0.92.0 declaration fix is intact.
- **GREEN** — Lucee 5.4.8.2 (CommandBox): `9/9 passed`.
- The gap is runtime-level (wrong values, no parse error), so the test is registered in `tests/runner.cfm`.
- Full `tests/runner.cfm` on this branch (RustCFML 0.105.0): **3613/3621 across 435 suites** — the only 8 failures are this suite's absence-check/read assertions; no abort.