### PR TITLE
Add CFML test for per-application session namespacing

### DIFF
--- a/tests/lifecycle/session_namespace/a/Application.cfc
+++ b/tests/lifecycle/session_namespace/a/Application.cfc
@@ -1,0 +1,9 @@
+<cfcomponent output="false">
+    <cfset this.name = "lucee_compat_session_ns_a" />
+    <cfset this.sessionManagement = true />
+    <cfset this.sessionTimeout = createTimespan(0, 0, 10, 0) />
+
+    <cffunction name="onSessionStart" output="false">
+        <cfset session.started_in = "A" />
+    </cffunction>
+</cfcomponent>

--- a/tests/lifecycle/session_namespace/a/page.cfm
+++ b/tests/lifecycle/session_namespace/a/page.cfm
@@ -1,0 +1,4 @@
+<cfif (url.op ?: form.op ?: "") eq "write">
+    <cfset session.x = url.val ?: form.val ?: "" />
+</cfif>
+<cfoutput>app=[#getApplicationMetadata().name ?: ''#];started=[#session.started_in ?: ''#];x=[#session.x ?: ''#]</cfoutput>

--- a/tests/lifecycle/session_namespace/b/Application.cfc
+++ b/tests/lifecycle/session_namespace/b/Application.cfc
@@ -1,0 +1,9 @@
+<cfcomponent output="false">
+    <cfset this.name = "lucee_compat_session_ns_b" />
+    <cfset this.sessionManagement = true />
+    <cfset this.sessionTimeout = createTimespan(0, 0, 10, 0) />
+
+    <cffunction name="onSessionStart" output="false">
+        <cfset session.started_in = "B" />
+    </cffunction>
+</cfcomponent>

--- a/tests/lifecycle/session_namespace/b/page.cfm
+++ b/tests/lifecycle/session_namespace/b/page.cfm
@@ -1,0 +1,4 @@
+<cfif (url.op ?: form.op ?: "") eq "write">
+    <cfset session.x = url.val ?: form.val ?: "" />
+</cfif>
+<cfoutput>app=[#getApplicationMetadata().name ?: ''#];started=[#session.started_in ?: ''#];x=[#session.x ?: ''#]</cfoutput>

--- a/tests/lifecycle/test_session_app_namespace.cfm
+++ b/tests/lifecycle/test_session_app_namespace.cfm
@@ -1,0 +1,90 @@
+<cfscript>
+suiteBegin("Sessions are namespaced by application name");
+
+// ============================================================
+// Background
+// ============================================================
+// In CFML, session identity is the composite (application name, session id).
+// Application.cfc's pseudo-constructor runs per request and `this.name`
+// selects the application -- one server instance can host several apps, each
+// with an isolated application AND session scope. Lucee resolves the same
+// CFID presented under two different `this.name` values to two independent
+// sessions, and onSessionStart fires per (application, session).
+//
+// RustCFML namespaces the application scope correctly (ApplicationStore is
+// keyed by app name) but sessions are keyed by the bare session id, so two
+// applications in one process that receive the same CFID share -- and
+// corrupt -- one session. Browsers do not scope cookies by port, so
+// localhost:8180 (app A) and localhost:8181 (app B) send the identical CFID;
+// any copied CFID is also valid across applications (session-fixation-shaped).
+//
+// Behavioral round-trip: two fixture apps with distinct `this.name` live under
+// session_namespace/a and /b. Every probe WRITES to the session so the test is
+// agnostic to lazy session creation (post-v0.131.0 default: record, cookie and
+// onSessionStart happen on first session write). Runs only when served
+// (cgi.server_port present); skips from the CLI. Query params are passed via
+// cfhttpparam type="url" -- see the companion multi-param cfhttp test.
+// ============================================================
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+function sessNsCookieHeader(resp) {
+    var sc = resp.responseheader["Set-Cookie"] ?: "";
+    var raw = isArray(sc) ? sc : [sc];
+    var pairs = [];
+    for (var c in raw) {
+        var firstPart = trim(listFirst(c, ";"));
+        if (len(firstPart)) arrayAppend(pairs, firstPart);
+    }
+    return arrayToList(pairs, "; ");
+}
+
+if (skip) {
+    assertTrue("session app-namespace skipped (no cgi.server_port)", true);
+} else {
+    base = "http://127.0.0.1:" & serverPort & "/tests/lifecycle/session_namespace";
+
+    // r1: write to app A with no cookie; capture the session cookie it mints.
+    cfhttp(url="#base#/a/page.cfm", result="r1", timeout=15) {
+        cfhttpparam(type="url", name="op", value="write");
+        cfhttpparam(type="url", name="val", value="alpha");
+    }
+    cookieHeader = sessNsCookieHeader(r1);
+    assertTrue("app A mints a session cookie on first write", len(cookieHeader) GT 0);
+    assertTrue("control: app A onSessionStart ran in A", find("started=[A]", r1.filecontent) GT 0);
+
+    // r2 (control): same cookie back to app A -- session persists in-app.
+    cfhttp(url="#base#/a/page.cfm", result="r2", timeout=15) {
+        cfhttpparam(type="header", name="Cookie", value=cookieHeader);
+        cfhttpparam(type="url", name="op", value="read");
+    }
+    assertTrue("control: app A sees its own session value", find("x=[alpha]", r2.filecontent) GT 0);
+
+    // r3 (gap): the SAME cookie written to in app B must be a DIFFERENT
+    // session: onSessionStart fires for (app B, this id), not inherited
+    // from app A's session.
+    cfhttp(url="#base#/b/page.cfm", result="r3", timeout=15) {
+        cfhttpparam(type="header", name="Cookie", value=cookieHeader);
+        cfhttpparam(type="url", name="op", value="write");
+        cfhttpparam(type="url", name="val", value="beta");
+    }
+    assertTrue("onSessionStart fires per (application, session)", find("started=[B]", r3.filecontent) GT 0);
+
+    // r4 (gap): app B's write must not leak into app A's session.
+    cfhttp(url="#base#/a/page.cfm", result="r4", timeout=15) {
+        cfhttpparam(type="header", name="Cookie", value=cookieHeader);
+        cfhttpparam(type="url", name="op", value="read");
+    }
+    assertTrue("app B write does not leak into app A", find("x=[alpha]", r4.filecontent) GT 0);
+
+    // r5 (control): app B's own session persists independently.
+    cfhttp(url="#base#/b/page.cfm", result="r5", timeout=15) {
+        cfhttpparam(type="header", name="Cookie", value=cookieHeader);
+        cfhttpparam(type="url", name="op", value="read");
+    }
+    assertTrue("app B keeps its own session value", find("x=[beta]", r5.filecontent) GT 0);
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -246,6 +246,7 @@ try { include "includes/test_named_args_includes.cfm"; } catch (any e) { writeOu
 try { include "includes/test_closure_in_swapped_program.cfm"; } catch (any e) { writeOutput("ERROR | includes/test_closure_in_swapped_program.cfm | " & e.message & chr(10)); }
 
 // --- Lifecycle / server request fixtures ---
+try { include "lifecycle/test_session_app_namespace.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_session_app_namespace.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_mapping_coverage.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_mapping_coverage.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_load_errors.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_load_errors.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_scope_custom_tag.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_scope_custom_tag.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## What

Pins that session identity is the composite **(application name, session id)** — Lucee parity. `Application.cfc`'s pseudo-constructor runs on every request and `this.name` selects the application, so one server instance can host several applications (e.g. resolved from the Host header: hub.domain.com, delivery.domain.com, floor.domain.com) with isolated application AND session scopes. The same CFID presented under two different `this.name` values must resolve to two independent sessions, and `onSessionStart` must fire per (application, session).

## Why

RustCFML already gets the application side right — `ApplicationStore` is keyed by application name. Sessions, however, are keyed by **bare session id**: `SessionStore.get/set/remove/rotate` take only the id (`crates/cfml-vm/src/session_store.rs`), and the request handler resolves the single global `CFID` cookie with no application context (`crates/cli/src/lib.rs`, cookie extraction ~1342 / Set-Cookie ~1413).

**Consequence:** two applications in one process that receive the same CFID share — and corrupt — one session. Not hypothetical: browsers don't scope cookies by port, so localhost:8180 (app A) and localhost:8181 (app B) send the identical CFID; any copied CFID is also valid across applications (a session-fixation-shaped hole). Verified on current main:

```
app A write (no cookie)        -> started=[A] x=[alpha]  CFID minted
app B write (same CFID)        -> started=[A] x=[beta]   <- inherited A's session, no onSessionStart for B
app A read  (same CFID)        -> x=[beta]               <- B's write clobbered A
```

Notably, the new datasource session store's table is already keyed `(cfid, app_name)` — but `app_name` is a fixed per-store value ("v1 uses a single partition per store", `crates/cli/src/session/datasource.rs`), because the `SessionStore` API has no way to receive the per-request application name. The storage schema anticipates exactly this fix.

## Coverage

Two fixture apps with distinct `this.name` under `tests/lifecycle/session_namespace/{a,b}`; behavioral round-trip (runs served, self-skips from the CLI). Every probe **writes** to the session, so the test is agnostic to the v0.131.0 lazy default (record/cookie/onSessionStart on first write).

- **controls** (pass today): app A mints a cookie on first write; `onSessionStart` ran in A; A's session value persists in-app.
- **gaps** (expected-fail on current upstream): same CFID written in app B fires `onSessionStart` for (app B, id) — currently inherits app A's session; app B's write must not leak into app A; app B keeps its own value independently.

Not covered (deliberately): timing-based expiry isolation — per-app `this.sessionTimeout` on the same CFID — flaky in CI; the composite key makes it structural anyway.

Query params are passed via `cfhttpparam type="url"` because multi-param URLs currently break cfhttp — companion test PR incoming.

## Where the fix goes (for reference; not included here)

Introduce a typed composite key (e.g. `SessionKey { app_name, session_id }`, or an `app_name` parameter on the `SessionStore` trait methods) rather than string-concatenating at call sites — make it impossible to look up a session without an application name. Thread the current application name (already resolved for the application scope) through the handler's session resolution. All backends namespace consistently: in-memory map key, memcached key prefix (`key_prefix + app + id` — note this invalidates existing memcached session keys; worth a migration note), cluster CRDT doc keys, and the datasource store's existing `app_name` column switching from store-level constant to the real per-request value. Expiry bookkeeping (`take_expired`, the new background reaper) is then naturally per-(app, id), so per-app `this.sessionTimeout` applies to that app's sessions. Single-application deployments keep working unchanged apart from persisted key shape.

Test-only; no engine change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)