### PR TITLE
test(core): savecontent must deliver to a scope-qualified target variable

### DIFF
--- a/tests/core/test_savecontent_scoped_target.cfm
+++ b/tests/core/test_savecontent_scoped_target.cfm
@@ -1,0 +1,66 @@
+<cfscript>
+suiteBegin("Core: savecontent delivers to a scope-qualified target variable");
+
+// ============================================================
+// Background
+// ============================================================
+// savecontent's variable= attribute accepts a SCOPE-QUALIFIED name:
+// inside a function, variable="local.cap" must populate local.cap, and
+// variable="variables.cap" must populate the variables scope — on Lucee
+// (and Adobe CF) every form works identically to the unqualified one.
+//
+// RustCFML 0.128.0 captures correctly for UNQUALIFIED targets
+// (variable="cap", incl. a pre-declared `var cap`) but silently drops
+// the capture for scope-qualified targets: after the block,
+// local.cap / variables.cap simply don't exist. The body DOES execute
+// (side effects fire) — only the captured string is lost.
+//
+//   function f() {
+//       savecontent variable="local.cap" { writeOutput("X"); }
+//       return structKeyExists(local, "cap");   // RustCFML: false | Lucee: true
+//   }
+//
+// Why it matters for Wheels: EVERY view render runs through
+// $includeAndReturnOutput (vendor/wheels/Global.cfc):
+//
+//       savecontent variable="local.$wheels" { include "#template#"; }
+//       return local.$wheels;
+//
+// so on RustCFML every rendered view comes back EMPTY — the framework
+// boots, routes, and executes the view, then returns nothing. This is
+// the last gap standing between Wheels' blog tutorial app and a fully
+// stock RustCFML binary.
+// ============================================================
+
+function scstLocal() {
+    savecontent variable="local.scstCap" { writeOutput("LOCAL_OK"); }
+    return structKeyExists(local, "scstCap") ? local.scstCap : "(local.scstCap missing)";
+}
+function scstVariablesScope() {
+    savecontent variable="variables.scstCap2" { writeOutput("VARIABLES_OK"); }
+    return structKeyExists(variables, "scstCap2") ? variables.scstCap2 : "(variables.scstCap2 missing)";
+}
+function scstBare() {
+    savecontent variable="scstCap3" { writeOutput("BARE_OK"); }
+    return isDefined("scstCap3") ? scstCap3 : "(scstCap3 missing)";
+}
+function scstVarDeclared() {
+    var scstCap4 = "";
+    savecontent variable="scstCap4" { writeOutput("VAR_OK"); }
+    return scstCap4;
+}
+
+// --- the gap: scope-qualified targets must receive the capture ---
+assert("variable='local.X' populates local.X (the Wheels view-render shape)",
+    scstLocal(), "LOCAL_OK");
+assert("variable='variables.X' populates the variables scope",
+    scstVariablesScope(), "VARIABLES_OK");
+
+// --- CONTROLS (green on both engines): unqualified targets work ---
+assert("CONTROL: unqualified variable='x' captures",
+    scstBare(), "BARE_OK");
+assert("CONTROL: pre-declared `var x` + variable='x' captures",
+    scstVarDeclared(), "VAR_OK");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -32,6 +32,13 @@ try { include "core/test_undeclared_named_args.cfm"; } catch (any e) { writeOutp
 try { include "core/test_invoke_undeclared_keys.cfm"; } catch (any e) { writeOutput("ERROR | core/test_invoke_undeclared_keys.cfm | " & e.message & chr(10)); }
 try { include "core/test_struct_method_sequential.cfm"; } catch (any e) { writeOutput("ERROR | core/test_struct_method_sequential.cfm | " & e.message & chr(10)); }
 try { include "core/test_include_scope_capture.cfm"; } catch (any e) { writeOutput("ERROR | core/test_include_scope_capture.cfm | " & e.message & chr(10)); }
+//   - savecontent_scoped_target: savecontent's variable= attribute must
+//     deliver the capture to SCOPE-QUALIFIED targets (variable="local.cap" /
+//     "variables.cap"), not just unqualified ones. RustCFML silently dropped
+//     the scoped capture — Wheels renders EVERY view through
+//     savecontent variable="local.$wheels" { include ... } (Global.cfc), so
+//     all views came back empty on an otherwise-booting framework.
+try { include "core/test_savecontent_scoped_target.cfm"; } catch (any e) { writeOutput("ERROR | core/test_savecontent_scoped_target.cfm | " & e.message & chr(10)); }
 try { include "core/test_operators.cfm"; } catch (any e) { writeOutput("ERROR | core/test_operators.cfm | " & e.message & chr(10)); }
 try { include "core/test_subscript_autovivify.cfm"; } catch (any e) { writeOutput("ERROR | core/test_subscript_autovivify.cfm | " & e.message & chr(10)); }
 try { include "core/test_control_flow.cfm"; } catch (any e) { writeOutput("ERROR | core/test_control_flow.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap: savecontent drops the capture for scope-qualified target variables

savecontent's `variable=` attribute accepts a scope-qualified name: inside a function, `variable="local.cap"` must populate `local.cap`, and `variable="variables.cap"` must populate the variables scope. On Lucee every form behaves identically to the unqualified one. RustCFML 0.128.0 captures correctly for **unqualified** targets (`variable="cap"`, including a pre-declared `var cap`) but **silently drops** the capture for scope-qualified targets — the body executes (side effects fire), only the captured string is lost:

```cfml
function f() {
    savecontent variable="local.cap" { writeOutput("X"); }
    return structKeyExists(local, "cap");
}
```

| target form | RustCFML 0.128.0 | Lucee 5.4.8.2 |
|-------------|------------------|---------------|
| `variable="local.cap"` | **missing** | `"X"` |
| `variable="variables.cap"` | **missing** | captured |
| `variable="cap"` (control) | captured | captured |
| `var cap` + `variable="cap"` (control) | captured | captured |

### Why it matters for Wheels

This is the last gap standing between the Wheels blog tutorial app and a fully **stock** RustCFML binary. Every view render runs through `$includeAndReturnOutput` (`vendor/wheels/Global.cfc`):

```cfml
savecontent variable="local.$wheels" { include "#LCase(arguments.$template)#"; }
return local.$wheels;
```

so without a workaround every rendered view comes back empty — the framework boots, routes, executes the view template, then returns nothing. With the v0.125–v0.128 wave (issue #90's result-delivery + dbinfo, PR #107's servlet bridge) all the other Wheels-side workarounds are now redundant; this one still stands.

### What the test asserts

- `variable="local.X"` populates `local.X` — the exact Wheels view-render shape. *(red on RustCFML)*
- `variable="variables.X"` populates the variables scope. *(red on RustCFML)*
- CONTROLS (green on both engines): unqualified `variable="x"`, and pre-declared `var x` + `variable="x"`.

### Verification

- **RustCFML 0.128.0** (release binary): 2/4 — both scoped-target assertions fail with "(… missing)"; both controls pass. Full `tests/runner.cfm` on this branch: **3829/3831 across 449 suites** — the only 2 failures are this suite's; no abort.
- **Lucee 5.4.8.2** (CommandBox): 4/4 PASS.
- Runtime gap (lost capture, no parse error) → registered in the core block next to `test_include_scope_capture.cfm`.
