### PR TITLE
Extend pg temporal test: ISO 8601 offset/fractional/Z binds

### DIFF
--- a/tests/tags/test_pg_temporal_param_binds.cfm
+++ b/tests/tags/test_pg_temporal_param_binds.cfm
@@ -81,6 +81,36 @@ if (NOT pgskip) {
             [], { datasource: pgdsn });
         assert("ISO string binds to timestamp", r5.s[1] ?: "", "2026-01-02 03:04:05");
 
+        // --- gap: ISO 8601 / RFC 3339 strings WITH a timezone offset or
+        //     fractional seconds bind to timestamptz. This is the exact shape
+        //     RustCFML serializes a timestamptz column TO in JSON output
+        //     ("2026-06-10T07:20:42.177+00:00"), so an app that reads a record
+        //     and saves it back must be able to re-bind the engine's own
+        //     emitted value. ---
+        queryExecute("UPDATE #tbl# SET ts = ? WHERE id = 1",
+            ["2026-06-10T07:20:42+00:00"], { datasource: pgdsn });
+        r5a = queryExecute("SELECT to_char(ts AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("ISO 8601 with offset binds to timestamptz", r5a.s[1] ?: "", "2026-06-10 07:20:42");
+
+        queryExecute("UPDATE #tbl# SET ts = ? WHERE id = 1",
+            ["2026-06-10T07:20:42.177+00:00"], { datasource: pgdsn });
+        r5b = queryExecute("SELECT to_char(ts AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("ISO 8601 with fractional seconds + offset binds to timestamptz", r5b.s[1] ?: "", "2026-06-10 07:20:42");
+
+        queryExecute("UPDATE #tbl# SET ts = ? WHERE id = 1",
+            ["2026-06-10T07:20:42.177Z"], { datasource: pgdsn });
+        r5c = queryExecute("SELECT to_char(ts AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("ISO 8601 with Z (Zulu) suffix binds to timestamptz", r5c.s[1] ?: "", "2026-06-10 07:20:42");
+
+        queryExecute("UPDATE #tbl# SET tsn = ? WHERE id = 1",
+            ["2026-06-10T07:20:42.177"], { datasource: pgdsn });
+        r5d = queryExecute("SELECT to_char(tsn, 'YYYY-MM-DD HH24:MI:SS') AS s FROM #tbl# WHERE id = 1",
+            [], { datasource: pgdsn });
+        assert("ISO 8601 'T' with fractional seconds (no tz) binds to timestamp", r5d.s[1] ?: "", "2026-06-10 07:20:42");
+
         // --- gap: cfqueryparam-style struct with cf_sql_timestamp ---
         queryExecute("UPDATE #tbl# SET ts = ? WHERE id = 1",
             [{ value: createDateTime(2024, 6, 1, 12, 0, 0), cfsqltype: "cf_sql_timestamp" }],


### PR DESCRIPTION
## What

Extends the existing `tests/tags/test_pg_temporal_param_binds.cfm` with cases for ISO 8601 / RFC 3339 datetime strings that carry a **timezone offset**, a **`Z` (Zulu) suffix**, and/or **fractional seconds** — binding to `timestamptz` / `timestamp`.

## Why

The temporal-bind support added in v0.132.0 (PR #101) handles `createDateTime`/`createDate`, `{ts}`, and plain `"YYYY-MM-DD HH:MM:SS"` strings — but rejects the offset/fractional ISO forms:

```
cannot bind "2026-06-10T07:20:42+00:00"     as PostgreSQL timestamptz: not a recognised date/time
cannot bind "2026-06-10T07:20:42.177+00:00" as PostgreSQL timestamptz: not a recognised date/time
cannot bind "2026-06-10T07:20:42.177Z"      as PostgreSQL timestamptz: not a recognised date/time
cannot bind "2026-06-10T07:20:42.177"       as PostgreSQL timestamp:   not a recognised date/time
```

This matters especially because **`2026-06-10T07:20:42.177+00:00` is the exact shape RustCFML serializes a `timestamptz` column TO in JSON output**. So an app that reads a record (JSON `last_login_at: "…+00:00"`) and saves it back cannot re-bind the engine's own emitted value — it 500s. Real-world hit: saving a Moopa profile (which round-trips `last_login_at`) → `error serializing parameter N … not a recognised date/time`.

On current main (v0.145.0):

```
FAIL | PostgreSQL temporal param binds | 6/7 passed (1 failed)
       FAIL: temporal binds failed: ... cannot bind "2026-06-10T07:20:42+00:00" as PostgreSQL timestamptz: not a recognised date/time
```

(The pre-existing 6 assertions still pass; gated on `RUSTCFML_TEST_PG_URL` as before.)

## Coverage added

- `2026-06-10T07:20:42+00:00` — ISO 8601 `T` + numeric offset
- `2026-06-10T07:20:42.177+00:00` — fractional seconds + offset (the engine's own output format)
- `2026-06-10T07:20:42.177Z` — `Z` (Zulu/UTC) suffix
- `2026-06-10T07:20:42.177` — `T` separator + fractional seconds, no tz → `timestamp`

Round-trips asserted via `to_char(… AT TIME ZONE 'UTC', …)` so the wall-clock instant is checked, not client-side formatting.

## Where the fix goes

The datetime-text parser in the pg temporal bind path: accept RFC 3339 / ISO 8601 with an optional `T` separator, optional fractional seconds, and an optional `Z`/`±HH:MM` offset (chrono's `DateTime::parse_from_rfc3339` covers the offset/`Z` forms; `NaiveDateTime` with a `%.f` fractional arm covers the no-tz form). At minimum the engine must round-trip the string format it itself emits for timestamptz columns.
