### PR TITLE
test(core): invoke() should deliver undeclared argument-struct keys to the callee

### DIFF
--- a/tests/core/InvokeUndeclaredKeysFixture.cfc
+++ b/tests/core/InvokeUndeclaredKeysFixture.cfc
@@ -1,0 +1,30 @@
+// Fixture for the invoke()-undeclared-keys test. Each probe reports which
+// keys actually reached its arguments scope.
+component {
+
+	// Paramless target: every key in the argument struct is "undeclared".
+	public string function paramless() {
+		return "hasX=" & StructKeyExists(arguments, "x")
+			& "|hasLocked=" & StructKeyExists(arguments, "$locked");
+	}
+
+	// Declared-param target: x is declared, $locked is not.
+	public string function declared(string x = "(default)") {
+		return "x=" & arguments.x
+			& "|hasLocked=" & StructKeyExists(arguments, "$locked");
+	}
+
+	// Mirrors the re-entry guard shape of Wheels' $readFlash()/$simpleLock().
+	public string function guarded() {
+		if (!StructKeyExists(arguments, "$locked")) {
+			return "NOT-LOCKED";
+		}
+		return "LOCKED-OK";
+	}
+
+	// In-context dynamic dispatch control: this[name](argumentCollection = st).
+	public string function callViaThisBracket(required string m, required struct a) {
+		return this[arguments.m](argumentCollection = arguments.a);
+	}
+
+}

--- a/tests/core/test_invoke_undeclared_keys.cfm
+++ b/tests/core/test_invoke_undeclared_keys.cfm
@@ -1,0 +1,83 @@
+<cfscript>
+suiteBegin("Core: invoke() delivers undeclared argument-struct keys");
+
+// ============================================================
+// Background  (companion to test_invoke_canonical_forms.cfm; sibling of the
+//              argumentCollection-spread suite)
+// ============================================================
+// The argument struct handed to the positional BIF
+// invoke(objectOrName, method, argStruct) is a NAMED-ARGUMENT COLLECTION:
+// Lucee 5/6/7 and Adobe ColdFusion deliver EVERY key to the callee's
+// arguments scope — declared parameter or not, and even when the target
+// method declares no parameters at all. It is the same contract the engines
+// already honor for undeclared named args on a direct call
+// (test_undeclared_named_args.cfm covers that direct-call flavor).
+//
+// RustCFML binds only DECLARED parameter names when marshaling the invoke()
+// argument struct; undeclared keys are silently dropped, and a paramless
+// target receives an EMPTY arguments scope:
+//
+//   function declared(string x = "(default)") {...}   // $locked undeclared
+//   invoke(o, "declared", { x: "hello", "$locked": true })
+//     Lucee 5.4.8.2    -> x=hello, $locked present
+//     RustCFML 0.105.0 -> x=hello, $locked DROPPED
+//
+//   function paramless() {...}
+//   invoke(o, "paramless", { x: 1, "$locked": true })
+//     Lucee 5.4.8.2    -> both keys present
+//     RustCFML 0.105.0 -> arguments scope EMPTY
+//
+// The CONTROLS below already agree on both engines and point at the fix
+// shape: a direct named-arg call obj.m(argumentCollection = st) and an
+// in-context dynamic dispatch this[name](argumentCollection = st) both
+// deliver ALL keys — only the invoke() marshaling path filters by the
+// declared parameter list. (The `argumentCollection` key nested INSIDE the
+// invoke() argument struct is a SEPARATE contract covered by its own suite;
+// this one is about plain keys.)
+//
+// Wheels rides the undeclared-key contract on every request: $simpleLock()
+// re-enters its callback through $invoke() with a "$locked" guard key, and
+// the guarded method ($readFlash, ...) checks
+// StructKeyExists(arguments, "$locked") to know it already holds the lock
+// (vendor/wheels/Global.cfc). When the key is dropped the guard never trips,
+// $readFlash -> $simpleLock -> $readFlash recurses to depth 256, and every
+// request 500s.
+// ============================================================
+
+fixture = createObject("component", "InvokeUndeclaredKeysFixture");
+
+// --- CONTROL: declared params bind through invoke() on both engines ---
+// Guards the wiring: if this fails, invoke() itself is broken, not the
+// undeclared-key marshaling under test.
+assert("CONTROL: declared param binds through invoke()",
+	invoke(fixture, "declared", { x: "hello" }),
+	"x=hello|hasLocked=false");
+
+// --- the gap: an undeclared key must arrive alongside a declared param ---
+assert("undeclared key is delivered alongside a declared param",
+	invoke(fixture, "declared", { x: "hello", "$locked": true }),
+	"x=hello|hasLocked=true");
+
+// --- the gap: a paramless target must receive ALL keys ---
+assert("paramless target receives every argument-struct key",
+	invoke(fixture, "paramless", { x: 1, "$locked": true }),
+	"hasX=true|hasLocked=true");
+
+// --- the gap, in the exact Wheels guard shape ---
+assert("re-entry guard keyed on an undeclared $-prefixed key trips",
+	invoke(fixture, "guarded", { "$locked": true }),
+	"LOCKED-OK");
+
+// --- CONTROL: direct named-arg call delivers ALL keys on both engines ---
+args = { x: 9, "$locked": true };
+assert("CONTROL: obj.m(argumentCollection = st) delivers undeclared keys",
+	fixture.paramless(argumentCollection = args),
+	"hasX=true|hasLocked=true");
+
+// --- CONTROL: in-context dynamic dispatch delivers ALL keys on both engines ---
+assert("CONTROL: this[name](argumentCollection = st) delivers undeclared keys",
+	fixture.callViaThisBracket("paramless", args),
+	"hasX=true|hasLocked=true");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -18,6 +18,16 @@ try { include "core/test_function_scope_capture.cfm"; } catch (any e) { writeOut
 try { include "core/test_closure_env_leak.cfm"; } catch (any e) { writeOutput("ERROR | core/test_closure_env_leak.cfm | " & e.message & chr(10)); }
 try { include "core/test_compound_assignment.cfm"; } catch (any e) { writeOutput("ERROR | core/test_compound_assignment.cfm | " & e.message & chr(10)); }
 try { include "core/test_undeclared_named_args.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undeclared_named_args.cfm | " & e.message & chr(10)); }
+//   - invoke_undeclared_keys: the argument struct of the positional BIF
+//     invoke(obj, method, argStruct) is a named-argument collection — EVERY
+//     key must reach the callee's arguments scope, declared param or not,
+//     paramless targets included. RustCFML bound only declared names and
+//     silently dropped the rest (direct obj.m(argumentCollection=st) and
+//     in-context this[name](argumentCollection=st) already deliver all keys;
+//     only the invoke() marshaling path filtered). Surfaced while booting
+//     Wheels: $simpleLock()'s "$locked" re-entry guard key never arrived, so
+//     $readFlash recursed to depth 256 and 500'd every request.
+try { include "core/test_invoke_undeclared_keys.cfm"; } catch (any e) { writeOutput("ERROR | core/test_invoke_undeclared_keys.cfm | " & e.message & chr(10)); }
 try { include "core/test_struct_method_sequential.cfm"; } catch (any e) { writeOutput("ERROR | core/test_struct_method_sequential.cfm | " & e.message & chr(10)); }
 try { include "core/test_include_scope_capture.cfm"; } catch (any e) { writeOutput("ERROR | core/test_include_scope_capture.cfm | " & e.message & chr(10)); }
 try { include "core/test_operators.cfm"; } catch (any e) { writeOutput("ERROR | core/test_operators.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

The argument struct handed to the positional BIF `invoke(objectOrName, method, argStruct)` is a **named-argument collection**: Lucee (and Adobe CF) deliver *every* key to the callee's `arguments` scope — declared parameter or not, even when the target method declares no parameters at all. RustCFML 0.105.0 binds only **declared** parameter names and silently drops the rest; a paramless target receives an empty `arguments` scope.

```cfml
component {  // fixture
	public string function declared(string x = "(default)") {
		return "x=" & arguments.x & "|hasLocked=" & StructKeyExists(arguments, "$locked");
	}
	public string function paramless() {
		return "hasX=" & StructKeyExists(arguments, "x") & "|hasLocked=" & StructKeyExists(arguments, "$locked");
	}
}

invoke(o, "declared",  { x: "hello", "$locked": true });
invoke(o, "paramless", { x: 1, "$locked": true });
```

| Call | Lucee 5.4.8.2 | RustCFML 0.105.0 |
|---|---|---|
| `invoke(o, "declared", { x: "hello", "$locked": true })` | `x=hello\|hasLocked=true` | `x=hello\|hasLocked=false` — undeclared key dropped |
| `invoke(o, "paramless", { x: 1, "$locked": true })` | `hasX=true\|hasLocked=true` | `hasX=false\|hasLocked=false` — arguments scope empty |
| `o.paramless(argumentCollection = st)` (control) | all keys delivered | all keys delivered — already correct |
| `this[name](argumentCollection = st)` in-context (control) | all keys delivered | all keys delivered — already correct |

The two passing controls point at the fix shape: the direct named-arg call path and the in-context dynamic-dispatch path already deliver all keys — only the `invoke()` BIF's marshaling path filters the struct through the declared parameter list. RustCFML also already honors undeclared *named args* on a direct call (`test_undeclared_named_args.cfm`); this is the same contract on the `invoke()` surface.

Sibling gap: #89 covers the **separate** marshaling contract of an `argumentCollection` key nested *inside* the `invoke()` argument struct (`invoke(o, "target", { argumentCollection: { name: "posts" } })` must spread the inner struct). This suite is about plain keys; the assertions don't overlap.

## What the test asserts

- CONTROL (green on both engines): a declared param binds through `invoke()` — guards the wiring.
- An undeclared key (`"$locked"`) arrives alongside a declared param. *(red on RustCFML)*
- A paramless target receives every argument-struct key. *(red on RustCFML)*
- A re-entry guard keyed on an undeclared `$`-prefixed key trips — the exact Wheels shape. *(red on RustCFML)*
- CONTROL (green on both engines): `obj.m(argumentCollection = st)` delivers undeclared keys.
- CONTROL (green on both engines): `this[name](argumentCollection = st)` delivers undeclared keys.

## Why it matters for Wheels

This took down every request while laddering Wheels up to a full MVC round trip. Wheels serializes flash access through `$simpleLock()`, which re-enters its callback via `$invoke()` with a `"$locked"` guard key in the argument struct; the guarded method (`$readFlash()`) checks `StructKeyExists(arguments, "$locked")` to know it already holds the lock (`vendor/wheels/Global.cfc`). On RustCFML the key was dropped in `invoke()` marshaling, the guard never tripped, and `$readFlash -> $simpleLock -> $readFlash` recursed until the depth-256 limit — a 500 on every single request.

## Verification

- **RustCFML 0.105.0** (release binary): suite fails 3/6 — exactly the three gap assertions; the declared-param control and both `argumentCollection` controls pass. Identical results with `RUSTCFML_JIT=0` and with `RUSTCFML_JIT_THRESHOLD=1`.
- **Lucee 5.4.8.2** (CommandBox task runner; same assertions transliterated to a `chk()` harness because CommandBox shadows `assert`): 6/6 pass.
- Full `tests/runner.cfm` on this branch (RustCFML 0.105.0): **3615/3618 across 435 suites** — the only 3 failures are this suite's undeclared-key assertions; no abort.