### PR TITLE
test(core): bare-name method calls must not resolve through caller-stack frames

### DIFF
--- a/tests/core/BareCallLeakProbe.cfc
+++ b/tests/core/BareCallLeakProbe.cfc
@@ -1,0 +1,54 @@
+component {
+
+	// Fixture for core/test_bare_call_caller_stack_leak.cfm.
+	//
+	// bclTarget() calls two component methods by BARE NAME while ancestor
+	// frames on the call stack hold same-named DATA (struct params / a var).
+	// On a conforming engine the ancestor frames are invisible to the
+	// callee's function-name resolution; the data never shadows the methods.
+
+	// The two methods the deepest frame calls by bare name.
+	public string function bclFnA() {
+		return "FN_A_RESULT";
+	}
+
+	public string function bclFnB() {
+		return "FN_B_RESULT";
+	}
+
+	// Immediate caller of bclTarget(): declares a STRUCT param named bclFnA.
+	// The param is pure data; it must be invisible to bclTarget()'s bare call.
+	public struct function viaMid(struct bclFnA = {}) {
+		return bclTarget();
+	}
+
+	// Grandparent of bclTarget(): declares a STRUCT param named bclFnB, then
+	// calls viaMid() (which itself shadows bclFnA) — both ancestor frames
+	// shadow at once, two different depths.
+	public struct function viaDeep(struct bclFnB = {}) {
+		return viaMid();
+	}
+
+	// Ancestor shadows via a LOCAL (var) instead of a param.
+	public struct function viaLocalShadow() {
+		var bclFnA = {iAmData = true};
+		return bclTarget();
+	}
+
+	// Deepest frame: bare-name calls + scoped controls. Each call's result or
+	// error message is collected into a struct (never re-thrown) so the test
+	// can assert every case independently.
+	public struct function bclTarget() {
+		var res = {
+			bareA   = "", bareAError   = "",
+			bareB   = "", bareBError   = "",
+			scopedA = "", scopedAError = "",
+			thisA   = "", thisAError   = ""
+		};
+		try { res.bareA   = bclFnA(); }           catch (any e) { res.bareAError   = e.message; }
+		try { res.bareB   = bclFnB(); }           catch (any e) { res.bareBError   = e.message; }
+		try { res.scopedA = variables.bclFnA(); } catch (any e) { res.scopedAError = e.message; }
+		try { res.thisA   = this.bclFnA(); }      catch (any e) { res.thisAError   = e.message; }
+		return res;
+	}
+}

--- a/tests/core/test_bare_call_caller_stack_leak.cfm
+++ b/tests/core/test_bare_call_caller_stack_leak.cfm
@@ -1,0 +1,75 @@
+<cfscript>
+suiteBegin("Core: bare-name method calls ignore caller-stack frames (no dynamic scoping)");
+
+// Background
+// ----------
+// Inside a CFC method, a function called by BARE NAME resolves against the
+// method's own frame and then the component's variables/this scope — NEVER
+// against the arguments/locals of ANCESTOR frames on the call stack. CFML is
+// lexically scoped: a caller's parameter or local that happens to share a
+// name with a component method is pure data and must stay invisible to a
+// callee's function-name resolution. Lucee 5/6/7, Adobe CF, and BoxLang all
+// agree (all six probe calls succeed on Lucee 5.4.8.2).
+//
+// RustCFML 0.108.0 resolves bare-name calls through the caller stack
+// (dynamic scoping): if ANY ancestor frame holds a non-function value under
+// the function's name, the callee's bare call throws "Variable is not a
+// function or function '<unknown>' is not defined". The shadowing cascades
+// through the WHOLE stack — a grandparent's param breaks a grandchild's
+// call. Locals shadow too, not just params. `variables.fn()` and `this.fn()`
+// are immune on 0.108.0 (fix-shape hint: bare-name resolution should consult
+// the same scopes, functions-before-ancestor-data, frame-isolated).
+//
+// Likely the same frame-fusion family as the per-frame `local` gaps
+// (test_local_scope_frame_isolation.cfm and the absence-leak test filed
+// alongside this one): frames are not isolated, so name lookups fall through
+// to ancestor frames. Fixing frame-isolated name resolution may collapse
+// several of these at once.
+//
+// Surfaced booting Wheels: the $invokeOnSelf trampoline takes a param named
+// `$args`, and it sits above every controller action. Every bare `$args(...)`
+// call in ANY framework function below it on the stack — redirectTo()'s URL
+// building among them — hit the leak and died "Variable is not a function":
+// every POST redirect 500'd. Latent landmine: any param/local name matching
+// any function called bare anywhere below it on the stack.
+
+bclProbe = createObject("component", "core.BareCallLeakProbe");
+
+// (1) CONTROL — no shadowing ancestor frame: bare calls resolve. Green on
+//     both engines; guards the wiring.
+bclDirect = bclProbe.bclTarget();
+assert("direct: bare bclFnA() resolves with no shadowing frame",
+	bclDirect.bareA & bclDirect.bareAError, "FN_A_RESULT");
+assert("direct: bare bclFnB() resolves with no shadowing frame",
+	bclDirect.bareB & bclDirect.bareBError, "FN_B_RESULT");
+
+// (2) THE GAP — the IMMEDIATE CALLER declares a struct param named bclFnA.
+//     (On failure the assert shows the thrown message instead of the value.)
+bclMid = bclProbe.viaMid();
+assert("via mid: caller's struct param bclFnA does not shadow bare bclFnA()",
+	bclMid.bareA & bclMid.bareAError, "FN_A_RESULT");
+assert("via mid: unshadowed bare bclFnB() still resolves",
+	bclMid.bareB & bclMid.bareBError, "FN_B_RESULT");
+
+// (3) THE CASCADE — GRANDPARENT shadows bclFnB, parent shadows bclFnA:
+//     both bare calls in the grandchild must still resolve.
+bclDeep = bclProbe.viaDeep();
+assert("via deep: parent's struct param bclFnA does not shadow bare bclFnA()",
+	bclDeep.bareA & bclDeep.bareAError, "FN_A_RESULT");
+assert("via deep: grandparent's struct param bclFnB does not shadow bare bclFnB()",
+	bclDeep.bareB & bclDeep.bareBError, "FN_B_RESULT");
+
+// (4) LOCALS shadow too — the caller holds `var bclFnA = {...}`.
+bclLocalRes = bclProbe.viaLocalShadow();
+assert("via local: caller's var bclFnA does not shadow bare bclFnA()",
+	bclLocalRes.bareA & bclLocalRes.bareAError, "FN_A_RESULT");
+
+// (5) CONTROLS — scoped calls are immune even under the fully-shadowed
+//     stack (green on both engines, including RustCFML 0.108.0).
+assert("via deep: variables.bclFnA() resolves under the shadowed stack",
+	bclDeep.scopedA & bclDeep.scopedAError, "FN_A_RESULT");
+assert("via deep: this.bclFnA() resolves under the shadowed stack",
+	bclDeep.thisA & bclDeep.thisAError, "FN_A_RESULT");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -15,6 +15,22 @@ try { include "config/test_app_datasources.cfm"; } catch (any e) { writeOutput("
 try { include "core/test_variables.cfm"; } catch (any e) { writeOutput("ERROR | core/test_variables.cfm | " & e.message & chr(10)); }
 try { include "core/test_access_identifiers.cfm"; } catch (any e) { writeOutput("ERROR | core/test_access_identifiers.cfm | " & e.message & chr(10)); }
 try { include "core/test_function_scope_capture.cfm"; } catch (any e) { writeOutput("ERROR | core/test_function_scope_capture.cfm | " & e.message & chr(10)); }
+//   - bare_call_caller_stack_leak: a function called by BARE NAME inside a
+//     CFC method must resolve against the method's own frame and the
+//     component's variables/this scope only — NEVER through the
+//     arguments/locals of ANCESTOR frames on the call stack. RustCFML
+//     resolves bare-name calls dynamically: any ancestor frame holding
+//     same-named data (a struct param, a var) makes the callee's bare call
+//     throw "Variable is not a function", and the shadowing cascades through
+//     the whole stack (a grandparent's param breaks a grandchild's call).
+//     variables.fn()/this.fn() are immune. Surfaced booting Wheels: the
+//     $invokeOnSelf trampoline's `$args` param shadowed every bare
+//     `$args(...)` call below it on the stack (redirectTo()'s URL building
+//     among them) — every POST redirect 500'd. Likely the same frame-fusion
+//     family as the per-frame `local` gaps. Runtime-level (the bare call
+//     throws a catchable runtime error; no parse error), so registration is
+//     safe.
+try { include "core/test_bare_call_caller_stack_leak.cfm"; } catch (any e) { writeOutput("ERROR | core/test_bare_call_caller_stack_leak.cfm | " & e.message & chr(10)); }
 try { include "core/test_closure_env_leak.cfm"; } catch (any e) { writeOutput("ERROR | core/test_closure_env_leak.cfm | " & e.message & chr(10)); }
 try { include "core/test_compound_assignment.cfm"; } catch (any e) { writeOutput("ERROR | core/test_compound_assignment.cfm | " & e.message & chr(10)); }
 try { include "core/test_undeclared_named_args.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undeclared_named_args.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

A function called by **bare name** inside a CFC method must resolve against the method's own frame and the component's `variables`/`this` scope — never through the arguments/locals of **ancestor frames on the call stack**. CFML is lexically scoped: a caller's parameter or local that happens to share a name with a component method is pure data and stays invisible to the callee's function-name resolution.

RustCFML 0.108.0 resolves bare-name calls **dynamically through the caller stack**: if any ancestor frame holds a non-function value under the function's name, the callee's bare call throws — and the shadowing cascades the whole stack, so a *grandparent's* param breaks a *grandchild's* call. Locals (`var`) shadow too, not just params.

```cfm
component {
    function fnA()                    { return "OK"; }
    function mid(struct fnA = {})     { return target(); }  // param is DATA
    function target()                 { return fnA(); }      // bare call
}
```

| Call | Lucee 5.4.8.2 | RustCFML 0.108.0 |
|---|---|---|
| `p.target()` — no shadowing frame | `OK` | `OK` |
| `p.mid()` — immediate caller has struct param `fnA` | `OK` | throws `Variable is not a function or function '<unknown>' is not defined` |
| via grandparent with struct param `fnB` (calls `mid()`) | `OK` | both bare calls throw — cascades the whole stack |
| via caller with `var fnA = {...}` | `OK` | throws — locals shadow too |
| `variables.fnA()` / `this.fnA()` under the same stack | `OK` | `OK` — scoped calls are immune (fix-shape hint) |

Identical in all three execution modes (default, `RUSTCFML_JIT=0`, `RUSTCFML_JIT_THRESHOLD=1`).

Likely the same frame-fusion family as #93 (per-frame `local` absence-leak) and the `this`-write snapshot PR filed alongside: frames are not isolated, so name lookups fall through to ancestor frames. Fixing frame-isolated, functions-before-ancestor-data name resolution may collapse several of these at once.

## What the test asserts

`tests/core/test_bare_call_caller_stack_leak.cfm` + fixture `tests/core/BareCallLeakProbe.cfc` (9 assertions):

1. **CONTROL (green on both engines)**: with no shadowing ancestor frame, bare `bclFnA()` / `bclFnB()` resolve — guards the wiring.
2. **The gap**: the immediate caller declares `struct bclFnA = {}`; the callee's bare `bclFnA()` must still return the method's result.
3. **The cascade**: grandparent shadows `bclFnB`, parent shadows `bclFnA` — *both* bare calls in the grandchild must resolve.
4. **Locals shadow too**: the caller holds `var bclFnA = {...}` — the callee's bare call must still resolve.
5. **CONTROLS (green on both engines, incl. RustCFML 0.108.0)**: `variables.bclFnA()` and `this.bclFnA()` under the fully-shadowed stack — pins the fix shape.

The fixture collects each call's result-or-error into a struct, so a failing assert shows the thrown message instead of the expected value.

On RustCFML 0.108.0: 5/9 pass (the controls). On Lucee: 9/9.

## Why it matters for Wheels

This was the biggest find of the Wheels CRUD ladder. Wheels' `$invokeOnSelf` trampoline has a parameter named `$args`, and it sits above **every controller action** on the dispatch chain. Under this leak, every bare `$args(...)` call in any framework function below it on the stack — `redirectTo()`'s URL building among them, i.e. Wheels' canonical defaults-merging used all over the framework — saw the trampoline's struct param instead of the function and died with "Variable is not a function". Net effect: every POST → redirect cycle 500'd; `POST /posts` → `create()` → `redirectTo()` failed on the stock dispatch chain.

The general landmine is latent everywhere: *any* parameter or local name that matches *any* function called bare *anywhere below it on the call stack* breaks that call. That's not a code-style edge — Wheels (and CFML at large) leans on bare intra-component calls as the default calling convention.

## Verification

- **RED** — RustCFML 0.108.0 (release binary): `5/9 passed (4 failed)`; identical under default JIT, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`. The 4 failures are exactly the bare-call-under-shadow assertions (mid-param, deep-param x2, caller-var); the direct-call and `variables.`/`this.` controls pass.
- **GREEN** — Lucee 5.4.8.2 (CommandBox): `9/9 passed`.
- The gap is runtime-level (the bare call throws a catchable runtime error; no parse error), so the test is registered in `tests/runner.cfm`.
- Full `tests/runner.cfm` on this branch (RustCFML 0.108.0): **3637/3641 across 438 suites** — the only 4 failures are this suite's gap assertions; no abort. Full `tests/runner.cfm` on this branch (RustCFML 0.108.0).