### PR TITLE
test(core): bare call to a UDF named 'new' dispatches; method call on a null receiver throws

### DIFF
--- a/tests/core/NewUdfFixture.cfc
+++ b/tests/core/NewUdfFixture.cfc
@@ -1,0 +1,43 @@
+// Fixture for tests/core/test_new_udf_dispatch_and_null_call.cfm.
+//
+// `new` is a SOFT keyword on Lucee/Adobe CF/BoxLang: it introduces the
+// `new Foo()` operator, but it is equally legal as a function name, and a
+// BARE sibling call to it — `new (argumentCollection = {...})` with no
+// component path after the keyword — dispatches to the UDF. Wheels' model
+// creation depends on exactly this shape (vendor/wheels/model/create.cfc:32):
+//
+//     local.rv = new (argumentCollection = arguments);
+//     local.rv.save(...);
+component {
+
+	// The sibling method literally named `new` (the Wheels model shape).
+	public any function new(struct properties = {}) {
+		return {
+			marker = "NEW-RAN",
+			props  = arguments.properties
+		};
+	}
+
+	// The Wheels create() shape: a BARE call to the sibling UDF named `new`,
+	// forwarding arguments via argumentCollection.
+	public any function createViaBare() {
+		return new (argumentCollection = {properties = {a = 1}});
+	}
+
+	// Control: the same call, explicitly this-qualified (works on both engines).
+	public any function createViaThis() {
+		return this.new(argumentCollection = {properties = {a = 1}});
+	}
+
+	// Null source for the second half of the test: a function that returns
+	// nothing yields a null receiver, independent of the bare-new gap above.
+	public any function giveNothing() {
+		return;
+	}
+
+	// Real receiver for the method-call-on-null control.
+	public string function save(numeric a = 0) {
+		return "SAVED:" & arguments.a;
+	}
+
+}

--- a/tests/core/test_new_udf_dispatch_and_null_call.cfm
+++ b/tests/core/test_new_udf_dispatch_and_null_call.cfm
@@ -1,0 +1,87 @@
+<cfscript>
+suiteBegin("Core: bare call to a UDF named 'new' dispatches; method call on null throws");
+
+// Two RUNTIME silent-failure gaps that compose into the worst failure mode —
+// a framework API that reports success without doing anything:
+//
+// (C1) A bare sibling call to a UDF literally named `new` must dispatch to
+//      that UDF. `new` is a soft keyword: with no component path after it,
+//      `new (argumentCollection = {...})` is a plain function call, not the
+//      new-operator.
+//
+//          component {
+//              public any function new(struct properties = {}) { return {...}; }
+//              public any function createViaBare() {
+//                  return new (argumentCollection = {properties = {a = 1}});
+//              }
+//          }
+//
+//          o.createViaBare()
+//            RustCFML 0.105.0 -> NULL (the UDF never runs)
+//            Lucee 5.4.8.2    -> the struct returned by the UDF
+//          o.createViaThis() — this.new(argumentCollection=...) — works on BOTH.
+//
+// (C2) A method call on a null receiver must throw.
+//
+//          r = <null>; r.save(a = 1)
+//            RustCFML 0.105.0 -> silently evaluates to null (no error)
+//            Lucee 5.4.8.2    -> throws
+//
+// Why it matters for Wheels: model creation is exactly this composition
+// (vendor/wheels/model/create.cfc:32):
+//
+//          local.rv = new (argumentCollection = arguments);
+//          local.rv.save(...);
+//          return local.rv;
+//
+// On RustCFML the `new()` UDF never ran (C1: local.rv = null), `.save()` on
+// the null no-op'd (C2: no throw), and create() returned "success" while no
+// row was ever written. Either gap alone would at least be loud; composed,
+// they produce silent fake success.
+
+gapCFixture = new NewUdfFixture();
+
+// --- (C1) bare new(argumentCollection=...) dispatches to the sibling UDF ---
+gapCBareResult = gapCFixture.createViaBare();
+assertTrue("bare new() returned a value (the UDF ran)", !isNull(gapCBareResult));
+if (!isNull(gapCBareResult) && isStruct(gapCBareResult) && structKeyExists(gapCBareResult, "marker")) {
+    assert("bare new() dispatched to the sibling UDF (marker)",
+        gapCBareResult.marker, "NEW-RAN");
+    assert("argumentCollection was forwarded through the bare call",
+        gapCBareResult.props.a, 1);
+} else {
+    assert("bare new() dispatched to the sibling UDF (marker)",
+        "(no struct returned)", "NEW-RAN");
+    assert("argumentCollection was forwarded through the bare call",
+        "(no struct returned)", 1);
+}
+
+// --- (C1 CONTROL) explicit this.new(argumentCollection=...) — green on both ---
+gapCThisResult = gapCFixture.createViaThis();
+if (!isNull(gapCThisResult) && isStruct(gapCThisResult) && structKeyExists(gapCThisResult, "marker")) {
+    assert("CONTROL: this.new() dispatched to the UDF (marker)",
+        gapCThisResult.marker, "NEW-RAN");
+} else {
+    assert("CONTROL: this.new() dispatched to the UDF (marker)",
+        "(no struct returned)", "NEW-RAN");
+}
+
+// --- (C2) a method call on a null receiver must throw ---
+// Fresh, uniquely-named state struct: flag persistence across catch blocks
+// has engine-specific quirks, and the runner shares one variables scope
+// across every included test.
+gapCNullCallState = { threw = false, observed = "unset" };
+gapCNullReceiver = gapCFixture.giveNothing(); // returns nothing -> null receiver
+try {
+    gapCNullOutcome = gapCNullReceiver.save(a = 1);
+    gapCNullCallState.observed = isNull(gapCNullOutcome) ? "(null)" : toString(gapCNullOutcome);
+} catch (any e) {
+    gapCNullCallState.threw = true;
+}
+assertTrue("method call on a null receiver throws", gapCNullCallState.threw);
+
+// --- (C2 CONTROL) the same method call on a real receiver — green on both ---
+assert("CONTROL: save(a=1) on a real object works", gapCFixture.save(a = 1), "SAVED:1");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -389,6 +389,11 @@ try { include "core/test_logical_short_circuit.cfm"; } catch (any e) { writeOutp
 //   - getFunctionCalledName: a UDF injected under multiple aliases reports the
 //     alias it was called by — the primitive WireBox delegation dispatches on.
 try { include "core/test_get_function_called_name.cfm"; } catch (any e) { writeOutput("ERROR | core/test_get_function_called_name.cfm | " & e.message & chr(10)); }
+//   - new_udf_dispatch_and_null_call: a bare sibling call to a UDF literally
+//     named `new` (the Wheels model-create shape) must dispatch to the UDF,
+//     and a method call on a null receiver must throw — composed, the two
+//     gaps turn Wheels' create() into a silent no-op that reports success.
+try { include "core/test_new_udf_dispatch_and_null_call.cfm"; } catch (any e) { writeOutput("ERROR | core/test_new_udf_dispatch_and_null_call.cfm | " & e.message & chr(10)); }
 //   - delegate annotation metadata: bare + arbitrary-named property annotations
 //     are captured, and component-level annotations surface top-level in
 //     getComponentMetadata (Lucee parity) — the surface WireBox delegation reads.


### PR DESCRIPTION
## Two composing silent-failure gaps

Both are runtime-level (wrong values / silent nulls — no parse errors), so runner registration is safe.

### (C1) Bare call to a UDF named `new` evaluates to null instead of dispatching

`new` is a soft keyword on Lucee/Adobe CF/BoxLang: with no component path after it, `new (argumentCollection = {...})` is a plain sibling function call, not the new-operator. RustCFML 0.105.0 evaluates the bare call to NULL — the UDF never runs (likely parsed as the new-operator with nothing to instantiate). The explicit `this.new(...)` form already works on both engines (that contract landed with `NewMethodFixture.cfc`); this gap is specifically the bare, unqualified call.

```cfml
component {
    public any function new(struct properties = {}) {
        return { marker = "NEW-RAN", props = arguments.properties };
    }
    public any function createViaBare() {
        return new (argumentCollection = {properties = {a = 1}});
    }
}
```

| expression | RustCFML 0.105.0 | Lucee 5.4.8.2 |
|---|---|---|
| `o.createViaBare()` | `null` — the UDF never runs | struct, `marker = "NEW-RAN"` |
| `o.createViaThis()` (`this.new(...)`) | struct, `marker = "NEW-RAN"` | struct, `marker = "NEW-RAN"` |

### (C2) Method call on a null receiver silently returns null

| expression | RustCFML 0.105.0 | Lucee 5.4.8.2 |
|---|---|---|
| `r = <null-returning call>; r.save(a = 1)` | silently evaluates to `null` | throws |

## What the test asserts

`tests/core/test_new_udf_dispatch_and_null_call.cfm` + fixture `tests/core/NewUdfFixture.cfc`:

1. **(C1)** `createViaBare()` returns a non-null struct whose `marker` proves the `new()` UDF executed, and the `argumentCollection` payload arrived (`props.a == 1`).
2. **(C1 control)** `createViaThis()` dispatches to the same UDF — green on both engines, isolating the gap to the bare form.
3. **(C2)** `.save(a = 1)` on a null receiver (produced by a return-nothing function, independent of C1) must throw — try/catch with a uniquely-named state struct so the flag survives the catch on every engine.
4. **(C2 control)** the same `.save(a = 1)` on a real object works — green on both engines.

## Why it matters for Wheels

This is exactly how the composed gaps bit while laddering Wheels' ORM to a full MVC round trip. Wheels model creation is this composition, verbatim (`vendor/wheels/model/create.cfc:32`):

```cfml
local.rv = new (argumentCollection = arguments);  // (C1) null on RustCFML — the new() UDF never ran
local.rv.save(...);                               // (C2) silent no-op on the null receiver
return local.rv;                                  // create() reports success; no row was ever written
```

On RustCFML, `model("Post").create(...)` returned "success" with zero rows saved and zero errors raised. Either gap alone would at least be loud — C1 with throwing null-calls would crash immediately at `.save()`; C2 with a working bare `new` never sees a null receiver. Composed, they produce the worst failure mode: silent fake success.

## Verification

- **RustCFML 0.105.0** (release binary): suite FAILS as intended — 2/6, only the two controls pass; the four gap assertions fail (`bare new() returned a value`, `marker dispatch`, `argumentCollection forwarded`, `method call on a null receiver throws`). Identical under `RUSTCFML_JIT=0` and `RUSTCFML_JIT_THRESHOLD=1`.
- **Lucee 5.4.8.2** (CommandBox 6.3.2): 6/6 PASS (harness assert helpers renamed `chk*` locally for the CommandBox run because it shadows `assert`; test logic identical).
- Full `tests/runner.cfm` on this branch (RustCFML 0.105.0): **3614/3618 across 435 suites** — the only 4 failures are this suite's gap assertions; no abort.