### PR TITLE
test(tags): expandPath normalizes a leading double-slash before mapping resolution

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -229,6 +229,16 @@ try { include "tags/test_tags_cfquery_control_tags.cfm"; } catch (any e) { write
 try { include "tags/test_cfquery_result_delivery.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfquery_result_delivery.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdbinfo.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdbinfo.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_mapping_path.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_mapping_path.cfm | " & e.message & chr(10)); }
+//   - expandpath_leading_double_slash: a leading "//" must normalize to a
+//     single "/" before this.mappings resolution — expandPath("//x") ==
+//     expandPath("/x"), resolving the same mapping. RustCFML resolves
+//     expandPath("/wheelsmapprobe") via the mapping but lets "//wheelsmapprobe"
+//     fall through to a docroot-relative path, missing the mapping. The stock
+//     `wheels new` Application.cfc declares a /plugins mapping and boot joins
+//     webPath("/") & "/plugins" = "//plugins", so Plugins.cfc's
+//     cfdirectory(ExpandPath("//plugins")) hits a nonexistent dir, throws, and
+//     $init aborts — every request 500s on a pristine Wheels app.
+try { include "tags/test_expandpath_leading_double_slash.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_expandpath_leading_double_slash.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_function_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_function_form.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_recurse_symlink.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_recurse_symlink.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfdirectory_attrcoll_name.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfdirectory_attrcoll_name.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_expandpath_leading_double_slash.cfm
+++ b/tests/tags/test_expandpath_leading_double_slash.cfm
@@ -1,0 +1,47 @@
+<cfscript>
+suiteBegin("Tags: expandPath normalizes a leading double-slash before mapping resolution");
+
+// ============================================================
+// Background
+// ============================================================
+// A leading "//" in a path is equivalent to a single leading "/": CFML
+// normalizes redundant leading slashes before resolving the path against
+// this.mappings. On Lucee/Adobe/BoxLang expandPath("//x") == expandPath("/x"),
+// so a "//"-prefixed mapped path resolves to the SAME mapping target.
+//
+// RustCFML 0.144.0 resolves expandPath("/wheelsmapprobe") through the
+// this.mappings["/wheelsmapprobe"] entry correctly, but expandPath(
+// "//wheelsmapprobe") does NOT normalize the leading double-slash: it falls
+// through to a docroot-relative path (<docroot>/wheelsmapprobe), missing the
+// mapping entirely. A mid-string double-slash ("/wheelsmapprobe//x") still
+// resolves the mapping; only the LEADING "//" defeats it.
+//
+// Why it matters for Wheels: the stock `wheels new` Application.cfc declares
+// a "/plugins" mapping, and Wheels' boot builds the plugins path by joining
+// application.webPath("/") & application.pluginPath("/plugins") = "//plugins".
+// Plugins.cfc then does cfdirectory(action="list") on ExpandPath("//plugins").
+// On RustCFML that expands to <docroot>/plugins instead of the mapped target,
+// the directory doesn't exist, cfdirectory throws "directory not found", and
+// $init aborts — every request 500s before the app can render. (The split
+// public/ webroot + /plugins mapping is the stock template layout, so this
+// reproduces on any pristine Wheels app served by RustCFML.)
+// ============================================================
+
+// /wheelsmapprobe is declared in tests/Application.cfc -> tests/tags/, which
+// exists; it is NOT a real webroot subdirectory, so only the mapping can
+// resolve it (the same isolation tags/test_mapping_include.cfm relies on).
+epdsSingle = expandPath("/wheelsmapprobe");
+epdsDouble = expandPath("//wheelsmapprobe");
+
+// --- CONTROL (green on both engines): the single-slash mapped path resolves ---
+assertTrue("CONTROL: expandPath('/wheelsmapprobe') resolves the mapping (dir exists)",
+    directoryExists(epdsSingle));
+
+// --- the gap: a leading '//' must normalize to the same resolved path ---
+assert("expandPath('//x') equals expandPath('/x') (leading-slash normalization)",
+    epdsDouble, epdsSingle);
+assertTrue("expandPath('//wheelsmapprobe') still resolves the mapping (dir exists)",
+    directoryExists(epdsDouble));
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Gap: a leading `//` defeats `this.mappings` resolution in `expandPath`

A leading `//` is equivalent to a single `/`: CFML normalizes redundant leading slashes before resolving a path against `this.mappings`. On Lucee/Adobe/BoxLang `expandPath("//x") == expandPath("/x")`, so a `//`-prefixed mapped path resolves to the **same** mapping target.

RustCFML 0.144.0 resolves `expandPath("/wheelsmapprobe")` through `this.mappings["/wheelsmapprobe"]` correctly, but `expandPath("//wheelsmapprobe")` does **not** normalize the leading `//` — it falls through to a docroot-relative path, missing the mapping entirely:

```cfml
// Application.cfc: this.mappings["/wheelsmapprobe"] = <some real dir>
expandPath("/wheelsmapprobe")    // both engines: <mapped dir>
expandPath("//wheelsmapprobe")   // Lucee: <mapped dir>  |  RustCFML: docroot-relative, misses mapping
```

| call | RustCFML 0.144.0 | Lucee 5.4.8.2 (served) |
|------|------------------|------------------------|
| `expandPath("/wheelsmapprobe")` | resolves the mapping | resolves the mapping |
| `expandPath("//wheelsmapprobe")` | **docroot-relative, mapping missed** | resolves the mapping |
| `expandPath("//x") == expandPath("/x")` | **false** | true |
| `directoryExists(expandPath("//wheelsmapprobe"))` | **false** | true |

A *mid-string* double-slash (`"/wheelsmapprobe//x"`) still resolves the mapping; only the **leading** `//` defeats it. Without any mapping, both forms normalize identically on RustCFML too — the divergence is specifically the leading-`//` + mapping interaction.

### What the test asserts
- CONTROL (green on both engines): `expandPath("/wheelsmapprobe")` resolves the mapping (dir exists). Uses the existing `/wheelsmapprobe` mapping from `tests/Application.cfc`.
- `expandPath("//x")` equals `expandPath("/x")` — leading-slash normalization. *(red on RustCFML)*
- `directoryExists(expandPath("//wheelsmapprobe"))` — the `//` form still resolves the mapping. *(red on RustCFML)*

### Why it matters for Wheels
This is the **boot blocker** for a pristine Wheels app on RustCFML. The stock `wheels new` `Application.cfc` declares a `/plugins` mapping, and Wheels' boot builds the plugins path by joining `application.webPath("/") & application.pluginPath("/plugins")` = `"//plugins"`. `Plugins.cfc` then calls `cfdirectory(action="list")` on `ExpandPath("//plugins")`. On RustCFML that expands to `<docroot>/plugins` instead of the mapped target, the directory doesn't exist, `cfdirectory` throws "directory not found", `$init` aborts, and **every request 500s before the app can render**. The split `public/` webroot + `/plugins` mapping is the stock template layout, so this reproduces on any pristine Wheels app served by RustCFML.

### Verification
- **RustCFML 0.144.0** (release binary, full `tests/runner.cfm`): 1/3 — the normalization + `//`-resolves assertions fail; the single-slash control passes. Identical with `RUSTCFML_JIT=0` and `RUSTCFML_JIT_THRESHOLD=1`. Suite contributes exactly its 2 failures, no abort.
- **Lucee 5.4.8.2** (served via `box server`, Application.cfc declaring the mapping): 3/3 PASS. (Verified on a served instance rather than a CommandBox task because task contexts don't honor `this.mappings` for `expandPath`; the served run is the faithful comparison.)
- Registered in the tags block next to `test_cfdirectory_mapping_path.cfm`.
