### PR TITLE
test(core): for-in over a string iterates comma-list items, not characters

### DIFF
--- a/tests/core/test_forin_string_list.cfm
+++ b/tests/core/test_forin_string_list.cfm
@@ -1,0 +1,124 @@
+<cfscript>
+suiteBegin("Core: for-in over a string iterates comma-list ITEMS, not characters");
+
+// ============================================================
+// Background
+// ============================================================
+// In CFML, a for-in loop over a STRING treats the string as a
+// comma-delimited LIST and iterates its items:
+//
+//     for (col in "id,title,body")
+//     // Lucee:    "id", "title", "body"            (3 iterations)
+//     // RustCFML: "i","d",",","t","i","t","l","e",
+//     //           ",","b","o","d","y"              (13 iterations,
+//     //                                             commas included)
+//
+// The exact list contract, pinned empirically on Lucee 5.4.8.2:
+//
+//   - the delimiter is the comma and ONLY the comma -- "a;b;c" is a
+//     single item, the whole string;
+//   - items are NOT trimmed -- "a, b , c" yields "a", " b ", " c";
+//   - empty items are KEPT -- "a,,b" is 3 items ("a", "", "b") and
+//     "a,b," is 3 items ("a", "b", ""); note this DIFFERS from
+//     ListToArray's default, which skips empty items;
+//   - a string with no commas is ONE iteration of the whole string;
+//   - an empty string never enters the loop (zero iterations).
+//
+// RustCFML 0.108.0 instead iterates the string CHARACTER BY CHARACTER
+// (including the comma characters themselves). Controls that pass on
+// both engines: for-in over ListToArray() of the same string, and
+// for-in over the empty string.
+//
+// Why it matters for Wheels: $queryRowToStruct() in
+// vendor/wheels/model/serialize.cfc hydrates EVERY finder result row
+// into a model object via
+//
+//     for (local.column in arguments.properties.columnList) { ... }
+//
+// where columnList is the query's comma-delimited column-name string.
+// On RustCFML each model object built from a finder grew junk
+// single-character property keys (I, D, ",", T, L, E, ...) instead of
+// its real column properties -- findByKey()/findAll() returned garbage
+// objects for every model. All assertions below PASS on Lucee.
+// ============================================================
+
+// Helpers (fsl-prefixed: the runner shares one template scope).
+function fslJoin(required subject) {
+	var seen = [];
+	for (var fslItem in arguments.subject) {
+		ArrayAppend(seen, fslItem);
+	}
+	return ArrayToList(seen, "|");
+}
+function fslCount(required subject) {
+	var seen = [];
+	for (var fslItem in arguments.subject) {
+		ArrayAppend(seen, fslItem);
+	}
+	return ArrayLen(seen);
+}
+
+// ------------------------------------------------------------
+// (1) The Wheels shape: for-in over a comma-delimited column-list
+//     string iterates the LIST ITEMS.
+// ------------------------------------------------------------
+assert("for (col in 'id,title,body'): 3 list items, not 13 characters",
+	fslCount("id,title,body"), 3);
+assert("for (col in 'id,title,body'): the items are the fields",
+	fslJoin("id,title,body"), "id|title|body");
+
+// ------------------------------------------------------------
+// (2) Comma is the ONLY delimiter -- a semicolon string is one item.
+// ------------------------------------------------------------
+assert("for-in over 'a;b;c' is a single item (comma is the only delimiter)",
+	fslJoin("a;b;c"), "a;b;c");
+
+// ------------------------------------------------------------
+// (3) Items are not trimmed.
+// ------------------------------------------------------------
+assert("items keep their surrounding spaces",
+	fslJoin("a, b , c"), "a| b | c");
+
+// ------------------------------------------------------------
+// (4) A string with no commas is ONE iteration of the whole string.
+// ------------------------------------------------------------
+assert("for-in over 'title' is one item, not five characters",
+	fslJoin("title"), "title");
+assert("for-in over 'title' iterates exactly once",
+	fslCount("title"), 1);
+
+// ------------------------------------------------------------
+// (5) Empty items are kept (Lucee contract -- differs from
+//     ListToArray's default empty-skipping).
+// ------------------------------------------------------------
+assert("'a,,b' is 3 items -- the empty middle item is kept",
+	fslCount("a,,b"), 3);
+assert("'a,b,' is 3 items -- the empty trailing item is kept",
+	fslCount("a,b,"), 3);
+
+// ------------------------------------------------------------
+// (6) CONTROL: an empty string never enters the loop (passes on
+//     both engines).
+// ------------------------------------------------------------
+assert("for-in over '' is zero iterations",
+	fslCount(""), 0);
+
+// ------------------------------------------------------------
+// (7) CONTROL: for-in over ListToArray() of the same string (passes
+//     on both engines) -- the workaround Wheels code would not need
+//     on a compliant engine.
+// ------------------------------------------------------------
+assert("control: for-in over ListToArray('id,title,body')",
+	fslJoin(ListToArray("id,title,body")), "id|title|body");
+
+// ------------------------------------------------------------
+// (8) End-to-end Wheels shape: a real query's columnList string.
+//     (Count, not join -- engines differ on columnList letter case,
+//     which is not the contract under test.)
+// ------------------------------------------------------------
+fslQ = QueryNew("id,title,body", "integer,varchar,varchar", [[1, "Hello", "World"]]);
+assert("for (col in query.columnList) yields one item per column",
+	fslCount(fslQ.columnList), 3);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -263,6 +263,14 @@ try { include "tags/test_tags_script_syntax_body.cfm"; } catch (any e) { writeOu
 try { include "functions/test_expandpath_trailing_slash.cfm"; } catch (any e) { writeOutput("ERROR | functions/test_expandpath_trailing_slash.cfm | " & e.message & chr(10)); }
 try { include "core/test_forin_member_loop_var.cfm"; } catch (any e) { writeOutput("ERROR | core/test_forin_member_loop_var.cfm | " & e.message & chr(10)); }
 try { include "core/test_forin_keyword_member_access.cfm"; } catch (any e) { writeOutput("ERROR | core/test_forin_keyword_member_access.cfm | " & e.message & chr(10)); }
+//   - forin_string_list: for-in over a comma-delimited STRING must iterate
+//     the LIST ITEMS ("id","title","body"), not the CHARACTERS. RustCFML
+//     iterates character-by-character (commas included), so Wheels'
+//     $queryRowToStruct -- for (local.column in query.columnList) -- gave
+//     every finder-hydrated model object junk single-character property
+//     keys instead of its real columns. Runtime gap: wrong values, no
+//     parse error.
+try { include "core/test_forin_string_list.cfm"; } catch (any e) { writeOutput("ERROR | core/test_forin_string_list.cfm | " & e.message & chr(10)); }
 
 // --- v0.34.3 round: Wheels now parses, constructs, and boots its full app
 //     lifecycle + DI on RustCFML. This is the remaining language gap found


### PR DESCRIPTION
## Cross-engine gap: for-in over a string iterates CHARACTERS, not comma-list items

In CFML, a `for ... in` loop over a STRING treats the string as a comma-delimited LIST and iterates its items. RustCFML iterates the string character by character — including the comma characters themselves:

```cfml
items = [];
for (col in "id,title,body") { ArrayAppend(items, col); }
```

| engine | iterations | items |
|--------|-----------|-------|
| RustCFML 0.108.0 | **13** | `i`,`d`,`,`,`t`,`i`,`t`,`l`,`e`,`,`,`b`,`o`,`d`,`y` |
| Lucee 5.4.8.2 | 3 | `id`, `title`, `body` |

The exact list contract, pinned empirically on Lucee 5.4.8.2 before asserting anything:

- the delimiter is the comma and ONLY the comma — `"a;b;c"` is a single item, the whole string;
- items are NOT trimmed — `"a, b , c"` yields `"a"`, `" b "`, `" c"`;
- empty items are KEPT — `"a,,b"` is 3 items (`"a"`, `""`, `"b"`) and `"a,b,"` is 3 items; note this differs from `ListToArray`'s default, which skips empty items;
- a string with no commas is ONE iteration of the whole string (`"title"` → `"title"`, not five characters);
- an empty string never enters the loop.

### What the test asserts

- `for (col in "id,title,body")` runs 3 iterations and yields the fields `id|title|body` (the exact Wheels `$queryRowToStruct` shape)
- comma is the only delimiter (`"a;b;c"` → one item), items keep their spaces (`"a, b , c"` → `a| b | c`), a no-comma string iterates exactly once with the whole string
- empty items are kept: `"a,,b"` and `"a,b,"` are each 3 iterations
- end-to-end Wheels shape: `for (col in q.columnList)` on a real `QueryNew` query yields one item per column (count-only — engines differ on columnList letter case, which is not the contract under test)
- CONTROLS (pass on both engines): for-in over `ListToArray("id,title,body")` of the same string, and for-in over `""` (zero iterations)

### Why it matters for Wheels

`$queryRowToStruct()` in `vendor/wheels/model/serialize.cfc` hydrates EVERY finder result row into a model object via:

```cfml
for (local.column in arguments.properties.columnList) {
    if (!StructKeyExists(local.rv, local.column)) {
        local.rv[local.column] = arguments.properties[local.column][arguments.row];
    }
}
```

`columnList` is the query's comma-delimited column-name string. On RustCFML this loop visits `I`, `D`, `,`, `T`, `I`, `T`, `L`, `E`, ... — so every model object hydrated from a finder grew junk single-character property keys instead of its real column properties, and `findByKey()` / `findAll()` returned garbage objects for every model in the app. No error anywhere — the corruption only surfaces when views render the wrong properties. Root-caused while laddering the Wheels blog app through full CRUD.

### Verification

- **RustCFML 0.108.0** (release binary), staged repo layout (`harness.cfm` + this test): the suite fails exactly the 9 gap assertions (**2/11** — both controls PASS). Identical 2/11 with `RUSTCFML_JIT=0` and with `RUSTCFML_JIT_THRESHOLD=1` — interpreter semantics, not JIT-specific.
- **Lucee 5.4.8.2** (CommandBox): all **11/11** PASS. (Adobe CF was not run for this PR; the list-iteration contract is long-standing shared CFML behavior, but the trim/empty-item edge cases were pinned against Lucee only.)
- Full `tests/runner.cfm` on this branch (RustCFML 0.108.0): **3634/3643 across 438 suites** — the only 9 failures are this suite's gap assertions; no abort.
- Runtime gap (wrong iteration values, no parse error) → registered in the core for-in block of `tests/runner.cfm`, directly after `test_forin_keyword_member_access.cfm`.