### PR TITLE
test(core): local.X write must not shadow arguments.X reads in the same frame

### DIFF
--- a/tests/core/ArgsShadowFixture.cfc
+++ b/tests/core/ArgsShadowFixture.cfc
@@ -1,0 +1,17 @@
+component {
+
+	// Mirrors the vendor/wheels/Global.cfc URLFor() shape that surfaced the
+	// local-shadows-arguments gap: a declared `string params = ""` argument, a
+	// same-named route-params struct built in the local scope, and a late
+	// `Len(arguments.params)` check that appends the query string. With the
+	// gap, Len() sees the local struct (always truthy) and the struct itself
+	// is concatenated into the URL.
+	public string function buildUrl(string controller = "posts", string params = "") {
+		local.params = {controller: arguments.controller, action: "index"};
+		local.rv = "/" & local.params.controller;
+		if (Len(arguments.params)) {
+			local.rv = local.rv & "?" & arguments.params;
+		}
+		return local.rv;
+	}
+}

--- a/tests/core/test_local_shadows_arguments.cfm
+++ b/tests/core/test_local_shadows_arguments.cfm
@@ -1,0 +1,112 @@
+<cfscript>
+suiteBegin("Core: local.X write must not shadow arguments.X reads in the same frame");
+
+// ============================================================
+// Background
+// ============================================================
+// `local` and `arguments` are SEPARATE scopes within one call frame. Writing
+// `local.X` (or `var X`) creates/updates a slot in the LOCAL scope only; an
+// explicit `arguments.X` read afterwards must keep resolving to the argument
+// value — the passed value, or the declared default. RustCFML 0.108.0
+// collapses the two views after the local write: every subsequent
+// `arguments.X` read returns the local value instead.
+//
+//   function f(string params = "") {
+//       local.params = {controller: "x"};
+//       return Len(arguments.params);
+//   }
+//   f()                  RustCFML 0.108.0 -> 1 (the struct!)   Lucee -> 0 ("" default)
+//   f(params = "page=2") RustCFML 0.108.0 -> the struct        Lucee -> "page=2"
+//
+// Bare reads are NOT part of the gap: an unscoped `X` resolves through the
+// scope cascade (local before arguments) on every engine, so after the local
+// write a bare `params` IS the struct on Lucee too. The controls below pin
+// that, so a fix cannot overcorrect bare-name resolution. Reads BEFORE the
+// local write, distinct names, and explicit arguments-scope writes are also
+// already correct — only the read-after-local-write path aliases.
+//
+// Scoped-resolution sibling of the local-scope family: #77 (callee local
+// declaration clobbered the caller's; fixed v0.92.0) and #93 (caller's local
+// visible to an undeclared callee's absence-checks; open) covered local-vs-
+// local across frames — this one conflates the local and arguments views of a
+// SINGLE frame.
+// ============================================================
+
+// --- (1) THE GAP: defaulted, unpassed argument survives a same-name local write ---
+function argShadowDefaulted(string params = "") {
+	local.params = {controller: "x"};
+	return Len(arguments.params) & "|" & IsSimpleValue(arguments.params);
+}
+assert("unpassed default survives a local.X write (Len 0, still simple)",
+	argShadowDefaulted(), "0|true");
+
+// --- (2) THE GAP: a PASSED value also survives ---
+function argShadowPassed(string params = "") {
+	local.params = {controller: "x"};
+	return toString(arguments.params);
+}
+assert("passed value survives a local.X write",
+	argShadowPassed(params = "page=2"), "page=2");
+
+// --- (3) THE GAP: the `var X` form (identical semantics to local.X) ---
+function argShadowVarForm(string params = "") {
+	var params = {controller: "x"};
+	return Len(arguments.params);
+}
+assert("a `var X` write does not shadow arguments.X either",
+	argShadowVarForm(), 0);
+
+// --- (4) THE GAP: read-before-write is already correct; read-after must match ---
+function argShadowPrePost(string params = "") {
+	var pre = Len(arguments.params);
+	local.params = {controller: "x"};
+	return pre & "|" & Len(arguments.params);
+}
+assert("arguments.X reads identical before AND after the local write",
+	argShadowPrePost(), "0|0");
+
+// --- (5) CONTROL (green on both engines): bare X follows the scope cascade —
+//     local wins. Pins the boundary so a fix can't break bare-name reads. ---
+function argShadowBareRead(string params = "") {
+	local.params = {controller: "x"};
+	return IsStruct(params);
+}
+assertTrue("CONTROL: bare read resolves to the LOCAL struct (scope cascade)",
+	argShadowBareRead());
+
+// --- (6) CONTROL: a different local name leaves arguments.X alone ---
+function argShadowDistinct(string params = "") {
+	local.other = {controller: "x"};
+	return Len(arguments.params);
+}
+assert("CONTROL: a distinct local name leaves arguments.X alone",
+	argShadowDistinct(), 0);
+
+// --- (7) CONTROL: an explicit arguments-scope write lands in arguments ---
+function argShadowArgWrite(string params = "") {
+	arguments.params = "a=1";
+	return arguments.params;
+}
+assert("CONTROL: explicit arguments.X write then read round-trips",
+	argShadowArgWrite(), "a=1");
+
+// --- (8) CONTROL: the two slots stay separate in BOTH directions ---
+function argShadowBothWrites(string params = "") {
+	local.params = {controller: "x"};
+	arguments.params = "ARGWRITE";
+	return IsStruct(local.params) & "|" & toString(arguments.params);
+}
+assert("CONTROL: arguments.X write does not clobber local.X",
+	argShadowBothWrites(), "true|ARGWRITE");
+
+// --- (9/10) THE GAP, component-method shape — exactly how it bit Wheels'
+//     URLFor(): declared `string params = ""`, a same-named route-params
+//     struct in local, and a late Len(arguments.params) query-string check. ---
+argShadowFixture = createObject("component", "ArgsShadowFixture");
+assert("method: no query string when params was never passed",
+	argShadowFixture.buildUrl(), "/posts");
+assert("method: a passed params string reaches the query string intact",
+	argShadowFixture.buildUrl(params = "page=2"), "/posts?page=2");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -31,6 +31,19 @@ try { include "core/test_builtin_shadowing.cfm"; } catch (any e) { writeOutput("
 try { include "core/test_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_functions.cfm | " & e.message & chr(10)); }
 try { include "core/test_arrow_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_arrow_functions.cfm | " & e.message & chr(10)); }
 try { include "core/test_arguments_writeback.cfm"; } catch (any e) { writeOutput("ERROR | core/test_arguments_writeback.cfm | " & e.message & chr(10)); }
+//   - local_shadows_arguments: `local` and `arguments` are separate scopes
+//     within ONE frame — after `local.X = ...` (or `var X = ...`), an explicit
+//     `arguments.X` read must still resolve to the passed value / declared
+//     default, not the local value. Bare `X` reads (scope cascade: local wins)
+//     are pinned as controls so a fix can't overcorrect. Surfaced booting
+//     Wheels: URLFor() declares `string params = ""` and builds a route-params
+//     struct in `local.params`; its `Len(arguments.params)` query-string check
+//     saw the struct, so EVERY generated URL (linkTo / startFormTag /
+//     redirectTo) grew a ?%7Bcontroller...%7D= junk query string. Sibling of
+//     #77 (fixed v0.92.0) / #93 (open) — same scoped-name-resolution family,
+//     but conflating the local and arguments views of a single frame.
+//     Runtime-level (wrong values, no parse error), so registration is safe.
+try { include "core/test_local_shadows_arguments.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_shadows_arguments.cfm | " & e.message & chr(10)); }
 try { include "core/test_argument_reference_nested.cfm"; } catch (any e) { writeOutput("ERROR | core/test_argument_reference_nested.cfm | " & e.message & chr(10)); }
 try { include "core/test_language_features.cfm"; } catch (any e) { writeOutput("ERROR | core/test_language_features.cfm | " & e.message & chr(10)); }
 try { include "core/test_scopes.cfm"; } catch (any e) { writeOutput("ERROR | core/test_scopes.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

`local` and `arguments` are separate scopes within one call frame. Writing `local.X` (or `var X`) creates a slot in the local scope only — a later explicit `arguments.X` read must keep resolving to the argument value (the passed value, or the declared default). RustCFML 0.108.0 collapses the two views after the local write: every subsequent `arguments.X` read in the same function returns the LOCAL value.

```cfm
function f(string params = "") {
    local.params = {controller: "x"};
    return Len(arguments.params);
}
```

| Call | Lucee 5.4.8.2 | RustCFML 0.108.0 |
|---|---|---|
| `f()` (unpassed, default `""`) | `0` | `1` — `arguments.params` reads the local struct |
| `f(params = "page=2")` | `"page=2"` | the struct — a PASSED value is clobbered too |
| `var params = {...}` form | isolated | same alias (`var` ≡ `local.`) |
| `arguments.X` read BEFORE the local write | `0` | `0` — already correct |
| bare `params` after the local write (control) | the local struct | the local struct — correct (scope cascade, local wins) |
| explicit `arguments.params = "a=1"` write/read (control) | `"a=1"` | `"a=1"` — correct |
| `local.X` write then `arguments.X` write (control) | slots stay separate | slots stay separate — correct |

Same result template-level and component-method-level, and in all three execution modes (default, `RUSTCFML_JIT=0`, `RUSTCFML_JIT_THRESHOLD=1`).

The four passing controls fence the fix shape: bare-name reads must KEEP resolving local-first (scope cascade), pre-write reads and explicit arguments-scope writes already work — only the explicit `arguments.X` read after a same-named local write aliases.

Sibling of the scoped-name-resolution family: #77 (callee `local` declaration clobbered the caller's; fixed v0.92.0) and #93 (caller's `local` visible to an undeclared callee's absence-checks; open) covered local-vs-local ACROSS frames — this one conflates the local and arguments views of a SINGLE frame.

## What the test asserts

`tests/core/test_local_shadows_arguments.cfm` + fixture `tests/core/ArgsShadowFixture.cfc`:

1. An unpassed defaulted argument survives a same-name `local.X` write — `Len(arguments.X) == 0`, still a simple value. *(red on RustCFML)*
2. A PASSED value survives the local write. *(red)*
3. The `var X` form does not shadow either. *(red)*
4. `arguments.X` reads identical before AND after the local write. *(red — the post-write read)*
5. CONTROL (green on both engines): a bare `X` read resolves to the LOCAL struct — pins the scope cascade so a fix can't overcorrect bare-name resolution.
6. CONTROL: a distinct local name leaves `arguments.X` alone.
7. CONTROL: an explicit `arguments.X` write round-trips.
8. CONTROL: after both a `local.X` and an `arguments.X` write, the two slots stay separate in both directions.
9. /10. The exact Wheels `URLFor()` shape as a component method: declared `string params = ""`, a same-named route-params struct in `local`, a late `Len(arguments.params)` query-string check — the generated URL must be clean when `params` was never passed, and must carry the passed string intact. *(both red)*

On RustCFML 0.108.0: 4/10 pass (exactly the four controls). On Lucee: 10/10.

## Why it matters for Wheels

This poisoned EVERY generated URL while laddering the Wheels blog app through full CRUD. `URLFor()` (`vendor/wheels/Global.cfc`) declares `string params = ""`, then builds the route-params struct as `local.params = {}` + `StructAppend(local.params, variables.params)` — and later runs `if (Len(arguments.params))` to decide whether to append a caller-supplied query string. On RustCFML the `Len()` saw the request's route-params struct (always truthy) and the struct itself was serialized into the URL, so every link helper in every view — `linkTo`, `urlFor`, `startFormTag`, `redirectTo` — emitted `/posts/1?%7Bcontroller%3A+Posts%2C+action%3A+index...%7D=` garbage. Worked around in the ladder by renaming the local variable; fixing the scope split makes the framework's pervasive `local.X` + `arguments.X` same-name convention safe everywhere.

## Verification

- **RED** — RustCFML 0.108.0 (release binary): suite fails 6/10 — exactly the six gap assertions (defaulted, passed, `var`-form, post-write read, and both URLFor-shape method assertions); all four controls pass. Identical under default JIT, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`.
- **GREEN** — Lucee 5.4.8.2 (CommandBox task runner; same assertions transliterated to a `chk()` harness because CommandBox shadows `assert`): 10/10 pass.
- The gap is runtime-level (wrong values, no parse error), so the test is registered in `tests/runner.cfm`.
- Full `tests/runner.cfm` on this branch (RustCFML 0.108.0): **3636/3642 across 438 suites** — the only 6 failures are this suite's gap assertions; no abort.