### PR TITLE
Add CFML test for PostgreSQL error cause chaining

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -164,6 +164,7 @@ try { include "tags/test_queryexecute_param_structs.cfm"; } catch (any e) { writ
 try { include "tags/test_cfqueryparam_interpolated_value.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_interpolated_value.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfquery_quoted_identifier.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfquery_quoted_identifier.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfquery_control_tags.cfm | " & e.message & chr(10)); }
+try { include "tags/test_pg_error_cause_chain.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_pg_error_cause_chain.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_mapping_path.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_function_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_function_form.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfhttpparam_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttpparam_runtime_body.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_pg_error_cause_chain.cfm
+++ b/tests/tags/test_pg_error_cause_chain.cfm
@@ -1,0 +1,73 @@
+<cfscript>
+// PostgreSQL error messages must surface the server's cause (Lucee parity).
+//
+// When a query fails server-side, Lucee surfaces the driver's message in
+// cfcatch.message (e.g. "function zz_x() does not exist"). RustCFML currently
+// reports only the top-level error Display — a bare "db error" — and drops
+// the chained source() detail, which makes real failures undiagnosable from
+// CFML (and from the server log).
+//
+// Live test, gated on RUSTCFML_TEST_PG_URL (same pattern as the S3 tests).
+// To run locally:
+//   docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
+//   RUSTCFML_TEST_PG_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres \
+//     cargo run -- tests/runner.cfm
+
+suiteBegin("PostgreSQL error cause chain (skipped without RUSTCFML_TEST_PG_URL)");
+
+pgdsn = "";
+try {
+    pgdsn = server.system.environment.RUSTCFML_TEST_PG_URL ?: "";
+} catch (any e) {
+    pgdsn = "";
+}
+
+pgskip = false;
+
+if (pgdsn == "") {
+    pgskip = true;
+    writeOutput("  (skipped — set RUSTCFML_TEST_PG_URL to enable)" & chr(10));
+} else {
+    try {
+        queryExecute("SELECT 1", [], { datasource: pgdsn });
+    } catch (any e) {
+        pgskip = true;
+        writeOutput("  (skipped — PostgreSQL not reachable: " & e.message & ")" & chr(10));
+    }
+}
+
+if (NOT pgskip) {
+    // --- gap: a server-side error must carry the server's message ---
+    msg = "";
+    try {
+        queryExecute("SELECT zz_definitely_not_a_function_98765()", [], { datasource: pgdsn });
+        assertTrue("undefined-function query should have thrown", false);
+    } catch (any e) {
+        msg = e.message & " " & (e.detail ?: "");
+    }
+    assertTrue("error message names the failing function (got: [" & msg & "])",
+        find("zz_definitely_not_a_function_98765", msg) GT 0);
+    assertTrue("error message carries the server cause, not just 'db error' (got: [" & msg & "])",
+        findNoCase("does not exist", msg) GT 0);
+
+    // --- gap: same for a constraint violation ---
+    tbl = "zz_rcfml_chain_" & lCase(left(replace(createUUID(), "-", "", "all"), 8));
+    msg2 = "";
+    try {
+        queryExecute("CREATE TABLE #tbl# (id int PRIMARY KEY)", [], { datasource: pgdsn });
+        queryExecute("INSERT INTO #tbl# VALUES (1)", [], { datasource: pgdsn });
+        queryExecute("INSERT INTO #tbl# VALUES (1)", [], { datasource: pgdsn });
+        assertTrue("duplicate-key insert should have thrown", false);
+    } catch (any e) {
+        msg2 = e.message & " " & (e.detail ?: "");
+    }
+    assertTrue("constraint violation surfaces the server cause (got: [" & msg2 & "])",
+        findNoCase("duplicate key", msg2) GT 0 OR findNoCase("unique", msg2) GT 0);
+
+    try {
+        queryExecute("DROP TABLE #tbl#", [], { datasource: pgdsn });
+    } catch (any e) {}
+}
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

A live-PostgreSQL test asserting that server-side query errors surface the *server's* message in `cfcatch.message` — an undefined-function error and a unique-constraint violation.

Gated on `RUSTCFML_TEST_PG_URL` (same pattern as the S3 live tests), self-skips when unset/unreachable. To run it:

```
docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
RUSTCFML_TEST_PG_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres cargo run -- tests/runner.cfm
```

## Why

When a query fails server-side, Lucee surfaces the driver's message (e.g. `function zz_x() does not exist`) in `cfcatch.message`. RustCFML currently reports only the top-level error `Display` — a bare `db error` — and drops the chained `source()` detail, so real failures are undiagnosable from CFML and from the server log alike. Every other pg gap we've hit was masked behind this same `db error` string until we patched the chain locally.

On current main (v0.112.0):

```
FAIL | PostgreSQL error cause chain | 0/3 passed (3 failed)
       FAIL: error message names the failing function (got: [queryExecute: PostgreSQL query error: db error ])
       FAIL: error message carries the server cause, not just 'db error' (got: [queryExecute: PostgreSQL query error: db error ])
       FAIL: constraint violation surfaces the server cause (got: [queryExecute: PostgreSQL error: db error ])
```

## Coverage

- `SELECT zz_definitely_not_a_function_98765()` → message must contain the function name and "does not exist"
- duplicate-key INSERT into a PRIMARY KEY column → message must contain "duplicate key" / "unique"
- asserts on `e.message & " " & e.detail` so either field satisfying parity passes

## Where the fix goes

Wherever tokio_postgres errors are formatted into CFML exceptions: walk `std::error::Error::source()` and append each cause to the message (e.g. `db error <- ERROR: function … does not exist`), instead of stopping at the top-level `Display`.
