### PR TITLE
test(core): getPageContext() must provide non-null request/response objects

### DIFF
--- a/tests/core/test_pagecontext_request_response.cfm
+++ b/tests/core/test_pagecontext_request_response.cfm
@@ -1,0 +1,58 @@
+<cfscript>
+suiteBegin("Core: getPageContext() provides non-null request/response objects");
+
+// ============================================================
+// Background
+// ============================================================
+// The page context's servlet-bridge accessors are a load-bearing CFML
+// surface: getPageContext().getRequest() / .getResponse() return live
+// request/response objects on Lucee and Adobe CF in EVERY execution
+// context — including CLI/task contexts, where Lucee synthesizes them
+// (getRequestURL() returns "http://localhost/index.cfm" under a
+// CommandBox task with no real HTTP request in sight).
+//
+// RustCFML 0.124.0 returns a non-null page-context STUB whose
+// getRequest() and getResponse() are NULL, in both CLI and serve mode.
+//
+// Until v0.119.0 this was masked: a method call on a null receiver
+// silently returned null, so chains like
+//     GetPageContext().getRequest().getRequestURL()
+// limped through as null. v0.119.0 (PR #94) correctly made null-receiver
+// calls THROW — which turned the missing bridge into a request-killing
+// error: Wheels calls exactly that chain while building request URLs
+// (vendor/wheels/Global.cfc:2403), so every request on a Wheels app now
+// 500s with "cannot call method [getRequestURL] on a null value".
+// The fix that exposed it is right; the bridge underneath it is the gap.
+// ============================================================
+
+pgctxPc = getPageContext();
+pgctxReqNull = true;
+pgctxRespNull = true;
+pgctxReqUrl = "(unavailable)";
+if (!isNull(pgctxPc)) {
+    pgctxReq = pgctxPc.getRequest();
+    pgctxReqNull = isNull(pgctxReq);
+    if (!pgctxReqNull) {
+        try {
+            pgctxReqUrl = toString(pgctxReq.getRequestURL());
+        } catch (any pgctxE) {
+            pgctxReqUrl = "(threw: " & pgctxE.message & ")";
+        }
+    }
+    pgctxResp = pgctxPc.getResponse();
+    pgctxRespNull = isNull(pgctxResp);
+}
+
+// CONTROL (passes on both engines): the page context itself exists.
+assertFalse("CONTROL: getPageContext() returns an object", isNull(pgctxPc));
+
+// --- the gap: the bridge objects must be non-null in every context ---
+assertFalse("getPageContext().getRequest() returns a non-null request object",
+    pgctxReqNull);
+assertFalse("getPageContext().getResponse() returns a non-null response object",
+    pgctxRespNull);
+assertTrue("request.getRequestURL() yields a non-empty simple value",
+    isSimpleValue(pgctxReqUrl) && len(pgctxReqUrl) && left(pgctxReqUrl, 1) != "(");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -80,6 +80,15 @@ try { include "core/test_scopes.cfm"; } catch (any e) { writeOutput("ERROR | cor
 //     assertions, does NOT abort the run.
 try { include "core/test_this_dot_call_detaches_writes.cfm"; } catch (any e) { writeOutput("ERROR | core/test_this_dot_call_detaches_writes.cfm | " & e.message & chr(10)); }
 try { include "core/test_server_scope.cfm"; } catch (any e) { writeOutput("ERROR | core/test_server_scope.cfm | " & e.message & chr(10)); }
+//   - pagecontext_request_response: getPageContext().getRequest() /
+//     .getResponse() must return non-null servlet-bridge objects in EVERY
+//     execution context (Lucee synthesizes them even under a CLI task:
+//     getRequestURL() = "http://localhost/index.cfm"). RustCFML returns a
+//     stub with null request/response — masked until v0.119.0's correct
+//     method-on-null throw, which turned the chain Wheels runs on every
+//     request (GetPageContext().getRequest().getRequestURL(),
+//     vendor/wheels/Global.cfc:2403) into a request-killing 500.
+try { include "core/test_pagecontext_request_response.cfm"; } catch (any e) { writeOutput("ERROR | core/test_pagecontext_request_response.cfm | " & e.message & chr(10)); }
 try { include "core/test_localmode.cfm"; } catch (any e) { writeOutput("ERROR | core/test_localmode.cfm | " & e.message & chr(10)); }
 try { include "core/test_error_context.cfm"; } catch (any e) { writeOutput("ERROR | core/test_error_context.cfm | " & e.message & chr(10)); }
 try { include "core/test_null_coalescing.cfm"; } catch (any e) { writeOutput("ERROR | core/test_null_coalescing.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap: getPageContext().getRequest() / .getResponse() return null

The page context's servlet-bridge accessors are a load-bearing CFML surface. On Lucee (and Adobe CF) they return live request/response objects in **every** execution context — even CLI/task contexts, where Lucee synthesizes them:

```cfml
pc = getPageContext();
r  = pc.getRequest();      // Lucee: object — even under a CommandBox task
r.getRequestURL();          // Lucee CLI: "http://localhost/index.cfm"
pc.getResponse();           // Lucee: object
```

| call | RustCFML 0.124.0 | Lucee 5.4.8.2 |
|------|------------------|---------------|
| `getPageContext()` | non-null stub (control passes) | object |
| `.getRequest()` | **null** | request object |
| `.getResponse()` | **null** | response object |
| `request.getRequestURL()` | unreachable | `"http://localhost/index.cfm"` (synthetic, CLI) |

### How v0.119.0 unmasked it

Until v0.119.0 this was invisible: a method call on a null receiver silently returned null, so chains through the missing bridge limped along as null. v0.119.0 (PR #94) **correctly** made null-receiver calls throw — which turned the missing bridge into a request-killing error. Wheels calls exactly this chain while building request URLs (`vendor/wheels/Global.cfc:2403`):

```cfml
GetPageContext().getRequest().getRequestURL()
```

so on ≥ v0.119.0 every request on a Wheels app dies with `cannot call method [getRequestURL] on a null value` → 500. The throw is right; the bridge underneath it is the gap. (This is the next layer of the recurring pattern: each correctness fix exposes what silent failures were hiding.)

### What the test asserts

- CONTROL (green on both engines): `getPageContext()` itself returns an object.
- `.getRequest()` is non-null. *(red on RustCFML)*
- `.getResponse()` is non-null. *(red on RustCFML)*
- `request.getRequestURL()` yields a non-empty simple value. *(red on RustCFML — guarded so the null never crashes the suite)*

### Verification

- **RustCFML 0.124.0** (release binary): 1/4 — only the control passes; identical in CLI mode (and serve mode exhibits the same nulls — that's where the Wheels 500 reproduces).
- **Lucee 5.4.8.2** (CommandBox task): 4/4 — including the synthetic request URL with no real HTTP request in sight.
- Full `tests/runner.cfm` on this branch (RustCFML 0.124.0): **3735/3738 across 445 suites** — the only 3 failures are this suite's bridge assertions; no abort.
- Runtime gap (nulls, no parse error) → registered in the core block next to `test_server_scope.cfm`.
