### PR TITLE
test(core): nested write on a scope-qualified undeclared variable must auto-vivify a struct

### DIFF
--- a/tests/core/ScopedAutoVivFixture.cfc
+++ b/tests/core/ScopedAutoVivFixture.cfc
@@ -1,0 +1,44 @@
+// Fixture for the scope-qualified nested auto-vivification test. Each probe
+// performs the write inside a CFC method (the Wheels $initControllerClass
+// context) and reports exactly what state the variables scope ended up in,
+// so a silent-loss engine fails with a diagnosis instead of a bare mismatch.
+component {
+
+	// The exact Wheels Controller.cfc shape: variables.$class.name = ...
+	// where variables.$class is never pre-seeded ($-prefixed key included).
+	public string function vivClassName() {
+		try {
+			variables.$zzscvivClass.name = "vivified";
+		} catch (any e) {
+			return "THREW: " & e.message;
+		}
+		if (!StructKeyExists(variables, "$zzscvivClass")) {
+			return "NO-CONTAINER";
+		}
+		if (!IsStruct(variables.$zzscvivClass)) {
+			return "NOT-A-STRUCT";
+		}
+		return "name=[" & variables.$zzscvivClass.name & "]";
+	}
+
+	// Two-level chain (csrf mixin shape: variables.$class.csrf.type = ...):
+	// every missing level must vivify as a struct.
+	public string function vivDeep() {
+		try {
+			variables.scvivDeep.a.b = "deep-viv";
+		} catch (any e) {
+			return "THREW: " & e.message;
+		}
+		if (!StructKeyExists(variables, "scvivDeep")) {
+			return "NO-CONTAINER";
+		}
+		if (!IsStruct(variables.scvivDeep)) {
+			return "OUTER-NOT-A-STRUCT";
+		}
+		if (!StructKeyExists(variables.scvivDeep, "a") || !IsStruct(variables.scvivDeep.a)) {
+			return "INNER-NOT-A-STRUCT";
+		}
+		return "b=[" & variables.scvivDeep.a.b & "]";
+	}
+
+}

--- a/tests/core/test_scoped_nested_autoviv.cfm
+++ b/tests/core/test_scoped_nested_autoviv.cfm
@@ -1,0 +1,151 @@
+<cfscript>
+suiteBegin("Core: auto-vivify a nested write on a scope-QUALIFIED undeclared variable");
+
+// ============================================================
+// Background  (residual of test_undefined_var_autovivify.cfm)
+// ============================================================
+// On Lucee 5/6/7, Adobe ColdFusion 2018-2025, and BoxLang, assigning to a
+// member path of an undeclared variable auto-creates the container as a
+// struct even when the lvalue is SCOPE-QUALIFIED:
+//
+//     variables.$class.name = "x";   // variables.$class never initialized
+//     request.ctx.user      = "x";   // request.ctx never initialized
+//     local.cache.hit       = "x";   // (in a function) local.cache never initialized
+//
+// The engine implicitly performs `variables.$class = {}` on the first
+// nested write, exactly as it does for the UNSCOPED form (x.a = 1).
+//
+// RustCFML fixed the unscoped form (test_undefined_var_autovivify.cfm) and
+// the subscript form (test_subscript_autovivify.cfm); the scope-qualified
+// nested write is the residual, and on 0.130.0 it breaks in two different
+// ways:
+//
+//   - at template top level, `variables.X.name = "v"` THROWS
+//     "Variable 'X' is undefined";
+//   - everywhere else -- request./local. in any context, and variables.
+//     inside a function or CFC method -- the write is LOST SILENTLY: the
+//     scope key is registered (structKeyExists -> true) but bound to a
+//     non-struct empty value. isStruct() -> false, the written member is
+//     gone, and reading it back yields "" instead of throwing. No error
+//     at the write, no error at the read; the data just vanishes.
+//
+// Wheels hits the exact CFC-method shape on the FIRST line of controller
+// class initialization (vendor/wheels/Controller.cfc, $initControllerClass):
+//
+//     variables.$class.name = arguments.name;   // $class never pre-seeded
+//     variables.$class.filters = [];
+//     ...
+//
+// On RustCFML every one of those writes evaporates, so the controller
+// "initializes" with no name/filters/verifications/layouts and dispatch
+// fails far downstream of the real cause. Model.cfc and the csrf/caching
+// mixins (variables.$class.csrf.type = ...) ride the same contract.
+//
+// All assertions below PASS on Lucee/ACF/BoxLang. Risky writes are wrapped
+// in try/catch so the template-level RustCFML throw fails its assertions
+// gracefully instead of aborting the run.
+// ============================================================
+
+// ------------------------------------------------------------
+// (1) Template level, variables-scope-qualified.
+// ------------------------------------------------------------
+scvivTplVal = "(threw)";
+scvivTplErr = "";
+try {
+    variables.scvivTpl.name = "viv-tpl";
+    scvivTplVal = variables.scvivTpl.name;
+} catch (any e) {
+    scvivTplErr = e.message;
+}
+assert("variables.X.name on an undeclared X auto-vivifies at template level",
+    scvivTplVal, "viv-tpl");
+assertTrue("no exception thrown vivifying variables.X (got: [" & scvivTplErr & "])",
+    len(scvivTplErr) == 0);
+scvivTplIsStruct = false;
+try {
+    scvivTplIsStruct = StructKeyExists(variables, "scvivTpl") && IsStruct(variables.scvivTpl);
+} catch (any e) {
+}
+assertTrue("auto-vivified variables.X is a struct", scvivTplIsStruct);
+
+// ------------------------------------------------------------
+// (2) Template level, request-scope-qualified. On RustCFML this is the
+//     SILENT flavor: no throw, key registered, container not a struct,
+//     member readback comes back empty.
+// ------------------------------------------------------------
+scvivReqVal = "(threw)";
+scvivReqIsStruct = false;
+try {
+    request.scvivReq.name = "viv-req";
+    scvivReqVal = request.scvivReq.name;
+    scvivReqIsStruct = StructKeyExists(request, "scvivReq") && IsStruct(request.scvivReq);
+} catch (any e) {
+}
+assert("request.X.name on an undeclared X auto-vivifies", scvivReqVal, "viv-req");
+assertTrue("auto-vivified request.X is a struct", scvivReqIsStruct);
+
+// ------------------------------------------------------------
+// (3) Inside a function: local-scope-qualified.
+// ------------------------------------------------------------
+function scvivLocalFn() {
+    var out = {val: "(threw)", container: false};
+    try {
+        local.scvivLoc.name = "viv-local";
+        out.val = local.scvivLoc.name;
+        out.container = IsStruct(local.scvivLoc);
+    } catch (any e) {
+    }
+    return out;
+}
+scvivLocRes = scvivLocalFn();
+assert("local.X.name on an undeclared X auto-vivifies inside a function",
+    scvivLocRes.val, "viv-local");
+assertTrue("auto-vivified local.X is a struct", scvivLocRes.container);
+
+// ------------------------------------------------------------
+// (4) variables-scope write inside a template-level function: the vivified
+//     struct must land in the SHARED variables scope, visible after return.
+// ------------------------------------------------------------
+function scvivVarsFn() {
+    try {
+        variables.scvivFnv.name = "viv-fnv";
+    } catch (any e) {
+    }
+}
+scvivVarsFn();
+scvivFnvVal = "(missing)";
+try {
+    if (StructKeyExists(variables, "scvivFnv") && IsStruct(variables.scvivFnv)) {
+        scvivFnvVal = variables.scvivFnv.name;
+    }
+} catch (any e) {
+}
+assert("variables.X vivified inside a function is a struct visible after the call",
+    scvivFnvVal, "viv-fnv");
+
+// ------------------------------------------------------------
+// (5) CFC method, the exact Wheels $initControllerClass shape:
+//     variables.$class.name = ... with a $-prefixed key, never pre-seeded.
+// ------------------------------------------------------------
+scvivObj = createObject("component", "ScopedAutoVivFixture");
+assert("CFC method: variables.$class.name auto-vivifies ($initControllerClass shape)",
+    scvivObj.vivClassName(), "name=[vivified]");
+
+// ------------------------------------------------------------
+// (6) CFC method, two-level chain: variables.X.a.b must vivify EVERY level
+//     (csrf mixin shape: variables.$class.csrf.type = ...).
+// ------------------------------------------------------------
+assert("CFC method: deep chain variables.X.a.b vivifies every level",
+    scvivObj.vivDeep(), "b=[deep-viv]");
+
+// ------------------------------------------------------------
+// (7) Control (passes on RustCFML today): the same nested write succeeds
+//     when the container IS pre-initialized -- guards the test wiring.
+// ------------------------------------------------------------
+variables.scvivCtl = {};
+variables.scvivCtl.name = "ctl";
+assert("control: nested write on a pre-initialized scoped container works",
+    variables.scvivCtl.name, "ctl");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -346,6 +346,17 @@ try { include "core/test_forin_string_list.cfm"; } catch (any e) { writeOutput("
 //     for everything except the `local` scope. Wrapped in try/catch so the
 //     throw fails its assertions without aborting the run.
 try { include "core/test_undefined_var_autovivify.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undefined_var_autovivify.cfm | " & e.message & chr(10)); }
+//   - scoped_nested_autoviv: residual of undefined_var_autovivify -- a nested
+//     write on a SCOPE-QUALIFIED undeclared variable (variables.X.name = ...,
+//     request.X.name, local.X.name inside a function) must auto-create X as
+//     a struct. RustCFML throws "Variable 'X' is undefined" at template
+//     level and SILENTLY drops the write everywhere else (scope key
+//     registered, container not a struct, member readback ""). Wheels'
+//     Controller.cfc $initControllerClass opens with
+//     `variables.$class.name = ...` on a never-seeded $class, so controller
+//     class init loses every field with no error anywhere. Runtime gap:
+//     risky writes are wrapped so the throw fails assertions, not the run.
+try { include "core/test_scoped_nested_autoviv.cfm"; } catch (any e) { writeOutput("ERROR | core/test_scoped_nested_autoviv.cfm | " & e.message & chr(10)); }
 //   - multiword_operators: RustCFML rejects multi-word comparison operators
 //     (IS NOT, DOES NOT CONTAIN, GREATER THAN, ...) while accepting all
 //     single-word forms. A CFC using one fails to parse -> non-object.


### PR DESCRIPTION
## Cross-engine gap: nested write on a SCOPE-QUALIFIED undeclared variable does not auto-vivify

In CFML, assigning to a member path of an undeclared variable auto-creates the container as a struct even when the lvalue is scope-qualified. RustCFML fixed the UNSCOPED form (`x.a = 1`, PR #21 / `test_undefined_var_autovivify.cfm`) and the subscript form (`test_subscript_autovivify.cfm`); the scope-qualified flavor is the residual — and on 0.130.0 it fails in two different ways:

```cfml
variables.zzc.name = "x";   // variables.zzc never initialized
request.ctx.user   = "x";   // request.ctx never initialized
local.cache.hit    = "x";   // (inside a function) local.cache never initialized
```

| shape | Lucee 5.4.8.2 | RustCFML 0.130.0 |
|---|---|---|
| `variables.X.name = "v"` (template top level) | vivifies struct, readback OK | **throws** `Variable 'X' is undefined` |
| `request.X.name = "v"` (template top level) | vivifies struct, readback OK | **silent loss**: key registered, `isStruct()` → `false`, readback `""` |
| `local.X.name = "v"` (inside a function) | vivifies struct, readback OK | **silent loss** (same signature) |
| `variables.X.name = "v"` (function / CFC method) | vivifies struct, shared-scope visible | **silent loss** (same signature) |
| `variables.X.a.b = "v"` (CFC method, two missing levels) | vivifies the whole chain | **silent loss** (outer level not a struct) |

The silent flavor is the dangerous one: no error at the write, no error at the read. `structKeyExists(scope, "X")` even returns `true`, but the key is bound to a non-struct empty value, the written member is gone, and reading it back yields `""` instead of throwing — nothing points at the assignment that was dropped.

### What the test asserts

- `variables.X.name = ...` on an undeclared `X` at template level vivifies a struct: readback OK, no exception, `isStruct()` true
- same contract for `request.X.name = ...` at template level
- `local.X.name = ...` inside a function vivifies `local.X` as a struct
- `variables.X.name = ...` inside a template-level function lands in the SHARED variables scope, visible after the call
- CFC method (fixture `ScopedAutoVivFixture.cfc`): `variables.$class.name = "vivified"` with a `$`-prefixed, never-pre-seeded key — the exact Wheels `$initControllerClass` shape; the fixture returns `THREW: ...` / `NO-CONTAINER` / `NOT-A-STRUCT` / `name=[...]` so a failing engine self-diagnoses its flavor
- CFC method: two-level chain `variables.X.a.b = ...` must vivify EVERY missing level (the csrf-mixin chain shape)
- CONTROL (passes on RustCFML today): the same nested write on a PRE-INITIALIZED scoped container — guards the wiring

### Why it matters for Wheels

Controller class initialization opens with exactly this shape (`vendor/wheels/Controller.cfc`, `$initControllerClass()`):

```cfml
variables.$class.name = arguments.name;   // variables.$class never pre-seeded
variables.$class.path = arguments.path;
variables.$class.verifications = [];
variables.$class.filters = [];
variables.$class.cachableActions = [];
```

On RustCFML every one of those writes evaporates silently — the controller "initializes" with no name, no filters, no verifications, no layouts, and dispatch fails far downstream of the real cause (the csrf and caching mixins then read `variables.$class.csrf.type` / `variables.$class.cachableActions` off the broken container). Model class init rides the same contract. This gap was masked by a local workaround since before the test-PR strategy existed; with the cfinvoke family fixed in 0.130.0 it is the next silent killer on the Wheels dispatch path.

### Verification

- **RustCFML 0.130.0** (release binary), staged repo layout (`harness.cfm` + this test + fixture): **1/11** — only the pre-initialized CONTROL passes; all 10 gap assertions fail, no abort. Identical 1/11 with `RUSTCFML_JIT=0` and with `RUSTCFML_JIT_THRESHOLD=1` — interpreter semantics, not JIT-specific.
- **Lucee 5.4.8.2** (CommandBox): all **11/11** PASS. (Adobe CF was not run for this PR; scoped auto-vivification is long-standing shared CFML behavior, and the unscoped sibling test documents the same contract family — but these specific shapes were pinned against Lucee only.)
- Full `tests/runner.cfm` on this branch (RustCFML 0.130.0): **3835/3845 across 451 suites** — baseline on stock main is **3834/3834 across 450 suites**, so the only 10 failures are this suite's gap assertions; no abort.
- Runtime gap (the one throwing case is wrapped in try/catch; the silent flavor needs no wrapper) → registered in `tests/runner.cfm` directly after `core/test_undefined_var_autovivify.cfm`, its unscoped sibling.