### PR TITLE
test(tags): cffile script-call form (named attributes + attributeCollection)

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -218,6 +218,8 @@ try { include "tags/test_cfquery_result_delivery.cfm"; } catch (any e) { writeOu
 try { include "tags/test_cfdbinfo.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdbinfo.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_mapping_path.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_function_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_function_form.cfm | " & e.message & chr(10)); }
+// cffile script-call form (named attributes + attributeCollection)
+try { include "tags/test_cffile_script_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cffile_script_form.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_recurse_symlink.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_recurse_symlink.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfhttpparam_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttpparam_runtime_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfmail_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfmail_runtime_body.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_cffile_script_form.cfm
+++ b/tests/tags/test_cffile_script_form.cfm
@@ -1,0 +1,140 @@
+<cfscript>
+suiteBegin("Tags: cffile script-call form");
+
+// ============================================================
+// Background
+// ============================================================
+// CFML exposes built-in tags as script-callable functions. Inside a function,
+//
+//     cffile(action = "read", file = path, variable = "local.content");
+//     cffile(attributeCollection = "#local.args#");
+//
+// must behave exactly like the corresponding <cffile> tag. On RustCFML the
+// script-call form of cffile is not implemented at all: the call site is
+// treated as an undefined identifier and throws "Variable 'cffile' is
+// undefined" at runtime — identically for the named-attribute form and the
+// attributeCollection form, for every action. The TAG form <cffile> works
+// (control B below) and the fileRead()/fileWrite() BIFs work (control A),
+// so only the script-call lowering is missing.
+//
+// Cross-engine: Lucee (and Adobe CF) execute every shape below. RustCFML
+// 0.130.0 fails assertions (1)-(4) with "Variable 'cffile' is undefined"
+// while both controls pass.
+//
+// All scratch files live under getTempDirectory() and are deleted on both
+// the pass and the fail path, so the test is self-contained and runner-safe.
+// ============================================================
+
+// ---- Control A: file BIFs round-trip (works on both engines) ----
+function zzcffilesfBifControl() {
+	var p = getTempDirectory() & "zzcffilesf_bif_" & createUUID() & ".txt";
+	var result = "";
+	try {
+		fileWrite(p, "bif-ok");
+		result = fileRead(p);
+	} catch (any e) {
+		result = "ERROR: " & e.message;
+	}
+	if (fileExists(p)) fileDelete(p);
+	return result;
+}
+assert("control: fileWrite()/fileRead() BIFs round-trip", zzcffilesfBifControl(), "bif-ok");
+</cfscript>
+
+<!--- ---- Control B: TAG form of the same tag (works on both engines).
+      Tag syntax cannot appear inside a cfscript block, so this control runs
+      as a tag island — same mixed tag/script pattern as test_tags_include.cfm.
+      The tag form passing while assertions (1)-(4) fail pins the gap to the
+      script-call lowering, not to the tag's file machinery. --->
+<cfset request._zzcffilesf_tagPath = getTempDirectory() & "zzcffilesf_tag_" & createUUID() & ".txt">
+<cfset request._zzcffilesf_tag = "">
+<cftry>
+	<cffile action="write" file="#request._zzcffilesf_tagPath#" output="tag-roundtrip">
+	<cffile action="read" file="#request._zzcffilesf_tagPath#" variable="request._zzcffilesf_tag">
+	<cfcatch type="any">
+		<cfset request._zzcffilesf_tag = "ERROR: " & cfcatch.message>
+	</cfcatch>
+</cftry>
+<cfif fileExists(request._zzcffilesf_tagPath)>
+	<cfset fileDelete(request._zzcffilesf_tagPath)>
+</cfif>
+
+<cfscript>
+// trim(): action="write" may add a trailing newline depending on the engine's
+// addNewLine default; the contract under test is delivery, not newline policy.
+assert("control: tag form write+read round-trips", trim(request._zzcffilesf_tag), "tag-roundtrip");
+
+// ---- (1) script-call form, action="write", named attributes ----
+function zzcffilesfWrite() {
+	var p = getTempDirectory() & "zzcffilesf_w_" & createUUID() & ".txt";
+	var result = "";
+	try {
+		cffile(action = "write", file = p, output = "written-via-script-call");
+		result = fileExists(p) ? trim(fileRead(p)) : "no-file-created";
+	} catch (any e) {
+		result = "ERROR: " & e.message;
+	}
+	if (fileExists(p)) fileDelete(p);
+	return result;
+}
+assert("(1) cffile(action='write', file=, output=) writes the file",
+	zzcffilesfWrite(), "written-via-script-call");
+
+// ---- (2) script-call form, action="read", variable="local.content" ----
+// This is the exact shape Wheels' Global.cfc helpers use inside functions.
+function zzcffilesfRead() {
+	var p = getTempDirectory() & "zzcffilesf_r_" & createUUID() & ".txt";
+	var result = "";
+	local.content = "";
+	try {
+		fileWrite(p, "read-me-back");
+		cffile(action = "read", file = p, variable = "local.content");
+		result = local.content;
+	} catch (any e) {
+		result = "ERROR: " & e.message;
+	}
+	if (fileExists(p)) fileDelete(p);
+	return result;
+}
+assert("(2) cffile(action='read', file=, variable='local.content') delivers the content",
+	zzcffilesfRead(), "read-me-back");
+
+// ---- (3) script-call form, action="append" ----
+// Shape used by the Wheels migrator to emit SQL files (Base.cfc $file(action="append")).
+function zzcffilesfAppend() {
+	var p = getTempDirectory() & "zzcffilesf_app_" & createUUID() & ".txt";
+	var result = "";
+	try {
+		fileWrite(p, "line1");
+		cffile(action = "append", file = p, output = "line2", addnewline = "no");
+		result = fileRead(p);
+	} catch (any e) {
+		result = "ERROR: " & e.message;
+	}
+	if (fileExists(p)) fileDelete(p);
+	return result;
+}
+assert("(3) cffile(action='append', ..., addnewline='no') appends to the file",
+	zzcffilesfAppend(), "line1line2");
+
+// ---- (4) attributeCollection form ----
+// Byte-for-byte the body of Wheels' Global.cfc $file(): copy arguments into a
+// plain struct, then cffile(attributeCollection = "#local.args#").
+function zzcffilesfAcWrite() {
+	var p = getTempDirectory() & "zzcffilesf_ac_" & createUUID() & ".txt";
+	var result = "";
+	try {
+		local.args = {action: "write", file: p, output: "ac-write-ok"};
+		cffile(attributeCollection = "#local.args#");
+		result = fileExists(p) ? trim(fileRead(p)) : "no-file-created";
+	} catch (any e) {
+		result = "ERROR: " & e.message;
+	}
+	if (fileExists(p)) fileDelete(p);
+	return result;
+}
+assert("(4) cffile(attributeCollection='##local.args##') executes the collected attributes",
+	zzcffilesfAcWrite(), "ac-write-ok");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Cross-engine gap: the script-call form of `cffile` does not exist

CFML exposes built-in tags as script-callable functions. Inside a function:

```cfml
cffile(action = "read", file = path, variable = "local.content");

// or, the generic-wrapper shape:
local.args = {action: "write", file: path, output: content};
cffile(attributeCollection = "#local.args#");
```

On RustCFML the call site is parsed as a bare identifier, so every script-form `cffile(...)` throws at runtime — the same error for the named-attribute form, the attributeCollection form, and every action:

```
Variable 'cffile' is undefined
```

| engine | `cffile(action=, ...)` script call | `cffile(attributeCollection=)` | tag `<cffile>` | `fileRead()`/`fileWrite()` BIFs |
|--------|-----------------------------------|--------------------------------|----------------|--------------------------------|
| RustCFML 0.130.0 | **`Variable 'cffile' is undefined`** | **`Variable 'cffile' is undefined`** | works | work |
| Lucee 5.4.8.2 | works | works | works | work |

The tag form and the file BIFs both work, so only the script-call lowering for `cffile` is missing. And the script-call form of `cfdirectory(...)` already works (`test_cfdirectory_function_form.cfm` passes), so this is a per-tag gap, not a general script-call gap.

### What the test asserts

- (1) `cffile(action="write", file=, output=)` creates the file with the given content
- (2) `cffile(action="read", file=, variable="local.content")` delivers the content into the calling function's local scope
- (3) `cffile(action="append", ..., addnewline="no")` appends to an existing file
- (4) `cffile(attributeCollection = "#local.args#")` executes the collected attributes (write shape)
- CONTROLS (pass on both engines): a `fileWrite()`/`fileRead()` BIF round-trip, and a tag-island `<cffile action="write">` + `<cffile action="read">` round-trip (mixed tag/script in one test file — the `test_tags_include.cfm` pattern). The tag control passing while (1)-(4) fail pins the gap to the script-call surface, not the tag's file machinery.

All scratch files live under `getTempDirectory()` and are deleted on both the pass and the fail path — self-contained and runner-safe.

### Why it matters for Wheels

Wheels' `Global.cfc` `$file()` is byte-for-byte assertion (4):

```cfml
public any function $file() {
	local.args = {};
	for (local.key in arguments) {
		local.args[local.key] = arguments[local.key];
	}
	cffile(attributeCollection = "#local.args#");
}
```

Its callers are the next rungs of the ladder: the migrator writes generated migration files (`migrator/AutoMigrator.cfc`, `action="write"`) and emits SQL files (`migrator/Base.cfc`, `action="append"` with `addNewLine`), and `renderWith(writeToFile=...)` persists rendered output (`controller/miscellaneous.cfc`, `action="write"`). None of these sit on the CRUD path that now serves, which is why this gap lived behind a local workaround since before the test-PR strategy existed — but the migrator ladder hits it immediately.

### Verification

- **RustCFML 0.130.0** (release binary), staged repo layout (`harness.cfm` + this test): **2/6** — assertions (1)-(4) all fail with `Variable 'cffile' is undefined`; both controls PASS. Identical 2/6 with `RUSTCFML_JIT=0` and with `RUSTCFML_JIT_THRESHOLD=1` — interpreter semantics, not JIT-specific.
- **Lucee 5.4.8.2** (CommandBox): all **6/6** PASS. (Adobe CF was not run for this PR; the script-call tag surface is long-standing shared CFML behavior.)
- Full `tests/runner.cfm` with this test registered (RustCFML 0.130.0): **3836/3840 across 451 suites** — the only 4 failures are this suite's gap assertions; no abort. "Variable 'cffile' is undefined" is a catchable runtime error, so the runner's try/include isolation holds.
- Runtime gap → registered in the tags block of `tests/runner.cfm`, directly after `test_cfdirectory_function_form.cfm`. Full `tests/runner.cfm` on this branch (RustCFML 0.130.0): **3836/3840 across 451 suites** — the only 4 failures are this suite's gap assertions; no abort.