### PR TITLE
Add CFML test for cfdirectory recurse through symlinked directories

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -166,6 +166,7 @@ try { include "tags/test_cfquery_quoted_identifier.cfm"; } catch (any e) { write
 try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfquery_control_tags.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_mapping_path.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_function_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_function_form.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cfdirectory_recurse_symlink.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_recurse_symlink.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfhttpparam_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttpparam_runtime_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfmail_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfmail_runtime_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfstoredproc_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfstoredproc_runtime_body.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_cfdirectory_recurse_symlink.cfm
+++ b/tests/tags/test_cfdirectory_recurse_symlink.cfm
@@ -1,0 +1,79 @@
+<cfscript>
+// cfdirectory recurse=true must traverse symlinked directories (Lucee parity).
+//
+// Lucee's recursive directory listing follows directory symlinks; RustCFML's
+// does not, so files reachable only through a symlinked directory silently
+// vanish from the listing. This silently breaks apps that assemble route or
+// component registries from a recursive scan over a tree that contains
+// symlinks.
+//
+// Creating a symlink portably from CFML needs `ln -s` via cfexecute, so this
+// test is POSIX-only and self-skips when the link cannot be created.
+
+suiteBegin("cfdirectory recurse=true traverses symlinked directories");
+
+lnskip = false;
+base = getTempDirectory() & "/rcfml_symlink_" & lCase(left(replace(createUUID(), "-", "", "all"), 8));
+realDir = base & "/real_dir";
+linkDir = base & "/linked_dir";
+
+try {
+    directoryCreate(realDir, true);
+    fileWrite(realDir & "/Probe.cfc", "component {}");
+} catch (any e) {
+    lnskip = true;
+    writeOutput("  (skipped — cannot create fixture dir: " & e.message & ")" & chr(10));
+}
+</cfscript>
+
+<cfif NOT lnskip>
+    <cftry>
+        <cfexecute name="/bin/ln" arguments="-s #realDir# #linkDir#" timeout="10" />
+        <cfcatch type="any">
+            <cfset lnskip = true />
+            <cfoutput>  (skipped — cannot create symlink: #cfcatch.message#)#chr(10)#</cfoutput>
+        </cfcatch>
+    </cftry>
+</cfif>
+
+<cfif NOT lnskip>
+    <cfif NOT directoryExists(linkDir)>
+        <cfset lnskip = true />
+        <cfoutput>  (skipped — symlink was not created)#chr(10)#</cfoutput>
+    </cfif>
+</cfif>
+
+<cfif NOT lnskip>
+    <!--- control: listing the symlinked directory AS the root works today --->
+    <cfdirectory action="list" directory="#linkDir#" name="qDirect" filter="*.cfc" />
+    <cfscript>
+    assert("listing through a symlinked root finds the file (control)",
+        qDirect.recordCount, 1);
+    </cfscript>
+
+    <!--- control: non-recursive listing of the parent sees both entries --->
+    <cfdirectory action="list" directory="#base#" name="qTop" />
+    <cfscript>
+    assert("non-recursive parent listing sees both dirs (control)",
+        qTop.recordCount, 2);
+    </cfscript>
+
+    <!--- gap: recursive listing must traverse INTO the symlinked directory.
+          Lucee finds Probe.cfc twice (real_dir + linked_dir); an engine that
+          does not follow directory symlinks finds it once. --->
+    <cfdirectory action="list" directory="#base#" name="qRec" recurse="true" filter="*.cfc" />
+    <cfscript>
+    assert("recursive listing traverses the symlinked directory",
+        qRec.recordCount, 2);
+    </cfscript>
+</cfif>
+
+<cfscript>
+try {
+    if (directoryExists(base)) {
+        directoryDelete(base, true);
+    }
+} catch (any e) {}
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

A test that `<cfdirectory action="list" recurse="true">` traverses *symlinked* directories the way Lucee does. POSIX-only: the symlink is created with `/bin/ln -s` via cfexecute, and the test self-skips when the link can't be created (e.g. Windows).

## Why

Lucee's recursive directory listing follows directory symlinks; RustCFML's does not, so files reachable only through a symlinked directory silently vanish from the listing — no error, just missing rows. Real-world hit: an app that assembles its route registry from a recursive `cfdirectory` scan lost every route under a symlinked directory, surfacing as unexplained 404s.

On current main (v0.112.0):

```
FAIL | cfdirectory recurse=true traverses symlinked directories | 2/3 passed (1 failed)
       FAIL: recursive listing traverses the symlinked directory | expected: [2] | got: [1]
```

## Coverage

- fixture: `base/real_dir/Probe.cfc` plus `base/linked_dir → real_dir`
- control: listing the symlinked directory *as the root* finds the file (passes today)
- control: non-recursive listing of the parent sees both entries (passes today)
- gap: `recurse="true" filter="*.cfc"` from the parent must find the file twice (Lucee: 2, current RustCFML: 1)

## Where the fix goes

The recursive walker behind `cfdirectory action="list"`: it should descend into directory symlinks. Worth pairing with cycle protection (track visited canonical paths) since following symlinks makes loops possible — Lucee follows them regardless.
