### PR TITLE
Add CFML test for WITH (CTE) statements as row-returning queries

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -224,6 +224,7 @@ try { include "tags/test_pg_vector_param_binds.cfm"; } catch (any e) { writeOutp
 try { include "tags/test_pg_error_cause_chain.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_pg_error_cause_chain.cfm | " & e.message & chr(10)); }
 try { include "tags/test_pg_extended_param_binds.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_pg_extended_param_binds.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfquery_quoted_identifier.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfquery_quoted_identifier.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cte_with_query.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cte_with_query.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfquery_control_tags.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfquery_result_delivery.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfquery_result_delivery.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdbinfo.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdbinfo.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_cte_with_query.cfm
+++ b/tests/tags/test_cte_with_query.cfm
@@ -1,0 +1,80 @@
+<cfscript>
+// A `WITH` (CTE) statement is a row-returning query (Lucee parity).
+//
+// CTEs are standard SQL; Lucee runs `WITH … SELECT …` as an ordinary query
+// and returns its rows. RustCFML decides whether a statement returns rows by
+// looking for a leading `SELECT`, so a `WITH` prefix is misclassified as a
+// non-row "execute" statement:
+//   - SQLite: errors "Execute returned results - did you mean to call query?"
+//   - PostgreSQL: the row is counted but every column reads back NULL.
+//
+// Real-world hit: the Moopa sysadmin route-security panel builds its payload
+// with `WITH profile_subjects AS (…), role_subjects AS (…) SELECT
+// row_to_json(…)::text AS data …`; the `data` column comes back empty and
+// `deserializeJSON("")` 500s the endpoint.
+//
+// Self-contained via the bundled SQLite driver (same skip pattern as
+// tests/tags/test_queryexecute_param_structs.cfm).
+
+suiteBegin("queryExecute: WITH (CTE) statements are row-returning queries");
+
+tmpfile = getTempDirectory() & "/rustcfml_cte_" & createUUID() & ".sqlite";
+ds = "sqlite://" & tmpfile;
+skip = false;
+
+try {
+    queryExecute("CREATE TABLE t (id INTEGER, label TEXT)", [], { datasource: ds });
+    queryExecute("INSERT INTO t VALUES (1, 'alpha'), (2, 'beta')", [], { datasource: ds });
+} catch (any e) {
+    skip = true;
+    assertTrue("CTE test skipped (no sqlite): " & e.message, true);
+}
+</cfscript>
+
+<cfif NOT skip>
+<cfscript>
+// --- control: a plain SELECT returns rows today ---
+ctrl = queryExecute("SELECT id, label FROM t ORDER BY id", [], { datasource: ds });
+assert("control: plain SELECT returns rows", ctrl.recordCount, 2);
+
+// --- gap: an inline-VALUES CTE must return its rows ---
+try {
+    rValues = queryExecute(
+        "WITH cte(n) AS (VALUES (10), (20), (30)) SELECT n FROM cte ORDER BY n",
+        [], { datasource: ds });
+    assert("inline-VALUES CTE returns its rows", rValues.recordCount, 3);
+    assert("inline-VALUES CTE first value", rValues.n[1] ?: "", "10");
+} catch (any e) {
+    assertTrue("inline-VALUES CTE query failed (misclassified as execute?): " & e.message, false);
+}
+
+// --- gap: a CTE over a real table must return its rows AND values ---
+try {
+    rTable = queryExecute(
+        "WITH labelled AS (SELECT id, label FROM t) SELECT label FROM labelled ORDER BY id",
+        [], { datasource: ds });
+    assert("table CTE returns its rows", rTable.recordCount, 2);
+    // the PostgreSQL form of this bug returns the row but a NULL column, so
+    // assert the actual value, not just the row count
+    assert("table CTE first column value is not lost", rTable.label[1] ?: "", "alpha");
+} catch (any e) {
+    assertTrue("table CTE query failed (misclassified as execute?): " & e.message, false);
+}
+
+// --- gap: a CTE feeding an aggregate (the shape the Moopa panel uses) ---
+try {
+    rAgg = queryExecute(
+        "WITH labelled AS (SELECT label FROM t) SELECT count(*) AS c FROM labelled",
+        [], { datasource: ds });
+    assert("CTE feeding an aggregate returns the value", rAgg.c[1] ?: "", "2");
+} catch (any e) {
+    assertTrue("CTE-with-aggregate query failed: " & e.message, false);
+}
+
+try { queryExecute("DROP TABLE t", [], { datasource: ds }); } catch (any e) {}
+</cfscript>
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

A self-contained SQLite test (`tests/tags/test_cte_with_query.cfm`, bundled-driver, same skip pattern as `test_queryexecute_param_structs.cfm`) asserting that a `WITH` (CTE) statement is run as a row-returning query.

## Why

CTEs are standard SQL — Lucee runs `WITH … SELECT …` as an ordinary query and returns its rows. RustCFML decides whether a statement returns rows by looking for a leading `SELECT`, so a `WITH` prefix is misclassified as a non-row "execute" statement:

- **SQLite**: errors `Execute returned results - did you mean to call query?`
- **PostgreSQL**: the row is counted but every column reads back NULL (so e.g. `deserializeJSON(q.data)` gets `""` → "EOF while parsing").

On current main (v0.143.0):

```
FAIL | queryExecute: WITH (CTE) statements are row-returning queries | 1/4 passed (3 failed)
       FAIL: inline-VALUES CTE query failed (misclassified as execute?): queryExecute: SQL error: Execute returned results - did you mean to call query?
       FAIL: table CTE query failed (misclassified as execute?): ...
       FAIL: CTE-with-aggregate query failed: ...
```

(The plain-`SELECT` control passes, confirming the harness/datasource is fine.)

This is **not** a regression — it reproduces identically on v0.132/v0.135/v0.143; CTEs simply hadn't been exercised before. Real-world hit: the Moopa sysadmin route-security panel builds its payload with `WITH profile_subjects AS (…), role_subjects AS (…) SELECT row_to_json(…)::text AS data …`; on PostgreSQL the `data` column comes back empty and `deserializeJSON("")` 500s the endpoint.

## Coverage

- control: a plain `SELECT` returns rows (passes today)
- inline-`VALUES` CTE returns its rows
- CTE over a real table returns its rows **and** column values (catches the PostgreSQL NULL-column form, not just the SQLite throw)
- CTE feeding an aggregate (`count(*)`)

## Where the fix goes

The statement classifier that decides query-vs-execute (and, on the pg path, whether to fetch + decode result rows): a statement whose first significant keyword is `WITH` should be treated as row-returning, same as `SELECT`. Practically: after stripping leading whitespace/comments, accept a leading `WITH` (a CTE that resolves to a `SELECT`) as a query — ideally also handle data-modifying CTEs (`WITH … INSERT/UPDATE … RETURNING`).
