### PR TITLE
Add cfcookie test: expires must render an RFC-1123 GMT cookie date

### DIFF
--- a/crates/cfml-vm/tests/cfcookie_expires.rs
+++ b/crates/cfml-vm/tests/cfcookie_expires.rs
@@ -1,0 +1,142 @@
+//! Regression: `<cfcookie expires=...>` must render the `Set-Cookie` header's
+//! `Expires=` as an RFC-1123 / cookie-date GMT string (Lucee parity).
+//!
+//! `cfcookie` accepts `expires` as a date, a number of days, "now", or "never".
+//! Lucee renders all of them as a proper cookie date, e.g.
+//!   Set-Cookie: deviceid=…; Expires=Tue, 14-Jul-2026 06:30:57 GMT; HttpOnly
+//! which browsers parse and persist.
+//!
+//! RustCFML currently pushes the raw value straight into the header
+//! (crates/cfml-vm/src/lib.rs `__cfcookie` → `format!("; Expires={}", expires.as_string())`),
+//! so a date renders as `Expires=2026-12-31 00:00:00` and a day count as
+//! `Expires=30`. Per RFC 6265 the cookie-date parser needs a *month name* (and
+//! GMT); a numeric/`30` value fails to parse, so the browser treats the cookie
+//! as a SESSION cookie — it is dropped on browser close. Real-world hit: a
+//! "keep me signed in for 30 days" remember-me cookie that doesn't survive a
+//! browser restart.
+//!
+//! Verified against Lucee 7: the same `cfcookie expires="<date>"` renders
+//! `Expires=Tue, 14-Jul-2026 06:30:57 GMT`.
+
+use cfml_codegen::compiler::CfmlCompiler;
+use cfml_common::dynamic::CfmlValue;
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlVirtualMachine, MemoryStore, ServerState, SessionStore};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+const APP: &str = r##"
+component {
+    this.name = "cfcookie-expires-test";
+    function onRequest(targetPage) { include "#targetPage#"; }
+}
+"##;
+
+/// Execute a CFML page and return the `Set-Cookie` header values it emitted.
+fn set_cookies(page: &str) -> Vec<String> {
+    let mut files: HashMap<String, Vec<u8>> = HashMap::new();
+    files.insert("Application.cfc".to_string(), APP.as_bytes().to_vec());
+    files.insert("index.cfm".to_string(), page.as_bytes().to_vec());
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+
+    let page_path = format!("{}/index.cfm", VROOT);
+    let source = vfs.read_to_string(&page_path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    let program = CfmlCompiler::new().compile(ast);
+
+    let mut server_state = ServerState::with_production(false);
+    server_state.sessions = Arc::new(MemoryStore::new()) as Arc<dyn SessionStore>;
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+    for scope in ["url", "cgi", "form"] {
+        vm.globals
+            .entry(scope.to_string())
+            .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    }
+    vm.server_state = Some(server_state);
+    vm.session_id = Some("sid-cookie".to_string());
+
+    let _ = vm.execute_with_lifecycle();
+
+    vm.response_headers
+        .iter()
+        .filter(|(k, _)| k.eq_ignore_ascii_case("set-cookie"))
+        .map(|(_, v)| v.clone())
+        .collect()
+}
+
+/// The `Expires=` segment of the Set-Cookie for `name`, if present.
+fn expires_of(cookies: &[String], name: &str) -> Option<String> {
+    let prefix = format!("{}=", name);
+    let line = cookies.iter().find(|c| c.starts_with(&prefix))?;
+    line.split(';')
+        .map(|s| s.trim())
+        .find_map(|seg| seg.strip_prefix("Expires=").map(|s| s.to_string()))
+}
+
+const MONTHS: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/// A browser-parseable cookie date must carry a month NAME and GMT (RFC 1123 /
+/// RFC 6265 sane-cookie-date) — not a numeric "2026-12-31" or a bare "30".
+fn is_cookie_date(v: &str) -> bool {
+    v.contains("GMT") && MONTHS.iter().any(|m| v.contains(m))
+}
+
+#[test]
+fn cfcookie_expires_date_renders_rfc1123() {
+    let cookies = set_cookies(
+        r##"<cfcookie name="c_date" value="v" expires="#createDateTime(2026, 12, 31, 1, 2, 3)#" httponly="true">"##,
+    );
+    let exp = expires_of(&cookies, "c_date")
+        .expect("c_date cookie must carry an Expires");
+    assert!(
+        is_cookie_date(&exp),
+        "a date `expires` must render as an RFC-1123 GMT cookie date, got: Expires={}",
+        exp
+    );
+}
+
+#[test]
+fn cfcookie_expires_daycount_renders_future_date() {
+    let cookies = set_cookies(r#"<cfcookie name="c_days" value="v" expires="30">"#);
+    let exp = expires_of(&cookies, "c_days")
+        .expect("c_days cookie must carry an Expires");
+    assert!(
+        is_cookie_date(&exp),
+        "a numeric `expires` (days) must render as a future RFC-1123 GMT cookie date, got: Expires={}",
+        exp
+    );
+}
+
+#[test]
+fn cfcookie_expires_never_renders_far_future_date() {
+    let cookies = set_cookies(r#"<cfcookie name="c_never" value="v" expires="never">"#);
+    let exp = expires_of(&cookies, "c_never")
+        .expect("c_never cookie must carry an Expires");
+    assert!(
+        is_cookie_date(&exp),
+        "`expires=never` must render as a far-future RFC-1123 GMT cookie date, got: Expires={}",
+        exp
+    );
+}


### PR DESCRIPTION
## What

A `cfml-vm` integration test (`crates/cfml-vm/tests/cfcookie_expires.rs`) asserting that `<cfcookie expires=...>` renders the `Set-Cookie` header's `Expires=` as an RFC-1123 / RFC-6265 cookie-date (GMT), for a date value, a numeric day-count, and `expires="never"`.

## Why

`__cfcookie` pushes the raw value straight into the header (`crates/cfml-vm/src/lib.rs`, ~line 8932):

```rust
cookie.push_str(&format!("; Expires={}", expires.as_string()));
```

So on current main (v0.149.0):

```
test cfcookie_expires_date_renders_rfc1123 ... FAILED
   got: Expires=2026-12-31 01:02:03
test cfcookie_expires_daycount_renders_future_date ... FAILED
   got: Expires=30
test cfcookie_expires_never_renders_far_future_date ... FAILED
   got: Expires=never
```

Per RFC 6265 the cookie-date parser needs a **month name** and GMT; `2026-12-31 01:02:03` (numeric month, no GMT) and `30` are unparseable, so **browsers treat the cookie as a session cookie** and drop it on browser close.

**Verified against Lucee 7** — the identical `cfcookie expires="<date>"` renders a proper cookie date:

```
Set-Cookie: deviceid=…; Path=/; Expires=Tue, 14-Jul-2026 06:30:57 GMT; HttpOnly; SameSite=Lax
```

Real-world hit: a Moopa "keep me signed in for 30 days" remember-me cookie (`<cfcookie name="deviceid" expires="#dateAdd('d',30,now())#">`) silently degrades to a session cookie on RustCFML, so users are logged out on browser restart despite checking the 30-day box.

## Coverage

- `expires` = a date value → must be an RFC-1123 GMT cookie date (not `2026-12-31 01:02:03`)
- `expires` = a numeric day-count (`"30"`) → must be a future GMT cookie date (not `30`)
- `expires` = `"never"` → must be a far-future GMT cookie date (not `never`)

The assertion is format-level (`contains "GMT"` and a 3-letter month name) so it's stable regardless of the exact rendered instant.

## Where the fix goes

`crates/cfml-vm/src/lib.rs`, the `__cfcookie` handler. Instead of `format!("; Expires={}", expires.as_string())`, interpret `expires` the way Lucee/ACF do and emit RFC-1123 GMT:
- a **date** → that instant in GMT
- a **number** → `now + N days`
- `"now"` → a past date (immediate expiry); `"never"` → a far-future date (Lucee uses ~9999 / +30y)

(The same cookie-date formatting the session-cookie path already produces would do — see `crates/cfml-common/src/session_cookie.rs`.)
