### PR TITLE
test(core): this.method() dot-calls must not detach the frame's this binding from later writes

### DIFF
--- a/tests/core/ThisDotCallDetachFixture.cfc
+++ b/tests/core/ThisDotCallDetachFixture.cfc
@@ -1,0 +1,92 @@
+component {
+
+	// Pseudo-constructor: seed the state the matrix rows assert against.
+	this.pre = "A";
+	this.bag = { n = 0 };
+	variables.vMark = "";
+
+	public void function noop() {
+	}
+
+	public void function writeNested() {
+		this.nestedMark = "N";
+	}
+
+	// ------------------------------------------------------------
+	// RED rows on RustCFML 0.108.0 -- each performs a `this.`-DOT
+	// qualified method call, then a this-write. The write is visible
+	// in-frame (returned string) but discarded when the frame returns.
+	// ------------------------------------------------------------
+
+	public string function dotCallThenNewKeyWrite() {
+		this.noop();        // dot-qualified call: detaches `this` on RustCFML
+		this.mkNew = "X";   // lands on the detached copy
+		return "inFrame=" & structKeyExists(this, "mkNew");
+	}
+
+	public string function dotCallThenOverwrite() {
+		this.noop();
+		this.pre = "B";     // existing key: silently reverts to "A" on return
+		return "inFrame=" & this.pre;
+	}
+
+	public string function dotCallThenNestedBareWrite() {
+		this.noop();
+		writeNested();      // a frame called AFTER the dot-call is poisoned too
+		return "inFrame=" & structKeyExists(this, "nestedMark");
+	}
+
+	// ------------------------------------------------------------
+	// GREEN control rows -- the closest non-detaching neighbours of the
+	// trigger shape. All already pass on RustCFML 0.108.0.
+	// ------------------------------------------------------------
+
+	public string function bareCallThenWrite() {
+		noop();             // bare call: no detach
+		this.mkBare = "X";
+		return "inFrame=" & structKeyExists(this, "mkBare");
+	}
+
+	public string function bracketCallThenWrite() {
+		this["noop"]();     // bracket-dispatch on this: no detach
+		this.mkBracket = "X";
+		return "inFrame=" & structKeyExists(this, "mkBracket");
+	}
+
+	public string function dotReadThenWrite() {
+		var f = this.noop;  // dot-READ (no call): no detach
+		this.mkRead = "X";
+		return "inFrame=" & structKeyExists(this, "mkRead");
+	}
+
+	public string function otherObjectDotCallThenWrite() {
+		var other = createObject("component", "ThisDotCallDetachFixture");
+		other.noop();       // dot-call, but the receiver is NOT this frame's `this`
+		this.mkOther = "X";
+		return "inFrame=" & structKeyExists(this, "mkOther");
+	}
+
+	public string function helperMemberDotCallThenWrite() {
+		this.helperObj.noop();  // dot-call THROUGH a this-member: receiver is helperObj
+		this.mkHelper = "X";
+		return "inFrame=" & structKeyExists(this, "mkHelper");
+	}
+
+	public string function dotCallThenVariablesWrite() {
+		this.noop();
+		variables.vMark = "V";  // the variables scope is never snapshotted
+		return "inFrame=" & variables.vMark;
+	}
+
+	public string function getVMark() {
+		return variables.vMark;
+	}
+
+	// PIN: the detached copy is SHALLOW -- a nested struct reached through
+	// `this` is a shared reference, so its mutation escapes the detach.
+	public string function dotCallThenNestedStructMutation() {
+		this.noop();
+		this.bag.n = 7;
+		return "inFrame=" & this.bag.n;
+	}
+}

--- a/tests/core/test_this_dot_call_detaches_writes.cfm
+++ b/tests/core/test_this_dot_call_detaches_writes.cfm
@@ -1,0 +1,139 @@
+<cfscript>
+suiteBegin("Core: this.-dot method call must not detach the frame's this binding");
+
+// ============================================================
+// Background
+// ============================================================
+// Inside a component method, calling a sibling method with a `this.`-DOT
+// qualified call expression (`this.noop()`) must leave the frame's `this`
+// binding alone. Lucee 5/6/7, Adobe ColdFusion 2018-2025, and BoxLang all
+// dispatch the member call against the live object: any subsequent
+// `this.key = value` write in that frame -- or in any frame it calls --
+// is visible to the caller after the method returns.
+//
+// RustCFML 0.108.0 instead DETACHES the frame's `this` binding onto a
+// data-complete SHALLOW COPY of the object at the moment of the dot-call.
+// Every later this-write in that frame, and in frames called after it
+// (any call shape), lands on the detached copy: visible in-frame,
+// DISCARDED when the detaching frame returns.
+//
+//     component {                       // fixture
+//         public void function noop() {}
+//         public void function combo() {
+//             this.noop();              // <- detaches `this` on RustCFML
+//             this.mk = "X";            // lands on the detached copy
+//         }
+//     }
+//     o = createObject("component", "Fixture");
+//     o.combo();
+//     structKeyExists(o, "mk")
+//         Lucee 5/6/7 / ACF / BoxLang -> true
+//         RustCFML 0.108.0            -> false  (write discarded on return)
+//
+// The trigger is EXACTLY the member-call shape `this.method()`:
+//   - a bare call `noop()`                     does NOT detach
+//   - a bracket call `this["noop"]()`          does NOT detach
+//   - a dot-READ `f = this.noop` (no call)     does NOT detach
+//   - a dot-call on ANOTHER object             does NOT detach
+//     (`other.noop()`, and even `this.member.noop()`)
+//   - `variables`-scope writes always survive
+//   - mutations of a NESTED struct reached through `this` escape even
+//     while detached (the copy is shallow; struct refs are shared) --
+//     pinned below as documented behaviour so a fix can't silently
+//     regress reference semantics for nested containers.
+//
+// The failure is JIT-independent (identical under RUSTCFML_JIT=0 and
+// RUSTCFML_JIT_THRESHOLD=1) and depth-independent (pure recursion to
+// depth 200 without a dot-call stays green). The detach does not
+// propagate upward: caller writes after a poisoned callee returns are
+// fine, and a fresh method call on the same object sees true state.
+//
+// Why this matters for Wheels: the model save chain crosses TWO such
+// dot-calls. invokeWithTransaction() calls this.$hashedConnectionArgs()
+// (vendor/wheels/model/transactions.cfc) before dispatching $save -- so
+// the primary key, timestamps, and persisted-state flags written below
+// it all land on a detached copy: after update() the caller's object
+// keeps a stale updatedAt and reports hasChanged() = true even though
+// the DB row is correct. And $create() calls this.columnDataForProperty()
+// (vendor/wheels/model/create.cfc) right before assigning the generated
+// primary key -- the PK write dies one return later, so create() hands
+// back an object with no id. Flipping each call site from `this.$x()`
+// to the bare `$x()` restores full Lucee semantics, which is how the
+// two sites were isolated.
+// ============================================================
+
+tdcd_obj = createObject("component", "ThisDotCallDetachFixture");
+tdcd_obj.helperObj = createObject("component", "ThisDotCallDetachFixture");
+
+// ------------------------------------------------------------
+// RED row 1: dot-call, then NEW-KEY this-write in the same frame. The
+// in-frame assert passes on every engine (the write IS visible inside
+// the method); the after-return assert is the gap.
+// ------------------------------------------------------------
+tdcd_r = tdcd_obj.dotCallThenNewKeyWrite();
+assert("dot-call then new-key this-write: visible in-frame (both engines)",
+    tdcd_r, "inFrame=true");
+assertTrue("dot-call then new-key this-write: this.mkNew SURVIVES the return",
+    structKeyExists(tdcd_obj, "mkNew"));
+
+// ------------------------------------------------------------
+// RED row 2: dot-call, then EXISTING-KEY overwrite. On RustCFML the key
+// silently REVERTS to its pre-call value when the frame returns.
+// ------------------------------------------------------------
+tdcd_r = tdcd_obj.dotCallThenOverwrite();
+assert("dot-call then existing-key overwrite: visible in-frame (both engines)",
+    tdcd_r, "inFrame=B");
+assert("dot-call then existing-key overwrite: this.pre SURVIVES the return",
+    tdcd_obj.pre, "B");
+
+// ------------------------------------------------------------
+// RED row 3: the dot-call poisons frames called AFTER it -- a this-write
+// made inside a nested BARE call is also discarded on the outer return.
+// ------------------------------------------------------------
+tdcd_r = tdcd_obj.dotCallThenNestedBareWrite();
+assert("dot-call then nested bare-call this-write: visible in-frame (both engines)",
+    tdcd_r, "inFrame=true");
+assertTrue("dot-call then nested bare-call this-write: this.nestedMark SURVIVES the return",
+    structKeyExists(tdcd_obj, "nestedMark"));
+
+// ------------------------------------------------------------
+// GREEN controls -- the sharp wedge for the fix. Each is the closest
+// NON-detaching neighbour of the trigger shape and already passes on
+// RustCFML 0.108.0; a fix that breaks any of these overshot.
+// ------------------------------------------------------------
+tdcd_r = tdcd_obj.bareCallThenWrite();
+assertTrue("CONTROL: bare call noop() does not detach (this.mkBare survives)",
+    structKeyExists(tdcd_obj, "mkBare"));
+
+tdcd_r = tdcd_obj.bracketCallThenWrite();
+assertTrue("CONTROL: bracket call this['noop']() does not detach (this.mkBracket survives)",
+    structKeyExists(tdcd_obj, "mkBracket"));
+
+tdcd_r = tdcd_obj.dotReadThenWrite();
+assertTrue("CONTROL: dot-READ f = this.noop does not detach (this.mkRead survives)",
+    structKeyExists(tdcd_obj, "mkRead"));
+
+tdcd_r = tdcd_obj.otherObjectDotCallThenWrite();
+assertTrue("CONTROL: dot-call on a DIFFERENT object does not detach (this.mkOther survives)",
+    structKeyExists(tdcd_obj, "mkOther"));
+
+tdcd_r = tdcd_obj.helperMemberDotCallThenWrite();
+assertTrue("CONTROL: dot-call through this.helperObj (receiver is not this) does not detach",
+    structKeyExists(tdcd_obj, "mkHelper"));
+
+tdcd_r = tdcd_obj.dotCallThenVariablesWrite();
+assert("CONTROL: variables-scope write after a dot-call survives",
+    tdcd_obj.getVMark(), "V");
+
+// ------------------------------------------------------------
+// PIN (documented behaviour, passes on BOTH engines): the detached copy
+// is SHALLOW -- mutating a nested struct reached through `this` escapes
+// the detach because the struct reference is shared. Pinned so an engine
+// fix keeps reference semantics for nested containers.
+// ------------------------------------------------------------
+tdcd_r = tdcd_obj.dotCallThenNestedStructMutation();
+assert("PIN: nested-struct mutation through this escapes (shared reference)",
+    tdcd_obj.bag.n, 7);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -34,6 +34,18 @@ try { include "core/test_arguments_writeback.cfm"; } catch (any e) { writeOutput
 try { include "core/test_argument_reference_nested.cfm"; } catch (any e) { writeOutput("ERROR | core/test_argument_reference_nested.cfm | " & e.message & chr(10)); }
 try { include "core/test_language_features.cfm"; } catch (any e) { writeOutput("ERROR | core/test_language_features.cfm | " & e.message & chr(10)); }
 try { include "core/test_scopes.cfm"; } catch (any e) { writeOutput("ERROR | core/test_scopes.cfm | " & e.message & chr(10)); }
+//   - this_dot_call_detaches_writes: inside a component method, a `this.`-DOT
+//     qualified method call (this.noop()) detaches the frame's `this` binding
+//     onto a data-complete SHALLOW COPY on RustCFML 0.108.0 -- every later
+//     this-write in that frame (and in frames it calls, any call shape) lands
+//     on the detached copy: visible in-frame, DISCARDED when the detaching
+//     frame returns. Bare calls, bracket calls (this["noop"]()), dot-READS,
+//     and dot-calls on other objects do not detach; variables-scope writes
+//     survive; nested-struct mutations escape (the copy is shallow -- pinned).
+//     Broke Wheels model persistence twice over (generated PK vanishing after
+//     create(), stale dirty-state after update()). Runtime-level: fails 3
+//     assertions, does NOT abort the run.
+try { include "core/test_this_dot_call_detaches_writes.cfm"; } catch (any e) { writeOutput("ERROR | core/test_this_dot_call_detaches_writes.cfm | " & e.message & chr(10)); }
 try { include "core/test_server_scope.cfm"; } catch (any e) { writeOutput("ERROR | core/test_server_scope.cfm | " & e.message & chr(10)); }
 try { include "core/test_localmode.cfm"; } catch (any e) { writeOutput("ERROR | core/test_localmode.cfm | " & e.message & chr(10)); }
 try { include "core/test_error_context.cfm"; } catch (any e) { writeOutput("ERROR | core/test_error_context.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

Inside a component method, a `this.`-DOT-qualified method call (`this.noop()`) must dispatch against the live object and leave the frame's `this` binding alone — Lucee (and Adobe CF, BoxLang) deliver every subsequent `this.key = value` write in that frame, and in any frame it calls, to the caller's object. RustCFML 0.108.0 instead **detaches the frame's `this` binding onto a data-complete SHALLOW COPY** at the moment of the dot-call: every later this-write in the frame (and in frames called after it, any call shape) lands on the detached copy — visible in-frame, **discarded when the detaching frame returns**.

```cfml
component {  // fixture
	public void function noop() {}
	public void function combo() {
		this.noop();      // <- detaches `this` on RustCFML
		this.mk = "X";    // lands on the detached copy
	}
}

o = createObject("component", "Fixture");
o.combo();
structKeyExists(o, "mk");  // Lucee: true | RustCFML 0.108.0: false
```

| After the method returns | Lucee 5.4.8.2 | RustCFML 0.108.0 |
|---|---|---|
| `this.noop(); this.mk = "X"` (new key) | `mk` present | `mk` missing — write discarded |
| `this.noop(); this.pre = "B"` (existing key) | `pre == "B"` | reverts to the pre-call value |
| `this.noop(); bareWrite()` (write in a frame called after the dot-call) | mark present | discarded with the detaching frame |
| `noop()` bare call, then write (control) | survives | survives — no detach |
| `this["noop"]()` bracket call, then write (control) | survives | survives — no detach |
| `f = this.noop` dot-READ, then write (control) | survives | survives — no detach |
| `other.noop()` / `this.member.noop()` (receiver is not `this`), then write (control) | survives | survives — no detach |
| `variables.x = ...` after a dot-call (control) | survives | survives — `variables` never snapshotted |
| `this.bag.n = 7` nested-struct mutation after a dot-call (pin) | escapes | escapes — the copy is shallow, struct refs shared |

The six green controls are the sharp wedge for the fix: the trigger is exactly the member-call shape `this.method()` — bare dispatch, bracket dispatch on `this`, dot-reads, and dot-calls whose receiver is another object all leave `this` attached. The detached copy is data-complete (in-frame reads see the writes; the suite asserts in-frame visibility separately from after-return survival) and shallow (nested-struct mutations escape — pinned so a fix can't silently regress reference semantics for nested containers). The failure is JIT-independent (identical under `RUSTCFML_JIT=0` and `RUSTCFML_JIT_THRESHOLD=1`) and depth-independent (bare recursion to depth 200 followed by a this-write stays green — re-verified on 0.108.0). It also does not propagate upward: caller writes after a poisoned callee returns are fine, and a fresh method call on the same object sees true state — which is exactly what made it hard to localize from above.

## What the test asserts

- Dot-call then NEW-KEY this-write: visible in-frame (green on both engines), and `this.mkNew` survives the return. *(after-return assert red on RustCFML)*
- Dot-call then EXISTING-KEY overwrite: visible in-frame (green on both), and `this.pre == "B"` after return — RustCFML silently reverts it. *(red on RustCFML)*
- Dot-call poisons frames called AFTER it: a this-write made inside a nested BARE call is also discarded on the outer return. *(red on RustCFML)*
- CONTROL (green on both engines): bare call `noop()` does not detach.
- CONTROL (green on both engines): bracket call `this["noop"]()` does not detach.
- CONTROL (green on both engines): dot-READ `f = this.noop` does not detach.
- CONTROL (green on both engines): dot-call on a DIFFERENT object — both `other.noop()` and `this.helperObj.noop()` — does not detach.
- CONTROL (green on both engines): a `variables`-scope write after a dot-call survives.
- PIN (green on both engines): a nested-struct mutation through `this` escapes the detach — the copy is shallow and shares struct references.

## Why it matters for Wheels

This is the gap that broke Wheels model persistence end-to-end while laddering the blog app through full CRUD. The save chain crosses TWO masked detach points:

- `invokeWithTransaction()` calls `this.$hashedConnectionArgs()` (`vendor/wheels/model/transactions.cfc:24`) before dispatching `$save` — so the primary key, timestamps, and persisted-state flags written below it all landed on a detached copy. User-visible: after `update()` the DB row is correct but the caller's object keeps a stale `updatedAt` and reports `hasChanged() = true` with `changedProperties() = [updatedAt]`.
- `$create()` calls `this.columnDataForProperty()` (`vendor/wheels/model/create.cfc:289`) right before assigning the generated primary key — the PK write died one return later, so `create()` handed back an object with no id.

The two points overlapped and mimicked a single strange "transaction boundary" until each was isolated by elimination. Flipping each call site from `this.$x()` to the bare `$x()` — one line per site — restored full Lucee semantics: the sharpest possible demonstration that member-call dispatch clones the receiver while bare and bracket dispatch don't. Any CFC that calls one of its own methods with `this.` qualification and then mutates `this` is affected, so this reaches well beyond the two Wheels sites.

## Verification

- **RustCFML 0.108.0** (release binary): suite fails 3/13 — exactly the three after-return assertions; all three in-frame asserts, all six controls, and the shallow-copy pin pass. Identical results with `RUSTCFML_JIT=0` and with `RUSTCFML_JIT_THRESHOLD=1`.
- **Lucee 5.4.8.2** (CommandBox task runner; same assertions transliterated to a `chk()` harness because CommandBox shadows `assert`): 13/13 pass.
- Full `tests/runner.cfm` on this branch (RustCFML 0.108.0): **3642/3645 across 438 suites** — the only 3 failures are this suite's after-return assertions; no abort.