### PR TITLE
test(core): assigning a null/void function return must not create the target key

### DIFF
--- a/tests/core/test_null_return_no_key.cfm
+++ b/tests/core/test_null_return_no_key.cfm
@@ -1,0 +1,119 @@
+<cfscript>
+suiteBegin("Core: assigning a null/void function return must NOT create the target key");
+
+// Background (cross-engine contract):
+// Assigning the result of a function that returns null/void (`return;` or no
+// return statement at all) must NOT create the target variable. On Lucee the
+// assigned name stays undefined — StructKeyExists() is false, isDefined() is
+// false — in every scope (local, var, variables, unscoped), and assigning a
+// void return to a PRE-EXISTING variable deletes it. Only isNull() on a read
+// of the name answers true. RustCFML 0.130.0 instead materializes the key
+// with a null value:
+//
+//   function v() { return; }
+//   local.rv = v();
+//   StructKeyExists(local, "rv")   RustCFML 0.130.0 -> TRUE   Lucee -> FALSE
+//   isDefined("rv")                RustCFML 0.130.0 -> TRUE   Lucee -> FALSE
+//   isNull(local.rv)               both -> TRUE (so isNull alone can't discriminate)
+//
+// This is the OTHER half of the old $callback() breaker (the caller-local-leak
+// half was fixed in v0.118 / PR #93). Wheels' universal invocation pattern is
+//
+//   local.rv = $invoke(...);
+//   if (!StructKeyExists(local, "rv")) { local.rv = true; }
+//
+// i.e. "callback returned nothing -> treat as true". When the engine
+// materializes a null-valued key, the default-true fallback never fires, the
+// pattern returns null, every model callback chain evaluates falsy, and
+// save() aborts before the INSERT — silently. (Deliberately NOT asserted:
+// StructKeyList(local) — Lucee itself lists the name there even though
+// StructKeyExists is false; that quirk is not part of the contract Wheels
+// relies on.)
+
+// --- helpers ---
+function nrkVoid() {
+	return; // explicit bare return
+}
+function nrkNoReturn() {
+	var x = 1; // no return statement at all (implicit void)
+}
+
+// --- CONTROL (green on both engines): the call itself reads as null ---
+assertTrue("CONTROL: isNull() on the void call itself is true", isNull(nrkVoid()));
+
+// --- the gap: local-scope target inside a function ---
+function nrkLocalProbe() {
+	local.rv = nrkVoid();
+	return {
+		keyExists = structKeyExists(local, "rv"),
+		defined   = isDefined("rv"),
+		nullRead  = isNull(local.rv)
+	};
+}
+nrkShape = nrkLocalProbe();
+assertFalse("local.rv = voidFn(): StructKeyExists(local,'rv') is false", nrkShape.keyExists);
+assertFalse("local.rv = voidFn(): isDefined('rv') is false", nrkShape.defined);
+assertTrue("CONTROL: isNull(local.rv) reads true after the void assignment", nrkShape.nullRead);
+
+// --- var-declared target inside a function ---
+function nrkVarProbe() {
+	var rv2 = nrkVoid();
+	return structKeyExists(local, "rv2");
+}
+assertFalse("var rv2 = voidFn(): no 'rv2' key lands in local", nrkVarProbe());
+
+// --- variables-scope target at template level ---
+variables.nrkTv = nrkVoid();
+assertFalse("variables.x = voidFn(): StructKeyExists(variables, x) is false",
+	structKeyExists(variables, "nrkTv"));
+assertFalse("variables.x = voidFn(): isDefined(x) is false", isDefined("nrkTv"));
+
+// --- unscoped target at template level ---
+nrkTv2 = nrkVoid();
+assertFalse("unscoped x = voidFn(): isDefined(x) is false", isDefined("nrkTv2"));
+assertFalse("unscoped x = voidFn(): no key lands in variables",
+	structKeyExists(variables, "nrkTv2"));
+
+// --- a PRE-EXISTING variable assigned a void return is DELETED ---
+variables.nrkPre = "before";
+variables.nrkPre = nrkVoid();
+assertFalse("pre-existing variables-scope var is deleted by the void assignment",
+	structKeyExists(variables, "nrkPre"));
+function nrkPreLocalProbe() {
+	local.pre = "before";
+	local.pre = nrkVoid();
+	return structKeyExists(local, "pre");
+}
+assertFalse("pre-existing local is deleted by the void assignment", nrkPreLocalProbe());
+
+// --- a function with NO return statement behaves identically ---
+function nrkNoReturnProbe() {
+	local.rv = nrkNoReturn();
+	return structKeyExists(local, "rv");
+}
+assertFalse("fn with no return statement: assignment creates no key either",
+	nrkNoReturnProbe());
+
+// --- the Wheels $invoke()/callback shape: default-true fallback must fire ---
+function nrkCallbackChain() {
+	local.rv = nrkVoid();
+	if (!structKeyExists(local, "rv")) {
+		local.rv = true;
+	}
+	return isNull(local.rv) ? "NULL" : toString(local.rv);
+}
+assert("Wheels callback pattern: default-true fallback fires for a void return",
+	nrkCallbackChain(), "true");
+
+// --- CONTROL (green on both engines): a value-returning fn DOES create the key ---
+function nrkValueFn() {
+	return "val";
+}
+function nrkValueProbe() {
+	local.rv = nrkValueFn();
+	return structKeyExists(local, "rv") ? local.rv : "KEY-MISSING";
+}
+assert("CONTROL: value-returning fn assignment creates the key", nrkValueProbe(), "val");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -480,6 +480,18 @@ try { include "core/test_get_function_called_name.cfm"; } catch (any e) { writeO
 //     and a method call on a null receiver must throw — composed, the two
 //     gaps turn Wheels' create() into a silent no-op that reports success.
 try { include "core/test_new_udf_dispatch_and_null_call.cfm"; } catch (any e) { writeOutput("ERROR | core/test_new_udf_dispatch_and_null_call.cfm | " & e.message & chr(10)); }
+//   - null_return_no_key: assigning a null/void function return must NOT
+//     create the target variable — StructKeyExists/isDefined stay false in
+//     every scope (local, var, variables, unscoped), a pre-existing variable
+//     is deleted by the assignment, and only isNull() on a read of the name
+//     answers true. RustCFML materializes a null-valued key instead, so
+//     Wheels' universal `local.rv = $invoke(...); if (!StructKeyExists(local,
+//     "rv")) local.rv = true;` default-true fallback never fires — every
+//     model callback chain returns null/falsy and save() aborts before the
+//     INSERT, silently. The OTHER half of the old $callback() breaker (the
+//     caller-local-leak half was fixed in v0.118 / PR #93). Runtime-level
+//     (no parse error), so registration is safe.
+try { include "core/test_null_return_no_key.cfm"; } catch (any e) { writeOutput("ERROR | core/test_null_return_no_key.cfm | " & e.message & chr(10)); }
 //   - struct_key_case_parity: struct keys are case-insensitive on WRITE, not
 //     just read — a differently-cased write must update the existing key in
 //     place (one key; first-written casing wins the key list), never fork a


### PR DESCRIPTION
## Gap

Assigning the result of a function that returns null/void (`return;` with no expression, or no return statement at all) must **NOT create the target variable**. On Lucee the assigned name simply stays undefined — `StructKeyExists()` is false, `isDefined()` is false — in every scope (`local.x`, `var x`, `variables.x`, unscoped `x`), and assigning a void return to a **pre-existing** variable deletes it. Only `isNull()` on a read of the name answers true.

RustCFML 0.130.0 instead **materializes the key with a null value** in every one of those scopes:

```cfm
function v() { return; }
local.rv = v();
StructKeyExists(local, "rv")   // RustCFML 0.130.0 -> TRUE, Lucee -> FALSE
```

| Probe | Lucee 5.4.8.2 | RustCFML 0.130.0 |
|---|---|---|
| `local.rv = v(); StructKeyExists(local, "rv")` | `false` | `true` |
| `local.rv = v(); isDefined("rv")` | `false` | `true` |
| `var rv2 = v(); StructKeyExists(local, "rv2")` | `false` | `true` |
| `variables.tv = v(); StructKeyExists(variables, "tv")` / `isDefined("tv")` | `false` | `true` |
| unscoped `tv2 = v(); isDefined("tv2")` | `false` | `true` |
| pre-existing `pre = "x"; pre = v(); isDefined("pre")` | `false` (deleted) | `true` (kept) |
| same with a fn that has **no return statement at all** | no key | key created |
| `isNull(local.rv)` after the void assignment | `true` | `true` (agrees — isNull alone can't discriminate) |
| Wheels default-true callback pattern (below) returns | `true` | null |

Identical in all three execution modes (default, `RUSTCFML_JIT=0`, `RUSTCFML_JIT_THRESHOLD=1`).

## What the test asserts

`tests/core/test_null_return_no_key.cfm` (14 assertions, no fixture CFC):

1. **CONTROL (green on both engines)**: `isNull()` directly on the void call is true.
2. **The gap, local scope**: `local.rv = voidFn()` → `StructKeyExists(local, "rv")` false AND `isDefined("rv")` false; **CONTROL**: `isNull(local.rv)` still reads true.
3. **var-declared target**: `var rv2 = voidFn()` → no `rv2` key in `local`.
4. **variables-scope target** (template level): `StructKeyExists(variables, x)` false, `isDefined(x)` false.
5. **Unscoped target** (template level): `isDefined(x)` false, no key lands in `variables`.
6. **Deletion semantics**: a pre-existing variable (variables-scope AND local) assigned a void return is deleted.
7. **Implicit void**: a fn with no return statement at all behaves identically.
8. **The Wheels shape**: `local.rv = voidFn(); if (!StructKeyExists(local, "rv")) { local.rv = true; }` must return `true` (on RustCFML it returns null — the fallback never fires).
9. **CONTROL (green on both engines)**: a value-returning fn assignment DOES create the key.

Deliberately NOT asserted: `StructKeyList(local)` after the void assignment — Lucee itself lists the name there even though `StructKeyExists` is false. That quirk is not part of the contract Wheels relies on, and pinning it would make a conforming engine fail.

## Why it matters for Wheels

This is the **other half of the old `$callback()` breaker** — the caller-local-leak half was fixed in v0.118 (PR #93); this half has been covered by a local workaround since before the test-PR strategy existed and was never filed (it resurfaced as probe G12 in the milestone strip-workarounds run).

Wheels' universal invocation pattern is:

```cfm
local.rv = $invoke(...);
if (!StructKeyExists(local, "rv")) {
    local.rv = true;   // "callback returned nothing -> treat as success"
}
```

When the engine materializes a null-valued key, `StructKeyExists(local, "rv")` answers TRUE for a callback that returned nothing, the default-true fallback never fires, and the pattern hands null back up the chain. Every model callback chain (`beforeValidation` → … → `afterSave`) evaluates falsy, so `save()` aborts before the INSERT — **silently**: no error, no record, `save()` just returns false. Any CFML code that distinguishes "returned a value" from "returned nothing" via `StructKeyExists`/`isDefined` (a very common CFML idiom, not just Wheels) breaks the same way.

## Verification

- **RED** — RustCFML 0.130.0 (release binary): `3/14 passed (11 failed)`; identical under default JIT, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`. The 3 passes are exactly the controls (isNull-on-call, isNull read-back, value-returning fn).
- **GREEN** — Lucee 5.4.8.2 (CommandBox): `14/14 passed`.
- The gap is runtime-level (no parse error; the suite runs to completion and reports), so the test is registered in `tests/runner.cfm`.
- Full `tests/runner.cfm` with this test registered (staged copy of origin/main, RustCFML 0.130.0): **3837/3848 across 451 suites** — the only 11 failures are this suite's gap assertions, no abort (baseline runner without it: 3834/3834 across 450 suites).
- Full `tests/runner.cfm` on this branch (RustCFML 0.130.0): **3837/3848 across 451 suites** — the only 11 failures are this suite's gap assertions; no abort.