### PR TITLE
Add CFML test for PostgreSQL temporal parameter binds

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -161,6 +161,7 @@ try { include "tags/test_tags_cfcache.cfm"; } catch (any e) { writeOutput("ERROR
 try { include "tags/test_tags_cfstoredproc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfstoredproc.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfqueryparam_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfqueryparam_attribute_collection.cfm | " & e.message & chr(10)); }
 try { include "tags/test_queryexecute_param_structs.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_queryexecute_param_structs.cfm | " & e.message & chr(10)); }
+try { include "tags/test_pg_temporal_param_binds.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_pg_temporal_param_binds.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfqueryparam_interpolated_value.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_interpolated_value.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfquery_quoted_identifier.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfquery_quoted_identifier.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfquery_control_tags.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_pg_temporal_param_binds.cfm
+++ b/tests/tags/test_pg_temporal_param_binds.cfm
@@ -1,0 +1,101 @@
+<cfscript>
+// PostgreSQL temporal parameter binds (Lucee parity).
+//
+// Lucee binds CFML date/time values (and date-like strings) to PostgreSQL
+// timestamp / timestamptz / date / time columns. RustCFML currently binds
+// every parameter in the binary wire format but has no temporal encodings,
+// so any parameter bound to a temporal column fails server-side with
+// "incorrect binary data format in bind parameter N" (surfaced as a generic
+// "db error").
+//
+// Live test, gated on RUSTCFML_TEST_PG_URL (same pattern as the S3 tests).
+// To run locally:
+//   docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
+//   RUSTCFML_TEST_PG_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres \
+//     cargo run -- tests/runner.cfm
+
+suiteBegin("PostgreSQL temporal param binds (skipped without RUSTCFML_TEST_PG_URL)");
+
+pgdsn = "";
+try {
+    pgdsn = server.system.environment.RUSTCFML_TEST_PG_URL ?: "";
+} catch (any e) {
+    pgdsn = "";
+}
+
+pgskip = false;
+tbl = "zz_rcfml_temporal_" & lCase(left(replace(createUUID(), "-", "", "all"), 8));
+
+if (pgdsn == "") {
+    pgskip = true;
+    writeOutput("  (skipped — set RUSTCFML_TEST_PG_URL to enable)" & chr(10));
+} else {
+    try {
+        queryExecute("CREATE TABLE #tbl# (id int, ts timestamptz, tsn timestamp, d date, t time)",
+            [], { datasource: pgdsn });
+    } catch (any e) {
+        pgskip = true;
+        writeOutput("  (skipped — PostgreSQL not reachable: " & e.message & ")" & chr(10));
+    }
+}
+
+if (NOT pgskip) {
+    try {
+        // --- control: non-temporal binds already work ---
+        queryExecute("INSERT INTO #tbl# (id) VALUES (?)", [1], { datasource: pgdsn });
+        rc = queryExecute("SELECT id FROM #tbl# WHERE id = ?", [1], { datasource: pgdsn });
+        assert("integer param binds (control)", rc.recordCount, 1);
+
+        // --- gap: CFML datetime value bound to timestamptz ---
+        queryExecute("UPDATE #tbl# SET ts = ? WHERE id = 1",
+            [createDateTime(2024, 3, 15, 10, 30, 45)], { datasource: pgdsn });
+        r1 = queryExecute("SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("datetime value binds to timestamptz", r1.s[1] ?: "", "2024-03-15 10:30:45");
+
+        // --- gap: CFML datetime value bound to timestamp (no tz) ---
+        queryExecute("UPDATE #tbl# SET tsn = ? WHERE id = 1",
+            [createDateTime(2025, 12, 31, 23, 59, 59)], { datasource: pgdsn });
+        r2 = queryExecute("SELECT to_char(tsn, 'YYYY-MM-DD HH24:MI:SS') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("datetime value binds to timestamp", r2.s[1] ?: "", "2025-12-31 23:59:59");
+
+        // --- gap: CFML date value bound to date ---
+        queryExecute("UPDATE #tbl# SET d = ? WHERE id = 1",
+            [createDate(2024, 3, 15)], { datasource: pgdsn });
+        r3 = queryExecute("SELECT to_char(d, 'YYYY-MM-DD') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("date value binds to date", r3.s[1] ?: "", "2024-03-15");
+
+        // --- gap: CFML time value bound to time ---
+        queryExecute("UPDATE #tbl# SET t = ? WHERE id = 1",
+            [createTime(10, 30, 45)], { datasource: pgdsn });
+        r4 = queryExecute("SELECT to_char(t, 'HH24:MI:SS') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("time value binds to time", r4.s[1] ?: "", "10:30:45");
+
+        // --- gap: date-like STRING bound to timestamp (Lucee accepts) ---
+        queryExecute("UPDATE #tbl# SET tsn = ? WHERE id = 1",
+            ["2026-01-02 03:04:05"], { datasource: pgdsn });
+        r5 = queryExecute("SELECT to_char(tsn, 'YYYY-MM-DD HH24:MI:SS') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("ISO string binds to timestamp", r5.s[1] ?: "", "2026-01-02 03:04:05");
+
+        // --- gap: cfqueryparam-style struct with cf_sql_timestamp ---
+        queryExecute("UPDATE #tbl# SET ts = ? WHERE id = 1",
+            [{ value: createDateTime(2024, 6, 1, 12, 0, 0), cfsqltype: "cf_sql_timestamp" }],
+            { datasource: pgdsn });
+        r6 = queryExecute("SELECT to_char(ts, 'YYYY-MM-DD HH24:MI:SS') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("cf_sql_timestamp param struct binds", r6.s[1] ?: "", "2024-06-01 12:00:00");
+    } catch (any e) {
+        assertTrue("temporal binds failed: " & e.message, false);
+    }
+
+    try {
+        queryExecute("DROP TABLE #tbl#", [], { datasource: pgdsn });
+    } catch (any e) {}
+}
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

A live-PostgreSQL test for parameters bound to temporal columns (`timestamptz`, `timestamp`, `date`, `time`): CFML date/time values, a date-like string, and a cfqueryparam-style `cf_sql_timestamp` param struct.

Gated on `RUSTCFML_TEST_PG_URL` (same pattern as the S3 live tests) and self-skips when unset or the server is unreachable, so the suite stays green on machines/CI without PostgreSQL. To run it:

```
docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
RUSTCFML_TEST_PG_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres cargo run -- tests/runner.cfm
```

## Why

RustCFML binds every pg parameter in the binary wire format, but has no temporal encodings — any parameter bound to a temporal column fails server-side with `ERROR: incorrect binary data format in bind parameter N`, surfaced in CFML as a generic "db error". Lucee binds all of these. First real-world hit: a framework's "stay logged in" INSERT into a `timestamptz` column 500s the login page.

On current main (v0.112.0):

```
FAIL | PostgreSQL temporal param binds | 1/2 passed (1 failed)
       FAIL: temporal binds failed: queryExecute: PostgreSQL error: db error
```

## Coverage

- control: integer param binds (passes today)
- CFML datetime → `timestamptz` and `timestamp`
- CFML date → `date`, CFML time → `time`
- date-like string (`"2026-01-02 03:04:05"`) → `timestamp` (Lucee accepts)
- cfqueryparam-style struct `{value, cfsqltype: "cf_sql_timestamp"}`
- round-trips asserted via server-side `to_char()` so the test doesn't depend on client-side temporal decoding

## Where the fix goes

The pg parameter encoding path in `crates/cfml-stdlib` — the same match that already parses uuid/int/float/numeric/bool parameter text into native binary encodings — needs temporal arms: parse CFML datetime text (stringified date objects, ODBC `{ts ...}`, ISO 8601, bare dates) and encode via chrono's `ToSql` impls. (An alternative general fix: fall back to text-format params for types with no binary encoding.)
