### PR TITLE
Add CFML test for invoke() keeping undeclared named arguments

### DIFF
--- a/tests/core/InvokeUndeclaredArgFixture.cfc
+++ b/tests/core/InvokeUndeclaredArgFixture.cfc
@@ -1,0 +1,10 @@
+component {
+	public string function probe(required string a) {
+		var hasB = StructKeyExists(arguments, "b");
+		var hasC = StructKeyExists(arguments, "c");
+		if (hasB && hasC) {
+			return "a=" & arguments.a & ",b=" & arguments.b & ",c=" & arguments.c;
+		}
+		return "MISSING (keys=" & StructKeyList(arguments) & ")";
+	}
+}

--- a/tests/core/test_invoke_undeclared_named_args.cfm
+++ b/tests/core/test_invoke_undeclared_named_args.cfm
@@ -1,0 +1,39 @@
+<cfscript>
+// invoke() must keep undeclared named arguments (Lucee parity).
+//
+// Direct method calls already keep named arguments that match no declared
+// cfargument — they land in the arguments scope by name (covered by
+// core/test_undeclared_named_args.cfm). Lucee behaves the same when the call
+// goes through invoke() or <cfinvoke>. RustCFML currently DROPS the
+// undeclared names on the invoke() path, so only declared parameters arrive.
+// This breaks dynamic dispatch frameworks that pass route/request parameters
+// as an argument struct: invoke(handler, endpoint, args) silently loses
+// every key the handler did not declare.
+
+suiteBegin("Core: invoke() keeps undeclared named arguments");
+
+o = createObject("component", "InvokeUndeclaredArgFixture");
+
+// --- control: direct call keeps undeclared named args ---
+assert("direct call keeps undeclared named args (control)",
+	o.probe(a = "A", b = "B", c = "C"), "a=A,b=B,c=C");
+
+// --- control: invoke() passes DECLARED args fine (no missing-arg error) ---
+declaredOnly = invoke(o, "probe", { a: "A" });
+assertTrue("invoke() passes declared args (control)",
+	find("MISSING", declaredOnly) EQ 1);
+
+// --- gap: invoke() with an argument struct keeps undeclared names ---
+assert("invoke() keeps undeclared named args",
+	invoke(o, "probe", { a: "A", b: "B", c: "C" }), "a=A,b=B,c=C");
+</cfscript>
+
+<!--- --- gap: <cfinvoke> with extra attributes behaves like Lucee too --- --->
+<cfinvoke component="#o#" method="probe" returnvariable="tagResult"
+	a="A" b="B" c="C" />
+
+<cfscript>
+assert("cfinvoke keeps undeclared named args", tagResult, "a=A,b=B,c=C");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -18,6 +18,7 @@ try { include "core/test_function_scope_capture.cfm"; } catch (any e) { writeOut
 try { include "core/test_closure_env_leak.cfm"; } catch (any e) { writeOutput("ERROR | core/test_closure_env_leak.cfm | " & e.message & chr(10)); }
 try { include "core/test_compound_assignment.cfm"; } catch (any e) { writeOutput("ERROR | core/test_compound_assignment.cfm | " & e.message & chr(10)); }
 try { include "core/test_undeclared_named_args.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undeclared_named_args.cfm | " & e.message & chr(10)); }
+try { include "core/test_invoke_undeclared_named_args.cfm"; } catch (any e) { writeOutput("ERROR | core/test_invoke_undeclared_named_args.cfm | " & e.message & chr(10)); }
 try { include "core/test_struct_method_sequential.cfm"; } catch (any e) { writeOutput("ERROR | core/test_struct_method_sequential.cfm | " & e.message & chr(10)); }
 try { include "core/test_include_scope_capture.cfm"; } catch (any e) { writeOutput("ERROR | core/test_include_scope_capture.cfm | " & e.message & chr(10)); }
 try { include "core/test_operators.cfm"; } catch (any e) { writeOutput("ERROR | core/test_operators.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## What

A pure-CFML test (no db, no network) that `invoke()` and `<cfinvoke>` keep named arguments that match no declared `cfargument` — the same behaviour direct method calls already have (covered by `core/test_undeclared_named_args.cfm`).

## Why

In Lucee, undeclared named arguments arrive in the callee's `arguments` scope by name whether the call is direct, via `invoke()`, or via `<cfinvoke>`. RustCFML keeps them on direct calls but DROPS them on the invoke path, so only declared parameters arrive. This silently breaks dynamic-dispatch frameworks: `invoke(handler, endpoint, args)` loses every key the handler didn't declare — in our app, every dynamic route parameter vanished ("No ID provided" on every parameterised route).

On current main (v0.112.0):

```
FAIL | Core: invoke() keeps undeclared named arguments | 2/4 passed (2 failed)
       FAIL: invoke() keeps undeclared named args | expected: [a=A,b=B,c=C] | got: [MISSING (keys=a)]
       FAIL: cfinvoke keeps undeclared named args | expected: [a=A,b=B,c=C] | got: [MISSING (keys=a)]
```

## Coverage

- control: direct call `o.probe(a="A", b="B", c="C")` keeps all three (passes today)
- control: `invoke()` with only the declared argument dispatches fine (passes today)
- gap: `invoke(o, "probe", {a, b, c})` must deliver `b`/`c` in the arguments scope
- gap: `<cfinvoke component="#o#" method="probe" a="A" b="B" c="C">` likewise

## Where the fix goes

The named-argument binding path used by `invoke()`/`__cfinvoke`: after matching declared `cfargument`s, unmatched named arguments should be appended to the callee's arguments scope by name — identical to what the direct named-call path already does.
