### PR TITLE
test(core): a data variable named like a builtin must not shadow it in call position

### DIFF
--- a/tests/core/BuiltinDataShadowFixture.cfc
+++ b/tests/core/BuiltinDataShadowFixture.cfc
@@ -1,0 +1,14 @@
+component {
+
+	// Mirrors the failing Wheels shape (vendor/wheels/Global.cfc,
+	// $convertToString): normalize the argument into local.val, then call the
+	// Val() BUILTIN with that local in the frame. On a conforming engine the
+	// data variable never shadows the builtin in call position.
+	public struct function convertProbe(required any value) {
+		var s = {ok = false, got = ""};
+		local.val = arguments.value;
+		try { s.got = Val(local.val); s.ok = true; } catch (any e) { s.err = e.message; }
+		return s;
+	}
+
+}

--- a/tests/core/test_builtin_data_shadow.cfm
+++ b/tests/core/test_builtin_data_shadow.cfm
@@ -1,0 +1,120 @@
+<cfscript>
+suiteBegin("Core: data variable named like a builtin must not shadow it in call position");
+
+// Background
+// ----------
+// A plain DATA variable whose name matches a built-in function must never make
+// that builtin uncallable. On RustCFML 0.108.0, once a variable named `val`
+// exists in the template scope, in a function's local scope, or in any LIVE
+// ANCESTOR frame on the call stack, every call-position use of `Val(...)`
+// throws:
+//
+//     Variable is not a function or function '<unknown>' is not defined
+//
+//   val = "29"; Val(val)
+//     RustCFML 0.108.0 -> throws (template scope, function-local, bare-read
+//                          argument, and cross-stack: a CALLER's `local.val`
+//                          poisons the CALLEE's `Val("123")`)
+//     Lucee 5.4.8.x    -> 29 everywhere; data variables never shadow builtins
+//                          in call position
+//
+// Value-position reads of the variable keep working on both engines — only
+// call-position resolution breaks, and only for the same-named builtin (other
+// builtins stay callable). The poison follows frame lifetime: a function-local
+// shadow clears when its frame dies, but a template-scope variable poisons the
+// builtin for the rest of the request — and structDelete()ing the variable
+// does NOT restore it.
+//
+// Sibling gap, kept disjoint: bare-name USER-function resolution through
+// caller frames (a caller's data variable hiding a user-defined function from
+// the callee). This suite is exclusively about BUILTINs vs data variables —
+// template scope included, which the user-function gap does not reach.
+//
+// ORDERING NOTE: the template-scope shape runs LAST because its poison is
+// request-sticky on the broken engine, and `Val` is deliberately a builtin no
+// other suite in tests/runner.cfm calls — a red run cannot cascade into
+// unrelated suites. The function-local shapes are self-contained (frame death
+// clears them).
+
+// --- CONTROL (green on both engines): no same-named variable exists yet, the
+//     builtin is an ordinary builtin. Guards the wiring. ---
+bdsCtl = {ok = false, got = ""};
+try { bdsCtl.got = Val("7"); bdsCtl.ok = true; } catch (any e) { bdsCtl.err = e.message; }
+assertTrue("CONTROL: Val('7') callable before any shadowing variable exists", bdsCtl.ok);
+assert("CONTROL: Val('7') returns 7", bdsCtl.got, 7);
+
+// --- 1. function-LOCAL, scoped argument: the exact Wheels $convertToString
+//        shape (local.val = ...; Val(local.val)) ---
+function bdsLocalShape() {
+	var s = {ok = false, got = ""};
+	local.val = "42";
+	try { s.got = Val(local.val); s.ok = true; } catch (any e) { s.err = e.message; }
+	return s;
+}
+bdsLocalRes = bdsLocalShape();
+assertTrue("function-local: Val(local.val) callable with local.val in the frame", bdsLocalRes.ok);
+assert("function-local: Val(local.val) returns 42", bdsLocalRes.got, 42);
+
+// --- 2. function-LOCAL, bare-read argument: in Val(val) the bare `val`
+//        resolves to the local DATA variable while the callee `Val` stays the
+//        builtin ---
+function bdsBareShape() {
+	var s = {ok = false, got = ""};
+	local.val = "42";
+	try { s.got = Val(val); s.ok = true; } catch (any e) { s.err = e.message; }
+	return s;
+}
+bdsBareRes = bdsBareShape();
+assertTrue("function-local bare read: Val(val) callable with local.val in the frame", bdsBareRes.ok);
+assert("function-local bare read: Val(val) returns 42", bdsBareRes.got, 42);
+
+// --- 3. generality: a second builtin (`Len`) behaves the same ---
+function bdsLenShape() {
+	var s = {ok = false, got = ""};
+	local.len = "abcde";
+	try { s.got = Len(local.len); s.ok = true; } catch (any e) { s.err = e.message; }
+	return s;
+}
+bdsLenRes = bdsLenShape();
+assertTrue("generality: Len(local.len) callable with local.len in the frame", bdsLenRes.ok);
+assert("generality: Len(local.len) returns 5", bdsLenRes.got, 5);
+
+// --- 4. cross-STACK: a CALLER's local data variable must not poison the
+//        CALLEE's builtin call ---
+function bdsAncestor() {
+	local.val = "77";
+	return bdsDescendant();
+}
+function bdsDescendant() {
+	var s = {ok = false, got = ""};
+	try { s.got = Val("123"); s.ok = true; } catch (any e) { s.err = e.message; }
+	return s;
+}
+bdsStackRes = bdsAncestor();
+assertTrue("cross-stack: Val('123') callable while a caller frame holds local.val", bdsStackRes.ok);
+assert("cross-stack: Val('123') returns 123", bdsStackRes.got, 123);
+
+// --- 5. component-method shape: mirrors Wheels' Global.cfc $convertToString
+//        (local.val = arguments.value; ... return Val(val);) ---
+bdsObj = createObject("component", "BuiltinDataShadowFixture");
+bdsCfcRes = bdsObj.convertProbe("29abc");
+assertTrue("component method: Val(local.val) callable with local.val in the frame", bdsCfcRes.ok);
+assert("component method: Val('29abc') returns 29", bdsCfcRes.got, 29);
+
+// --- 6. TEMPLATE scope (LAST — see ordering note above) ---
+bdsTpl = {ok = false, got = ""};
+val = "29";
+assert("template: value-position read of 'val' still returns the data", val, "29");
+try { bdsTpl.got = Val(val); bdsTpl.ok = true; } catch (any e) { bdsTpl.err = e.message; }
+assertTrue("template: Val(val) callable with template variable 'val' set", bdsTpl.ok);
+assert("template: Val(val) returns 29", bdsTpl.got, 29);
+
+// --- 7. deleting the variable must restore the builtin ---
+structDelete(variables, "val");
+bdsPost = {ok = false, got = ""};
+try { bdsPost.got = Val("7"); bdsPost.ok = true; } catch (any e) { bdsPost.err = e.message; }
+assertTrue("post-delete: Val('7') callable again after structDelete(variables, 'val')", bdsPost.ok);
+assert("post-delete: Val('7') returns 7", bdsPost.got, 7);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -28,6 +28,14 @@ try { include "core/test_cfloop_array_item_index.cfm"; } catch (any e) { writeOu
 try { include "core/test_cfloop_collection_item_index.cfm"; } catch (any e) { writeOutput("ERROR | core/test_cfloop_collection_item_index.cfm | " & e.message & chr(10)); }
 try { include "core/test_error_handling.cfm"; } catch (any e) { writeOutput("ERROR | core/test_error_handling.cfm | " & e.message & chr(10)); }
 try { include "core/test_builtin_shadowing.cfm"; } catch (any e) { writeOutput("ERROR | core/test_builtin_shadowing.cfm | " & e.message & chr(10)); }
+//   - builtin_data_shadow: a plain DATA variable named like a builtin
+//     (val = "29") must not make the builtin uncallable in call position —
+//     Val(val) throws "Variable is not a function" at template scope,
+//     function-local, and cross-stack (a caller's local.val poisons the
+//     callee's Val()). Surfaced in Wheels' $convertToString (Global.cfc does
+//     `local.val = arguments.value; ... return Val(val);`) — killed
+//     hasChanged() and with it every UPDATE statement.
+try { include "core/test_builtin_data_shadow.cfm"; } catch (any e) { writeOutput("ERROR | core/test_builtin_data_shadow.cfm | " & e.message & chr(10)); }
 try { include "core/test_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_functions.cfm | " & e.message & chr(10)); }
 try { include "core/test_arrow_functions.cfm"; } catch (any e) { writeOutput("ERROR | core/test_arrow_functions.cfm | " & e.message & chr(10)); }
 try { include "core/test_arguments_writeback.cfm"; } catch (any e) { writeOutput("ERROR | core/test_arguments_writeback.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

A plain DATA variable whose name matches a built-in function makes that builtin uncallable. Once `val` exists as a variable — template scope, function-local, or any live ancestor frame on the call stack — every call-position use of `Val(...)` throws.

```cfm
val = "29";
writeOutput(Val(val));
```

| Engine | `Val(val)` with a string variable `val` in scope |
|---|---|
| RustCFML 0.108.0 | throws `Variable is not a function or function '<unknown>' is not defined` |
| Lucee 5.4.8.2 | `29` — data variables never shadow builtins in call position |

All of these shapes throw on 0.108.0, in all three execution modes (default, `RUSTCFML_JIT=0`, `RUSTCFML_JIT_THRESHOLD=1`):

- **template scope**: `val = "29"; Val(val)`
- **function-local**: `local.val = "42"; Val(local.val)` — and the bare-read form `Val(val)`
- **cross-stack**: a CALLER's `local.val` poisons the CALLEE's `Val("123")` (the callee has no `val` of its own)
- **component method**: `local.val = arguments.value; Val(local.val)`
- **any builtin**: `local.len = "abcde"; Len(local.len)` throws the same way

Probing pinned down the mechanics: only the same-named builtin breaks (other builtins stay callable), value-position reads of the variable keep working, function-local poison clears when its frame dies — but a template-scope variable poisons the builtin for the rest of the request, including inside later-called functions, and `structDelete(variables, "val")` does **not** restore it.

Distinct from the sibling caller-stack gap filed in this batch: that one is about bare-name **user-function** resolution walking ancestor frames; this one is **builtin-vs-data** resolution in any single frame, template scope included. Assertions are disjoint.

## What the test asserts

`tests/core/test_builtin_data_shadow.cfm` + fixture `tests/core/BuiltinDataShadowFixture.cfc` — 17 assertions:

1. **CONTROL (green on both engines)**: `Val("7")` works before any shadowing variable exists — guards the wiring.
2. **Function-local, scoped argument** — the exact Wheels `$convertToString` shape: `local.val = "42"; Val(local.val)` returns 42.
3. **Function-local, bare-read argument**: in `Val(val)` the bare `val` resolves to the local data variable while the callee `Val` stays the builtin.
4. **Generality**: a second builtin (`Len` with `local.len` in the frame) behaves the same.
5. **Cross-stack**: a caller frame's `local.val` must not poison the callee's `Val("123")`.
6. **Component-method shape**: the fixture mirrors `$convertToString` (`local.val = arguments.value; return Val(local.val);`).
7. **Template scope** (deliberately last — its poison is request-sticky on the broken engine): `val = "29"` then `Val(val) == 29`, plus a value-position-read control (`val` still reads as `"29"` — passes on both engines).
8. **Cleanup restores the builtin**: after `structDelete(variables, "val")`, `Val("7")` is an ordinary builtin again.

On RustCFML 0.108.0: 3/17 pass (the CONTROL and the value-position read). On Lucee: 17/17.

`Val` was chosen deliberately: no other suite in `tests/runner.cfm` calls it, so the template-scope shape's request-sticky poison cannot cascade into unrelated suites while red, and the function-local shapes are self-contained (frame death clears them).

## Why it matters for Wheels

This killed **every UPDATE statement** in the Wheels boot ladder. Wheels' `$convertToString` (`vendor/wheels/Global.cfc`) normalizes values for comparison by doing `local.val = arguments.value` and later `return Val(val);` (plus several more `Val(...)` calls in its datetime branch) — the textbook shape of this gap. `$convertToString` canonicalizes both sides of `hasChanged()`'s dirty-comparison (`vendor/wheels/model/properties.cfc`), so on RustCFML every dirty-check threw, and no model could ever persist a change.

It is not a Wheels quirk: CFML codebases use `val`, `len`, `find`, `replace` as variable names constantly. Any frame that holds one breaks the same-named builtin for that frame, for every callee below it, and — if set at template scope — for the rest of the request.

## Verification

- **RED** — RustCFML 0.108.0 (release binary): `3/17 passed (14 failed)`; identical under default JIT, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`. Every shadow-shape assertion fails with `Variable is not a function or function '<unknown>' is not defined`; only the no-shadow CONTROL and the value-position read pass. Re-verified on 0.108.0 (gap originally found on 0.106.0); the v0.109.0 tag is a single QoQ perf commit and does not touch this.
- **GREEN** — Lucee 5.4.8.2 (CommandBox): `17/17 passed`.
- The gap is runtime-level (the engine resolves the call wrongly; no parse error), so the test is registered in `tests/runner.cfm`.
- Full `tests/runner.cfm` on this branch (RustCFML 0.108.0): **3635/3649 across 438 suites** — the only 14 failures are this suite's gap assertions; no abort.