### PR TITLE
test(tags): cfdirectory attributeCollection must deliver the name= result variable

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -219,6 +219,14 @@ try { include "tags/test_cfdbinfo.cfm"; } catch (any e) { writeOutput("ERROR | t
 try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_mapping_path.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_function_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_function_form.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_recurse_symlink.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_recurse_symlink.cfm | " & e.message & chr(10)); }
+// cfdirectory attributeCollection must deliver the name= listing query the
+// same way the direct named-attribute form does (Wheels Global.cfc::$directory
+// boots through exactly this shape; Plugins.cfc::$folders QoQs the result at
+// onApplicationStart). 0.130.0 fails in both modes: CLI drops the attribute
+// struct entirely (throws "cfdirectory: directory not found: " with an empty
+// path); serve mode runs the listing but binds the query to no scope.
+// Runtime-level in both modes (the test catches the CLI throw) -> runner-safe.
+try { include "tags/test_cfdirectory_attrcoll_name.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_attrcoll_name.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfhttpparam_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttpparam_runtime_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfmail_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfmail_runtime_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfstoredproc_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfstoredproc_runtime_body.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_cfdirectory_attrcoll_name.cfm
+++ b/tests/tags/test_cfdirectory_attrcoll_name.cfm
@@ -1,0 +1,131 @@
+<cfscript>
+suiteBegin("Tags: cfdirectory attributeCollection delivers name= result");
+
+// ============================================================
+// Background
+// ============================================================
+// cfdirectory's `name=` attribute names the variable that receives the
+// listing query. That contract must hold no matter HOW the attribute
+// reaches the tag: direct named attributes, attributeCollection = struct,
+// or the string-interpolated attributeCollection = "#local.args#" form.
+//
+//     local.rv = "";
+//     local.args = {action: "list", directory: dir, name: "rv"};
+//     cfdirectory(attributeCollection = "#local.args#");
+//     // Lucee 7          -> local.rv is the listing query
+//     // RustCFML 0.130.0 -> broken in BOTH execution modes:
+//     //   CLI mode:   the attributeCollection struct never reaches the
+//     //               tag at all -> throws "cfdirectory: directory not
+//     //               found: " (note the EMPTY path)
+//     //   serve mode: the attributes get through (the listing runs) but
+//     //               the name= result is delivered to NO scope --
+//     //               local.rv stays "", variables.rv unset,
+//     //               IsDefined("rv") false
+//
+// The direct form cfdirectory(action="list", ..., name="rv") delivers
+// correctly on RustCFML in both modes, and cfquery(attributeCollection=...)
+// delivers its name= / result= -- the delivery plumbing exists; only
+// cfdirectory's attributeCollection path is broken.
+//
+// Wheels hits this on EVERY boot: Global.cfc::$directory() is exactly this
+// shape (copy arguments into a struct -> attributeCollection -> return
+// local.rv), and Plugins.cfc::$folders() feeds its return value straight
+// into a query-of-queries at onApplicationStart -- the silent "" return
+// surfaces as "Query of Queries: table 'query' not found". The same helper
+// backs $fileExistsNoCase() -> $objectFileName(), i.e. every
+// controller/model class-file resolution.
+//
+// All cfdirectory calls are wrapped in try/catch so the CLI-mode throw is
+// reported as an assertion failure instead of aborting the bundle.
+// ============================================================
+
+// --- self-contained fixture: scratch dir with two known files ---
+cfdirAcTmp = getTempDirectory() & "rustcfml_cfdirac_" & createUUID() & "/";
+directoryCreate(cfdirAcTmp);
+fileWrite(cfdirAcTmp & "alpha.txt", "1");
+fileWrite(cfdirAcTmp & "beta.txt", "2");
+
+// helper: render the delivery outcome readable in failure messages
+function cfdirAcShape(required any rv) {
+	if (isQuery(arguments.rv)) {
+		return "QUERY rows=" & arguments.rv.recordCount;
+	}
+	if (isSimpleValue(arguments.rv)) {
+		return "NOT-DELIVERED [" & arguments.rv & "]";
+	}
+	return "NOT-A-QUERY";
+}
+
+// (1) green control: direct named attributes deliver into a pre-initialized
+//     local variable -- this works on RustCFML too, isolating the gap to the
+//     attributeCollection path.
+function cfdirAcDirect(required string dir) {
+	local.rv = "";
+	try {
+		cfdirectory(action = "list", directory = arguments.dir, filter = "*.txt", name = "rv");
+	} catch (any e) {
+		return "ERROR: " & e.message;
+	}
+	return cfdirAcShape(local.rv);
+}
+assert("direct named attrs: name= delivers the listing query",
+	cfdirAcDirect(cfdirAcTmp), "QUERY rows=2");
+
+// (2) attributeCollection passed as a struct value
+function cfdirAcStruct(required string dir) {
+	local.rv = "";
+	local.args = {action: "list", directory: arguments.dir, filter: "*.txt", name: "rv"};
+	try {
+		cfdirectory(attributeCollection = local.args);
+	} catch (any e) {
+		return "ERROR: " & e.message;
+	}
+	return cfdirAcShape(local.rv);
+}
+assert("attributeCollection = struct: name= delivers the listing query",
+	cfdirAcStruct(cfdirAcTmp), "QUERY rows=2");
+
+// (3) the EXACT Wheels Global.cfc::$directory shape: arguments copied into a
+//     plain struct, string-interpolated attributeCollection, result read
+//     back from the pre-initialized local.rv
+function cfdirAcWheels() {
+	local.rv = "";
+	arguments.name = "rv";
+	local.args = {};
+	for (local.key in arguments) {
+		local.args[local.key] = arguments[local.key];
+	}
+	cfdirectory(attributeCollection = "#local.args#");
+	return local.rv;
+}
+try {
+	cfdirAcQ = cfdirAcWheels(action = "list", directory = cfdirAcTmp, filter = "*.txt", sort = "name asc");
+} catch (any e) {
+	cfdirAcQ = "ERROR: " & e.message;
+}
+assert("Wheels $directory shape (interpolated attributeCollection): returns the query",
+	cfdirAcShape(cfdirAcQ), "QUERY rows=2");
+
+// (4) the delivered listing must be usable downstream -- the Plugins.cfc
+//     $folders() query-of-queries that is the first thing to die at Wheels
+//     boot when the delivery is dropped.
+function cfdirAcQoq(required any src) {
+	try {
+		local.q = queryExecute(
+			"SELECT name FROM src WHERE name NOT LIKE '.%' ORDER BY name ASC",
+			{},
+			{dbtype: "query"}
+		);
+		return "rows=" & local.q.recordCount & " first=" & local.q.name[1];
+	} catch (any e) {
+		return "ERROR: " & e.message;
+	}
+}
+assert("downstream QoQ over the delivered listing (Plugins.cfc $folders shape)",
+	cfdirAcQoq(cfdirAcQ), "rows=2 first=alpha.txt");
+
+// --- cleanup ---
+directoryDelete(cfdirAcTmp, true);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

A self-contained test (scratch dir created and deleted at runtime — no fixtures, no db, no network) that `cfdirectory(attributeCollection = attrs)` delivers the listing query to the variable named by the `name=` attribute, exactly like the direct named-attribute form already does.

```cfml
local.rv = "";
local.args = {action: "list", directory: dir, name: "rv"};
cfdirectory(attributeCollection = "#local.args#");
// Lucee -> local.rv is the listing query
```

| Engine | Result |
|---|---|
| Lucee 5.4.8.2 | `local.rv` is the listing query — 4/4 pass |
| RustCFML 0.130.0, CLI mode | the attribute struct never reaches the tag: throws `cfdirectory: directory not found: ` (empty path) |
| RustCFML 0.130.0, `--serve` mode | attributes get through and the listing runs, but the query is bound to NO scope: `local.rv` stays `""`, `variables.rv` unset, `IsDefined("rv")` false |

The direct form `cfdirectory(action="list", ..., name="rv")` works on RustCFML in both modes (it is the green control in this test), and `cfquery(attributeCollection=...)` delivers its `name=`/`result=` correctly (covered by `tags/test_cfquery_result_delivery.cfm`) — the result-variable write-back plumbing exists; only cfdirectory's attributeCollection path is broken. History: the function-call form itself was #56's territory; the attributeCollection shape regressed separately (CLI throws, serve silently no-delivers).

## Why (the Wheels story)

This is the first thing that kills a Wheels boot on RustCFML — it fires inside `onApplicationStart` before a single request is served:

- `Global.cfc::$directory()` is byte-for-byte the shape under test: copy `arguments` into a plain struct, `cfdirectory(attributeCollection = "#local.args#")`, return the pre-initialized `local.rv`.
- `Plugins.cfc::$folders()` feeds that return value straight into a query-of-queries — the silent `""` surfaces as `Query of Queries: table 'query' not found`, which is exactly what assertion (4) reproduces.
- The same helper backs `$fileExistsNoCase()` → `$objectFileName()`, i.e. EVERY controller and model class-file resolution goes through this path. There is no booting around it.

## Coverage

- control: direct named attrs deliver into a pre-initialized `local.rv` (passes on 0.130.0 today, both modes)
- gap: `attributeCollection = local.args` (struct value)
- gap: the exact Wheels `$directory` shape — arguments copied into a plain struct, string-interpolated `attributeCollection = "#local.args#"`, result read back from `local.rv`
- gap: downstream QoQ over the delivered listing (the `Plugins.cfc::$folders` shape that dies first at boot)

Every cfdirectory call is wrapped in try/catch so the CLI-mode throw registers as an informative assertion failure instead of aborting the bundle — the failure is runtime-level in both modes, so the test is runner-safe.

## Verification

RED — RustCFML 0.130.0, CLI mode (identical under default, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`):

```
FAIL | Tags: cfdirectory attributeCollection delivers name= result | 1/4 passed (3 failed)
       FAIL: attributeCollection = struct: name= delivers the listing query | expected: [QUERY rows=2] | got: [ERROR: cfdirectory: directory not found: ]
       FAIL: Wheels $directory shape (interpolated attributeCollection): returns the query | expected: [QUERY rows=2] | got: [NOT-DELIVERED [ERROR: cfdirectory: directory not found: ]]
       FAIL: downstream QoQ over the delivered listing (Plugins.cfc $folders shape) | expected: [rows=2 first=alpha.txt] | got: [ERROR: Query of Queries: table 'src' not found (no such query variable)]
```

RED — RustCFML 0.130.0, `--serve` mode (the silent no-delivery shape):

```
FAIL | Tags: cfdirectory attributeCollection delivers name= result | 1/4 passed (3 failed)
       FAIL: attributeCollection = struct: name= delivers the listing query | expected: [QUERY rows=2] | got: [NOT-DELIVERED []]
       FAIL: Wheels $directory shape (interpolated attributeCollection): returns the query | expected: [QUERY rows=2] | got: [NOT-DELIVERED []]
       FAIL: downstream QoQ over the delivered listing (Plugins.cfc $folders shape) | expected: [rows=2 first=alpha.txt] | got: [ERROR: Query of Queries: table 'src' not found (no such query variable)]
```

GREEN — Lucee 5.4.8.2 (CommandBox task runner; `assert` renamed to `chk` locally because CommandBox shadows `assert` — file content in this PR is the repo-style original):

```
PASS | Tags: cfdirectory attributeCollection delivers name= result | 4/4 passed
```

## Where the fix goes

Two layers of the same attribute-materialization path:

1. CLI mode: attributeCollection expansion for cfdirectory never happens — the struct is dropped before attribute resolution, so `directory` arrives empty and the tag throws.
2. serve mode: attributes are applied but the `name=` result variable is never written back to the caller's frame. cfquery's attributeCollection path already does this write-back correctly (including into function-local scope), so the same mechanism should be wired into cfdirectory. Worth sweeping the other result-producing tags that accept attributeCollection while there: `cffile(attributeCollection = {action: "read", file: f, variable: "rv"})` currently throws `Variable 'cffile' is undefined`, suggesting the same family of gaps.

Full `tests/runner.cfm` on this branch (RustCFML 0.130.0): **3835/3838 across 451 suites** — the only 3 failures are this suite's gap assertions; no abort.