### PR TITLE
Add CFML test for literal query strings in cfhttp url

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -211,6 +211,7 @@ try { include "tags/test_tags_cfmail.cfm"; } catch (any e) { writeOutput("ERROR 
 try { include "tags/test_tags_cfcache.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfcache.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfstoredproc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfstoredproc.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfqueryparam_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfqueryparam_attribute_collection.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cfhttp_multiparam_url.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttp_multiparam_url.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfqueryparam_interpolated_value.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_interpolated_value.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfquery_quoted_identifier.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfquery_quoted_identifier.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfquery_control_tags.cfm | " & e.message & chr(10)); }

--- a/tests/tags/cfhttp_multiparam_target.cfm
+++ b/tests/tags/cfhttp_multiparam_target.cfm
@@ -1,0 +1,1 @@
+<cfoutput>a=[#url.a ?: ''#];b=[#url.b ?: ''#]</cfoutput>

--- a/tests/tags/test_cfhttp_multiparam_url.cfm
+++ b/tests/tags/test_cfhttp_multiparam_url.cfm
@@ -1,0 +1,52 @@
+<cfscript>
+suiteBegin("cfhttp: literal query string in url");
+
+// ============================================================
+// Background
+// ============================================================
+// A literal query string in the cfhttp url attribute --
+// url="...page.cfm?a=1" or url="...page.cfm?a=1&b=2" -- must round-trip
+// like any other URL. On Lucee this just works.
+//
+// On RustCFML a request whose url contains a literal query string fails
+// SILENTLY: no exception is thrown, the result struct simply comes back with
+// an empty statuscode and empty filecontent. Observed consistently when
+// cfhttp runs in a request context (this suite served); intermittently from
+// the CLI. The request line DOES reach the server intact (verified against
+// the server debug log), so the failure is on the client's side of the
+// exchange. The same parameters passed via cfhttpparam type="url" work, and
+// string interpolation builds the url text correctly -- only the literal
+// query-string form is broken.
+//
+// Behavioral round-trip: GETs a local echo target; runs only when served
+// (cgi.server_port present), skips from the CLI.
+// ============================================================
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+if (skip) {
+    assertTrue("cfhttp literal query string skipped (no cgi.server_port)", true);
+} else {
+    target = "http://127.0.0.1:" & serverPort & "/tests/tags/cfhttp_multiparam_target.cfm";
+
+    // control: the same parameters via cfhttpparam type="url" round-trip
+    cfhttp(url="#target#", result="r1", timeout=15) {
+        cfhttpparam(type="url", name="a", value="1");
+        cfhttpparam(type="url", name="b", value="2");
+    }
+    assertTrue("control: cfhttpparam type=url params arrive", find("a=[1];b=[2]", r1.filecontent) GT 0);
+
+    // gap: a single literal query parameter
+    cfhttp(url="#target#?a=1", result="r2", timeout=15);
+    assertTrue("single-param literal url returns 200", find("200", r2.statuscode ?: "") GT 0);
+    assertTrue("single literal param arrives", find("a=[1]", r2.filecontent) GT 0);
+
+    // gap: two literal query parameters
+    cfhttp(url="#target#?a=1&b=2", result="r3", timeout=15);
+    assertTrue("multi-param literal url returns 200", find("200", r3.statuscode ?: "") GT 0);
+    assertTrue("both literal params arrive", find("a=[1];b=[2]", r3.filecontent) GT 0);
+}
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Pins that a literal query string in the cfhttp `url` attribute — `url="...page.cfm?a=1"` or `?a=1&b=2` — round-trips like any other URL (Lucee parity).

## Why

On RustCFML a cfhttp request whose url contains a literal query string fails **silently**: no exception, the result struct just comes back with empty `statuscode` and `filecontent`. Observed deterministically when cfhttp runs in a request context (the served suite — 4/4 failures every run) and intermittently from the CLI.

Diagnostics already done:
- The request line **reaches the server intact** (verified against the server debug log, query string included) — the failure is on the client's side of the exchange.
- String interpolation is not the culprit: `"#t#?a=1&b=2"` builds the correct string.
- The same parameters via `cfhttpparam type="url"` work fine (that's the test's control, and the workaround we used in #114's test).

Found while writing the session-namespacing test (#114): the fixture round-trips silently returned nothing as soon as the URL carried `?op=write&val=alpha`.

## Coverage

Local echo target + served round-trip (self-skips from the CLI), following the existing cfhttp round-trip pattern.

- **control** (passes today): two params via `cfhttpparam type="url"`.
- **gaps** (expected-fail on current upstream): single literal query param (status + value arriving), two literal query params (status + both values arriving).

Validated on current main: 4 gap assertions fail, control passes, no collateral (3851/3855).

## Where the fix goes (for reference; not included here)

Client side of `fn_cfhttp` — the URL with a query string is accepted and the request is emitted correctly on the wire, but the response never populates the result struct (and no error surfaces). Likely the response read/parse path keyed off the request URL; worth also surfacing whatever error is being swallowed, since the silent empty result made this expensive to trace.

Test-only; no engine change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)