### PR TITLE
Add CFML test for local-scoped variable named 'arguments'

### DIFF
--- a/tests/core/LocalArgumentsVarFixture.cfc
+++ b/tests/core/LocalArgumentsVarFixture.cfc
@@ -1,0 +1,19 @@
+component {
+
+	// A local-scoped variable that happens to be NAMED `arguments` must behave
+	// like any other local struct. This is the shape a Moopa route dispatcher
+	// uses: it builds a working struct `local.arguments = {}`, fills it with
+	// the matched route params, and hands it to the endpoint. The name is
+	// incidental — `local.arguments` is a variable in the `local` scope, not
+	// the `arguments` scope.
+	public string function build() {
+		local.arguments = {};
+		local.arguments["route"]    = "tracks/abc";
+		local.arguments["track_id"] = "THE-ID";
+		structAppend(local.arguments, { "extra": "Z" }, true);
+
+		return "keys=[" & structKeyList(local.arguments) & "]"
+			& " | track_id=[" & (local.arguments.track_id ?: "NULL") & "]"
+			& " | extra=[" & (local.arguments.extra ?: "NULL") & "]";
+	}
+}

--- a/tests/core/test_local_arguments_scope_independence.cfm
+++ b/tests/core/test_local_arguments_scope_independence.cfm
@@ -1,0 +1,32 @@
+<cfscript>
+// A `local`-scoped variable named `arguments` is an ordinary local struct
+// (Lucee parity).
+//
+// `local.arguments` is a variable in the `local` scope whose name happens to
+// be "arguments" — it is not the `arguments` scope. Assigning and reading it
+// must behave like any other local struct: the keys written to it are the
+// keys it has.
+//
+// Real-world hit: a Moopa route dispatcher (a custom tag, no declared
+// arguments) builds a working struct `local.arguments = {}`, fills it with
+// the matched route params, and passes it to the endpoint. When the engine
+// treats `local.arguments` as the `arguments` scope, the struct reads back
+// EMPTY, the route params are lost, and every parameterised route 500s with
+// "No ID provided".
+
+suiteBegin("Core: local-scoped 'arguments' variable behaves as an ordinary struct");
+
+o = createObject("component", "LocalArgumentsVarFixture");
+r = o.build();
+
+assertTrue("local.arguments keeps the keys written to it (got: [" & r & "])",
+	find("keys=[route,track_id,extra]", r) GT 0);
+
+assertTrue("local.arguments values are readable (got: [" & r & "])",
+	find("track_id=[THE-ID]", r) GT 0);
+
+assertTrue("structAppend into local.arguments works (got: [" & r & "])",
+	find("extra=[Z]", r) GT 0);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -20,6 +20,7 @@ try { include "core/test_bare_call_shadowing_semantics.cfm"; } catch (any e) { w
 try { include "core/test_closure_env_leak.cfm"; } catch (any e) { writeOutput("ERROR | core/test_closure_env_leak.cfm | " & e.message & chr(10)); }
 try { include "core/test_compound_assignment.cfm"; } catch (any e) { writeOutput("ERROR | core/test_compound_assignment.cfm | " & e.message & chr(10)); }
 try { include "core/test_undeclared_named_args.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undeclared_named_args.cfm | " & e.message & chr(10)); }
+try { include "core/test_local_arguments_scope_independence.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_arguments_scope_independence.cfm | " & e.message & chr(10)); }
 //   - invoke_undeclared_keys: the argument struct of the positional BIF
 //     invoke(obj, method, argStruct) is a named-argument collection — EVERY
 //     key must reach the callee's arguments scope, declared param or not,


### PR DESCRIPTION
## What

A pure-CFML test (no db, no network) that a `local`-scoped variable named `arguments` behaves like any other local struct — you can assign it, write keys, `structAppend` into it, and read them back.

## Why

`local.arguments` is a variable in the `local` scope whose name happens to be "arguments"; it is not the `arguments` scope. On current main the two share storage, so a local variable named `arguments` is silently aliased to the `arguments` scope — its keys read back empty (and, in a function with a declared argument, writing it clobbers that argument).

Real-world hit: a Moopa route dispatcher (a custom tag, no declared arguments) builds a working struct `local.arguments = {}`, fills it with the matched route params, and hands it to the endpoint via `invoke()`. With the alias, the struct is empty by the time it's passed on — the route params vanish and every parameterised route 500s with "No ID provided".

On current main (v0.132.0):

```
FAIL | Core: local-scoped 'arguments' variable behaves as an ordinary struct | 0/3 passed (3 failed)
       FAIL: local.arguments keeps the keys written to it (got: [keys=[] | track_id=[NULL] | extra=[NULL]])
       FAIL: local.arguments values are readable (got: [keys=[] | track_id=[NULL] | extra=[NULL]])
       FAIL: structAppend into local.arguments works (got: [keys=[] | track_id=[NULL] | extra=[NULL]])
```

Expected (Lucee parity): `keys=[route,track_id,extra] | track_id=[THE-ID] | extra=[Z]`.

## Regression window

This passed up to and including **v0.116** and broke at **v0.118.0** — commit `48fef47` ("per-frame `local` view — read side of #77", PR #93). Bisected with the minimal fixture in this PR:

```
befd2a1 (pre-v0.118) -> keys=[route,track_id]   (correct)
48fef47 (v0.118.0)   -> keys=[]                 (regressed)
```

## Coverage

- `local.arguments = {}`, two key writes, plus a `structAppend` — assert the final key list, a value read, and the appended key
- function takes no declared arguments, so this isolates the local-variable-named-`arguments` case (independent of the separate declared-arg shadowing work in #77)

## Where the fix goes

`crates/cfml-vm/src/lib.rs` — `build_local_scope_view` (~line 10451) unconditionally drops any local key named `arguments` (`if k == "this" || k == "super" || k == "arguments" || …`), and the `arguments` scope itself is stored in the same `locals` map under that key, so a user-declared `local.arguments` collides with it. The `local` view (and `local.X` writes) need to distinguish a user-declared local named `arguments` from the `arguments` scope — e.g. store the scope under a reserved internal key rather than `"arguments"`, or let the `DeclareLocal` reclaim path (which already removes the name from `inherited_or_param_keys`) win for `arguments` too.
