### PR TITLE
test(tags): cfqueryparam script-statement form inside a script cfquery

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -218,6 +218,15 @@ try { include "tags/test_tags_cfstoredproc.cfm"; } catch (any e) { writeOutput("
 try { include "tags/test_tags_cfqueryparam_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfqueryparam_attribute_collection.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfhttp_multiparam_url.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttp_multiparam_url.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfqueryparam_interpolated_value.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_interpolated_value.cfm | " & e.message & chr(10)); }
+//   - cfqueryparam_script_form: cfqueryparam must be callable as a script
+//     statement (positional AND attributeCollection) inside a script
+//     cfquery(){} block, like the <cfqueryparam> tag. RustCFML throws
+//     "Variable 'cfqueryparam' is undefined". vendor/wheels/databaseAdapters/
+//     Base.cfc emits exactly this shape for every bound value, so INSERT,
+//     UPDATE, soft-delete, and parameterized WHERE all throw on RustCFML —
+//     the ORM persistence layer is blocked. Runtime gap (undefined-identifier
+//     throw, catchable since v0.125), runner-safe.
+try { include "tags/test_cfqueryparam_script_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_script_form.cfm | " & e.message & chr(10)); }
 try { include "tags/test_pg_temporal_param_binds.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_pg_temporal_param_binds.cfm | " & e.message & chr(10)); }
 try { include "tags/test_pg_jsonb_param_binds.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_pg_jsonb_param_binds.cfm | " & e.message & chr(10)); }
 try { include "tags/test_pg_vector_param_binds.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_pg_vector_param_binds.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_cfqueryparam_script_form.cfm
+++ b/tests/tags/test_cfqueryparam_script_form.cfm
@@ -1,0 +1,67 @@
+<cfscript>
+suiteBegin("Tags: cfqueryparam script-statement form inside a script cfquery");
+
+// ============================================================
+// Background
+// ============================================================
+// Inside a script-syntax cfquery(){} block, cfqueryparam is callable as a
+// script statement — both the positional/named form
+//   cfqueryparam(value = v, cfsqltype = "cf_sql_integer");
+// and the attributeCollection form
+//   cfqueryparam(attributeCollection = qp);
+// must bind a parameter, exactly like the <cfqueryparam> TAG inside a
+// <cfquery> tag. Lucee, Adobe CF, and BoxLang all accept the script form.
+//
+// RustCFML 0.144.0 does not lower the script-statement cfqueryparam: the
+// call site is treated as an undefined identifier and throws
+//   Variable 'cfqueryparam' is undefined
+// for every form, while the TAG form <cfqueryparam ...> works (control below)
+// and queryExecute() with a named-param struct works (control below).
+//
+// Why it matters for Wheels: vendor/wheels/databaseAdapters/Base.cfc emits
+// exactly this shape — a script cfquery(){} whose body calls
+// cfqueryParam(attributeCollection = qp) for every bound value — on the
+// INSERT (create.cfc), UPDATE (update.cfc), soft-delete, and every
+// parameterized WHERE (findOne/findAll with a bind). On RustCFML this throws
+// before any write or parameterized read completes, so the ORM persistence
+// layer is fully blocked even though the framework boots and renders.
+// ============================================================
+
+cfqpsfQ = queryNew("id,name", "integer,varchar", [{id: 1, name: "alpha"}, {id: 2, name: "beta"}]);
+
+// --- CONTROL (green on both engines): queryExecute named-param struct binds ---
+cfqpsfQe = queryExecute("SELECT name FROM cfqpsfQ WHERE id = :tid",
+    {tid: {value: 2, cfsqltype: "cf_sql_integer"}}, {dbtype: "query"});
+assert("CONTROL: queryExecute named-param struct binds", cfqpsfQe.name, "beta");
+
+// --- the gap: positional script cfqueryparam inside a script cfquery ---
+cfqpsfPosVal = "(threw)";
+try {
+    cfquery(name = "local.cfqpsfR1", dbtype = "query") {
+        writeOutput("SELECT name FROM cfqpsfQ WHERE id = ");
+        cfqueryparam(value = 2, cfsqltype = "cf_sql_integer");
+    }
+    cfqpsfPosVal = local.cfqpsfR1.name;
+} catch (any e) {
+    cfqpsfPosVal = "THREW: " & e.message;
+}
+assert("positional cfqueryparam(value=, cfsqltype=) binds inside script cfquery",
+    cfqpsfPosVal, "beta");
+
+// --- the gap: attributeCollection script cfqueryparam (the Wheels Base.cfc shape) ---
+cfqpsfAcVal = "(threw)";
+try {
+    cfqpsfQp = {value: 1, cfsqltype: "cf_sql_integer"};
+    cfquery(name = "local.cfqpsfR2", dbtype = "query") {
+        writeOutput("SELECT name FROM cfqpsfQ WHERE id = ");
+        cfqueryparam(attributeCollection = cfqpsfQp);
+    }
+    cfqpsfAcVal = local.cfqpsfR2.name;
+} catch (any e) {
+    cfqpsfAcVal = "THREW: " & e.message;
+}
+assert("attributeCollection cfqueryparam binds inside script cfquery (Wheels Base.cfc shape)",
+    cfqpsfAcVal, "alpha");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Gap: `cfqueryparam` script-statement form is unimplemented

Inside a script-syntax `cfquery(){}` block, `cfqueryparam` is callable as a script statement — both forms:

```cfml
cfquery(name="local.r", dbtype="query") {
    writeOutput("SELECT name FROM q WHERE id = ");
    cfqueryparam(value = 2, cfsqltype = "cf_sql_integer");        // positional/named
}
// and the generic wrapper shape:
cfqueryparam(attributeCollection = qp);
```

Lucee, Adobe CF, and BoxLang all bind the parameter. RustCFML 0.144.0 treats the call site as an undefined identifier and throws for every form:

```
Variable 'cfqueryparam' is undefined
```

| form | RustCFML 0.144.0 | Lucee 5.4.8.2 |
|------|------------------|---------------|
| `cfqueryparam(value=, cfsqltype=)` in script `cfquery{}` | **`Variable 'cfqueryparam' is undefined`** | binds |
| `cfqueryparam(attributeCollection=qp)` in script `cfquery{}` | **`Variable 'cfqueryparam' is undefined`** | binds |
| `<cfqueryparam ...>` tag form (control) | works | works |
| `queryExecute(sql, {p: {value:, cfsqltype:}})` (control) | works | works |

The tag form works and `queryExecute` named-param structs work, so only the **script-statement lowering** of `cfqueryparam` is missing — the same shape `cfdirectory`/`cffile`/`cfinvoke` needed and recently got.

### What the test asserts
- CONTROL (green on both engines): `queryExecute` named-param struct binds.
- Positional `cfqueryparam(value=, cfsqltype=)` binds inside a script `cfquery{}`. *(red on RustCFML)*
- `cfqueryparam(attributeCollection=qp)` binds — the exact Wheels `Base.cfc` shape. *(red on RustCFML)*

### Why it matters for Wheels
`vendor/wheels/databaseAdapters/Base.cfc` emits exactly this — a script `cfquery(){}` whose body calls `cfqueryParam(attributeCollection = qp)` for every bound value — on the INSERT (`create.cfc`), UPDATE (`update.cfc`), soft-delete, and every parameterized `WHERE` (`findOne`/`findAll` with a bind). On RustCFML this throws before any write or parameterized read completes, so with the whole framework now booting and rendering on stock builds, **this is the gap that blocks the ORM persistence layer** — INSERT/UPDATE/DELETE and any bound-param finder. Param-free `SELECT`s (order-only finders) are the only working DB surface until it lands.

### Verification
- **RustCFML 0.144.0** (release binary): 1/3 — both `cfqueryparam` script-form assertions throw `Variable 'cfqueryparam' is undefined`; the control passes. Identical with `RUSTCFML_JIT=0` and `RUSTCFML_JIT_THRESHOLD=1`.
- **Lucee 5.4.8.2** (CommandBox): 3/3 PASS.
- Full `tests/runner.cfm` on this branch: this suite contributes exactly its 2 expected failures, no abort (catchable runtime error). Registered in the tags block after `test_cfqueryparam_interpolated_value.cfm`.
