### PR TITLE
test(tags): cfinvoke call form must marshal attributeCollection, deliver returnVariable, and dispatch sibling methods

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -368,6 +368,18 @@ try { include "core/test_component_soft_keyword.cfm"; } catch (any e) { writeOut
 //     also accepts the ACF-style cf-prefixed `cfinvoke` spelling, but Lucee
 //     rejects it, so the cross-engine test uses the cf-less `invoke`.)
 try { include "tags/test_cfinvoke_statement.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfinvoke_statement.cfm | " & e.message & chr(10)); }
+//   - cfinvoke_call_form_marshaling: the cf-PREFIXED parenthesized CALL form
+//     cfinvoke(...) — the spelling Lucee accepts and Wheels' Global.cfc
+//     $invoke() uses — runs but marshals nothing: the method attr is never
+//     read out of attributeCollection ("Method '' not found in component"),
+//     returnVariable is silently dropped in EVERY form, and the componentless
+//     form resolves the METHOD name as a COMPONENT path instead of
+//     dispatching the sibling method. cfquery(attributeCollection) honors the
+//     same spelling (in-suite control), so only cfinvoke's attribute
+//     marshaling is broken. This family alone kept pristine Wheels from
+//     booting: onApplicationStart -> $loadRoutes -> $simpleLock -> $invoke ->
+//     cfinvoke died, 500ing every request.
+try { include "tags/test_cfinvoke_tag_marshaling.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfinvoke_tag_marshaling.cfm | " & e.message & chr(10)); }
 //   - script_transaction_attrs: cfscript `transaction action="begin" { ... }`
 //     (the attribute form of the transaction tag, with a body).
 try { include "tags/test_script_transaction_attrs.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_script_transaction_attrs.cfm | " & e.message & chr(10)); }

--- a/tests/tags/CfInvokeMarshalFixture.cfc
+++ b/tests/tags/CfInvokeMarshalFixture.cfc
@@ -1,0 +1,26 @@
+// Fixture for the cfinvoke call-form marshaling test. `hello` and `sibling`
+// are plain probes; `invokeSibling` exercises the componentless call form
+// FROM INSIDE a CFC method — the Wheels Global.cfc $invoke() shape when the
+// target method already lives on the calling component. The try/catch turns
+// an engine error into a comparable string so the suite reports a failed
+// assertion instead of aborting.
+component {
+
+	public string function hello(string who = "world") {
+		return "hello-" & arguments.who;
+	}
+
+	public string function sibling() {
+		return "sibling-ok";
+	}
+
+	public string function invokeSibling() {
+		try {
+			cfinvoke(method = "sibling", returnVariable = "local.rv");
+		} catch (any e) {
+			return "THREW: " & e.message;
+		}
+		return StructKeyExists(local, "rv") ? local.rv : "RV-UNSET";
+	}
+
+}

--- a/tests/tags/test_cfinvoke_tag_marshaling.cfm
+++ b/tests/tags/test_cfinvoke_tag_marshaling.cfm
@@ -1,0 +1,152 @@
+<cfscript>
+suiteBegin("Tags: cfinvoke call form marshals attributeCollection, returnVariable, sibling dispatch");
+
+// ============================================================
+// Background  (companion to tags/test_cfinvoke_statement.cfm — the cf-LESS
+//              `invoke` STATEMENT form — and to
+//              core/test_invoke_undeclared_keys.cfm, whose tag-form asserts
+//              cover undeclared-ATTRIBUTE keeping, surfaced by PR 106)
+// ============================================================
+// Lucee accepts every CFML tag as a parenthesized CFScript CALL — including
+// `cfinvoke(component=o, method="m", returnVariable="r")` and the generic
+// `attributeCollection` spelling that passes ALL attributes as one struct.
+// Three contracts of that call form hold on Lucee 5/6/7:
+//
+//   (1) cfinvoke(attributeCollection = "#st#") reads its attributes
+//       (component, method, returnVariable, nested argumentCollection)
+//       from the struct;
+//   (2) returnVariable delivers the method's return value into the caller's
+//       scope — plain name, dotted `local.rv`, page level and function level;
+//   (3) cfinvoke(method = "m") with NO component attribute, written inside a
+//       CFC method, dispatches the SIBLING method `m` on the current
+//       component.
+//
+// RustCFML 0.130.0 parses and runs the call form but breaks all three:
+//
+//   (1) the method attribute is never read out of attributeCollection
+//         -> "Method '' not found in component";
+//   (2) returnVariable is accepted and silently dropped — the variable is
+//       never written, in ANY form (direct attrs, attributeCollection,
+//       dotted, page level, function level);
+//   (3) the componentless form resolves the METHOD name as a COMPONENT path
+//         -> "Component 'sibling' not found".
+//
+// The cfquery CONTROL below proves the attributeCollection plumbing itself
+// already works on both engines (same generic call-form spelling; name +
+// dbtype arrive via the struct) — cfinvoke just never reads from it. And the
+// cf-less `invoke` STATEMENT form (test_cfinvoke_statement.cfm) already
+// delivers returnVariable correctly, so the fix locus is the cfinvoke CALL
+// form's attribute marshaling, not the underlying __cfinvoke dispatch.
+//
+// Wheels rides all three on every request: Global.cfc $invoke() copies its
+// arguments into a struct and ends in exactly shapes (1)+(2) —
+//
+//     arguments.returnVariable = "local.rv";
+//     ...
+//     cfinvoke(attributeCollection = "#local.args#");
+//     if (StructKeyExists(local, "rv")) return local.rv;
+//
+// — and when the target method already exists on the calling component it
+// sets NO component attribute, riding (3). $invoke() backs $simpleLock() /
+// $doubleCheckedLock(), controller action dispatch ($callAction ->
+// $invoke(method = action) in controller/processing.cfc), filters, layouts,
+// model callbacks and validations. This family alone kept a pristine Wheels
+// app from booting on stock v0.130.0: onApplicationStart -> $loadRoutes ->
+// $simpleLock -> $invoke -> cfinvoke died with "Method '' not found in
+// component", 500ing every request before the first action could dispatch.
+//
+// Assertion style: each gap shape runs inside try/catch and surfaces a
+// thrown message as a "THREW: ..." string, so an engine error reads as a
+// failed assertion instead of aborting the suite.
+// ============================================================
+
+zzcimFx = createObject("component", "tags.CfInvokeMarshalFixture");
+
+// --- CONTROL: positional invoke() BIF dispatches on the fixture ---
+// Guards the wiring: if this fails, the fixture itself is broken, not the
+// cfinvoke call-form marshaling under test.
+assert("CONTROL: invoke() BIF dispatches on the fixture",
+	invoke(zzcimFx, "hello", { who: "bif" }), "hello-bif");
+
+// --- CONTROL: the SAME attributeCollection spelling is honored by cfquery ---
+// Query-of-query, so no datasource is needed: `name` and `dbtype` must both
+// arrive via the struct for the assert to even be reachable.
+zzcimSrc = queryNew("id,name", "integer,varchar", [[1, "alpha"]]);
+zzcimQAttrs = { name: "zzcimOut", dbtype: "query" };
+cfquery(attributeCollection = "#zzcimQAttrs#") {
+	writeOutput("SELECT name FROM zzcimSrc");
+}
+assert("CONTROL: cfquery(attributeCollection) honors name + dbtype from the struct",
+	zzcimOut.name[1], "alpha");
+
+// --- (1) attributeCollection must deliver method + returnVariable ---
+function zzcimAttrColl(required any comp) {
+	local.args = { component: arguments.comp, method: "hello", returnVariable: "local.rv" };
+	try {
+		cfinvoke(attributeCollection = "#local.args#");
+	} catch (any e) {
+		return "THREW: " & e.message;
+	}
+	return StructKeyExists(local, "rv") ? local.rv : "RV-UNSET";
+}
+assert("attributeCollection delivers method + returnVariable",
+	zzcimAttrColl(zzcimFx), "hello-world");
+
+// --- (1) the EXACT Global.cfc $invoke() shape: argumentCollection nested in the attrColl ---
+function zzcimWheelsShape(required any comp) {
+	local.args = {
+		component: arguments.comp,
+		method: "hello",
+		returnVariable: "local.rv",
+		argumentCollection: { who: "wheels" }
+	};
+	try {
+		cfinvoke(attributeCollection = "#local.args#");
+	} catch (any e) {
+		return "THREW: " & e.message;
+	}
+	return StructKeyExists(local, "rv") ? local.rv : "RV-UNSET";
+}
+assert("Wheels $invoke() shape: nested argumentCollection reaches the method",
+	zzcimWheelsShape(zzcimFx), "hello-wheels");
+
+// --- (2) returnVariable, direct named attrs, plain name, function level ---
+function zzcimDirectRv(required any comp) {
+	try {
+		cfinvoke(component = arguments.comp, method = "hello", returnVariable = "zzcimInnerRv");
+	} catch (any e) {
+		return "THREW: " & e.message;
+	}
+	return IsDefined("zzcimInnerRv") ? zzcimInnerRv : "RV-UNSET";
+}
+assert("direct-attrs returnVariable is delivered inside a function",
+	zzcimDirectRv(zzcimFx), "hello-world");
+
+// --- (2) returnVariable, dotted local.rv, pre-initialized ---
+function zzcimDottedRv(required any comp) {
+	local.rv = "";
+	try {
+		cfinvoke(component = arguments.comp, method = "hello", returnVariable = "local.rv");
+	} catch (any e) {
+		return "THREW: " & e.message;
+	}
+	return "[" & local.rv & "]";
+}
+assert("dotted local.rv returnVariable is written",
+	zzcimDottedRv(zzcimFx), "[hello-world]");
+
+// --- (2) returnVariable, page level ---
+try {
+	cfinvoke(component = zzcimFx, method = "hello", returnVariable = "zzcimPageRv");
+	zzcimPageReport = IsDefined("zzcimPageRv") ? zzcimPageRv : "RV-UNSET";
+} catch (any e) {
+	zzcimPageReport = "THREW: " & e.message;
+}
+assert("page-level returnVariable is delivered", zzcimPageReport, "hello-world");
+
+// --- (3) componentless cfinvoke inside a CFC dispatches the SIBLING method ---
+assert("componentless cfinvoke dispatches the sibling method, not a component path",
+	zzcimFx.invokeSibling(), "sibling-ok");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Gap

Lucee accepts every CFML tag as a parenthesized CFScript **call** — including `cfinvoke(component=o, method="m", returnVariable="r")` and the generic `attributeCollection` spelling that passes all attributes as one struct. Three contracts of that call form hold on Lucee; RustCFML 0.130.0 parses and runs the form but breaks all three:

1. **`attributeCollection` is never read** — `cfinvoke(attributeCollection = "#st#")` with `st = {component, method, returnVariable}` throws `Method '' not found in component` (the method attribute never arrives);
2. **`returnVariable` is never delivered, in any form** — direct attrs or attrColl, plain or dotted `local.rv`, page level or function level: the invocation runs, the variable is never written;
3. **the componentless form misresolves** — `cfinvoke(method = "sibling", returnVariable = ...)` inside a CFC method must dispatch the **sibling method** on the current component; RustCFML resolves the method name as a **component path** and throws `Component 'sibling' not found`.

```cfml
// fixture method `hello(who = "world")` returns "hello-" & who

local.args = { component: obj, method: "hello", returnVariable: "local.rv" };
cfinvoke(attributeCollection = "#local.args#");          // (1)

cfinvoke(component = obj, method = "hello", returnVariable = "rv");  // (2)

// inside a CFC that has a sibling() method:
cfinvoke(method = "sibling", returnVariable = "local.rv");           // (3)
```

| Shape | Lucee 5.4.8.2 | RustCFML 0.130.0 |
|---|---|---|
| `cfinvoke(attributeCollection = "#st#")`, st = component/method/returnVariable | invokes, rv delivered | throws `Method '' not found in component` |
| same + nested `argumentCollection: {who: "wheels"}` (the exact `Global.cfc` `$invoke()` shape) | `hello-wheels` | throws `Method '' not found in component` |
| `cfinvoke(component=o, method="hello", returnVariable="rv")`, function level | rv delivered | runs; rv never written |
| same, dotted pre-initialized `local.rv` | `local.rv = "hello-world"` | stays `""` |
| same, page level | rv delivered | runs; rv never written |
| `cfinvoke(method="sibling", returnVariable=...)` inside a CFC method | dispatches the sibling method | throws `Component 'sibling' not found` |
| `cfquery(attributeCollection = "#st#")`, QoQ (control) | attrs honored | attrs honored — plumbing exists |
| `invoke(o, "hello", {who: "bif"})` BIF (control) | `hello-bif` | `hello-bif` |

The two green controls pin the fix locus. `cfquery(attributeCollection)` honors the **same generic call-form spelling** on 0.130.0 — the attributeCollection plumbing exists; cfinvoke just never reads from it. And in the same run, the `<cfinvoke>` **tag** form delivers `returnvariable` correctly (`core/test_invoke_undeclared_keys.cfm`, 8/8) and the cf-less `invoke` **statement** form delivers `returnvariable="local.res"` correctly (`tags/test_cfinvoke_statement.cfm`, 6/6) — so the underlying `__cfinvoke` dispatch is fine; only the parenthesized call form's attribute marshaling is broken.

Sibling suites, no assertion overlap: #106 (credit Blute) covers undeclared-**attribute** keeping on the tag form; `test_cfinvoke_statement.cfm` covers the cf-less statement form; `test_invoke_canonical_forms.cfm` deliberately does **not** pin the named-arg call form. This suite is exactly that remaining surface — the `cfinvoke(...)` call form Lucee accepts and Wheels uses.

## What the test asserts

- CONTROL (green on both engines): the positional `invoke()` BIF dispatches on the fixture — guards the wiring.
- CONTROL (green on both engines): `cfquery(attributeCollection = "#st#")` (query-of-query, no datasource) honors `name` + `dbtype` from the struct — proves the attrColl plumbing itself works.
- `cfinvoke(attributeCollection = "#st#")` delivers `method` + `returnVariable`. *(red on RustCFML)*
- The exact Wheels `$invoke()` shape — `argumentCollection` nested **inside** the attrColl — reaches the method (`hello-wheels`). *(red on RustCFML)*
- Direct-attrs `returnVariable` is delivered inside a function. *(red on RustCFML)*
- Dotted, pre-initialized `local.rv` is written. *(red on RustCFML)*
- Page-level `returnVariable` is delivered. *(red on RustCFML)*
- Componentless `cfinvoke(method=...)` inside a CFC dispatches the sibling method, not a component path. *(red on RustCFML)*

Each gap shape runs inside try/catch and surfaces a thrown message as a `THREW: ...` string, so an engine error reads as a failed assertion instead of aborting the suite — runner-safe.

## Why it matters for Wheels

This family was **the** remaining boot blocker. Wheels' `Global.cfc` `$invoke()` copies its arguments into a struct and ends in exactly shapes (1)+(2):

```cfml
arguments.returnVariable = "local.rv";
...
cfinvoke(attributeCollection = "#local.args#");
if (StructKeyExists(local, "rv")) return local.rv;
```

— and when the target method already exists on the calling component it sets **no** component attribute, riding shape (3). `$invoke()` backs `$simpleLock()` / `$doubleCheckedLock()`, controller action dispatch (`$callAction` → `$invoke(method = action)` in `controller/processing.cfc`), filters, layouts, model callbacks and validations. With the previously-filed gaps fixed in stock v0.130.0, this family alone kept a pristine Wheels app from booting: `onApplicationStart` → `$loadRoutes` → `$simpleLock` → `$invoke` → `cfinvoke` died with `Method '' not found in component`, 500ing every request before the first action could dispatch.

## Verification

- **RustCFML 0.130.0** (release binary): suite fails 6/8 — exactly the six gap assertions (`THREW: Method '' not found in component` ×2, `RV-UNSET` ×2, `[]`, `THREW: Component 'sibling' not found`); both controls pass. Identical results with `RUSTCFML_JIT=0` and with `RUSTCFML_JIT_THRESHOLD=1`.
- **Lucee 5.4.8.2** (CommandBox task runner; same assertions transliterated to a `chk()` harness because CommandBox shadows `assert`): 8/8 pass.
- Full `tests/runner.cfm` with this suite registered (RustCFML 0.130.0): **3836/3842 across 451 suites** — the only 6 failures are this suite's gap assertions; no abort. In the same run the tag-form (`test_invoke_undeclared_keys`, 8/8) and statement-form (`test_cfinvoke_statement`, 6/6) suites pass, confirming the fix locus is the call form's marshaling only.
- Runner registration: included immediately after the `tags/test_cfinvoke_statement.cfm` include. Full `tests/runner.cfm` on this branch (RustCFML 0.130.0): **3836/3842 across 451 suites** — the only 6 failures are this suite's gap assertions; no abort.