### PR TITLE
Add cfcookie test: secure/httponly must evaluate expressions

### DIFF
--- a/crates/cfml-vm/tests/cfcookie_secure_httponly_expr.rs
+++ b/crates/cfml-vm/tests/cfcookie_secure_httponly_expr.rs
@@ -1,0 +1,143 @@
+//! Regression: `<cfcookie secure="#expr#">` / `httponly="#expr#"` must EVALUATE
+//! the expression (Lucee parity), not literal-match the attribute text.
+//!
+//! Every CFML tag attribute supports `#expr#` interpolation. RustCFML's cfcookie
+//! tag parser special-cases `secure`/`httponly`: it compares the RAW attribute
+//! string to "true"/"yes" at parse time
+//! (crates/cfml-compiler/src/tag_parser.rs, the `"cfcookie"` arm), so an
+//! expression like `secure="#true#"` or `secure="#myBool#"` is seen as the
+//! literal text `#true#` → not "true"/"yes" → emitted as `false`. The flag is
+//! therefore ALWAYS dropped when set via an expression; only a literal
+//! `secure="true"` works.
+//!
+//! Real-world hit: an app that sets the Secure flag dynamically — e.g. from the
+//! request scheme / a config flag, `secure="#isHttps#"` — silently ships
+//! non-Secure cookies on RustCFML while working on Lucee.
+//!
+//! Verified against Lucee 7: `cfcookie ... secure="#expr#"` evaluates the
+//! expression and emits `; Secure` when it is true.
+
+use cfml_codegen::compiler::CfmlCompiler;
+use cfml_common::dynamic::CfmlValue;
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlVirtualMachine, MemoryStore, ServerState, SessionStore};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+const APP: &str = r##"
+component {
+    this.name = "cfcookie-secure-expr-test";
+    function onRequest(targetPage) { include "#targetPage#"; }
+}
+"##;
+
+/// Execute a CFML page and return the `Set-Cookie` header values it emitted.
+fn set_cookies(page: &str) -> Vec<String> {
+    let mut files: HashMap<String, Vec<u8>> = HashMap::new();
+    files.insert("Application.cfc".to_string(), APP.as_bytes().to_vec());
+    files.insert("index.cfm".to_string(), page.as_bytes().to_vec());
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+
+    let page_path = format!("{}/index.cfm", VROOT);
+    let source = vfs.read_to_string(&page_path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    let program = CfmlCompiler::new().compile(ast);
+
+    let mut server_state = ServerState::with_production(false);
+    server_state.sessions = Arc::new(MemoryStore::new()) as Arc<dyn SessionStore>;
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+    for scope in ["url", "cgi", "form"] {
+        vm.globals
+            .entry(scope.to_string())
+            .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    }
+    vm.server_state = Some(server_state);
+    vm.session_id = Some("sid-cookie".to_string());
+
+    let _ = vm.execute_with_lifecycle();
+
+    vm.response_headers
+        .iter()
+        .filter(|(k, _)| k.eq_ignore_ascii_case("set-cookie"))
+        .map(|(_, v)| v.clone())
+        .collect()
+}
+
+fn cookie(cookies: &[String], name: &str) -> String {
+    let prefix = format!("{}=", name);
+    cookies
+        .iter()
+        .find(|c| c.starts_with(&prefix))
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn has_attr(cookie_line: &str, attr: &str) -> bool {
+    cookie_line
+        .split(';')
+        .any(|seg| seg.trim().eq_ignore_ascii_case(attr))
+}
+
+#[test]
+fn cfcookie_secure_literal_is_emitted_control() {
+    // Control: a literal secure="true" already works today.
+    let cookies = set_cookies(r#"<cfcookie name="lit" value="v" secure="true" httponly="true">"#);
+    let c = cookie(&cookies, "lit");
+    assert!(has_attr(&c, "Secure"), "literal secure=\"true\" should emit Secure, got: {}", c);
+    assert!(has_attr(&c, "HttpOnly"), "literal httponly=\"true\" should emit HttpOnly, got: {}", c);
+}
+
+#[test]
+fn cfcookie_secure_expression_is_evaluated() {
+    let cookies = set_cookies(r##"<cfcookie name="exp" value="v" secure="#(1 EQ 1)#">"##);
+    let c = cookie(&cookies, "exp");
+    assert!(
+        has_attr(&c, "Secure"),
+        "secure=\"#(1 EQ 1)#\" must evaluate to true and emit Secure, got: {}",
+        c
+    );
+}
+
+#[test]
+fn cfcookie_httponly_expression_is_evaluated() {
+    let cookies = set_cookies(r##"<cfcookie name="exph" value="v" httponly="#(1 EQ 1)#">"##);
+    let c = cookie(&cookies, "exph");
+    assert!(
+        has_attr(&c, "HttpOnly"),
+        "httponly=\"#(1 EQ 1)#\" must evaluate to true and emit HttpOnly, got: {}",
+        c
+    );
+}
+
+#[test]
+fn cfcookie_secure_variable_expression_is_evaluated() {
+    let cookies = set_cookies(
+        r##"<cfset isSecure = true><cfcookie name="var" value="v" secure="#isSecure#">"##,
+    );
+    let c = cookie(&cookies, "var");
+    assert!(
+        has_attr(&c, "Secure"),
+        "secure=\"#isSecure#\" (a boolean var) must emit Secure, got: {}",
+        c
+    );
+}


### PR DESCRIPTION
## What

A `cfml-vm` integration test (`crates/cfml-vm/tests/cfcookie_secure_httponly_expr.rs`) asserting that `<cfcookie secure="#expr#">` and `httponly="#expr#"` **evaluate** the expression, rather than literal-matching the attribute text at parse time.

## Why — this completes earlier tag-attribute interpolation work

Prior PRs established that `#expr#` must be interpolated in tag attributes, by routing the value through the `format_attr_value()` helper: #62 (tag attribute interpolation), #59 (tag string interpolation), #44 (cflog), #45 (cfhttp), #46 (cfhttpparam), #72 (cflog/cfmail), #74 (cfhttp timeout). Those all covered **string** attributes.

**Boolean attributes were never wired into that path.** In `crates/cfml-compiler/src/tag_parser.rs`, boolean attributes are resolved by comparing the *raw* attribute text to `"true"/"yes"` at parse time:

```rust
// the "cfcookie" arm — but the same pattern repeats across tags
if k == "secure" || k == "httponly" {
    let lower = v.to_lowercase();              // v = the RAW attribute text
    if lower == "true" || lower == "yes" { parts.push(format!("{}: true", k)); }
    else { parts.push(format!("{}: false", k)); }
}
```

So `secure="#true#"` / `secure="#isHttps#"` is read as the literal text `#…#` → not `"true"/"yes"` → emitted as `false`. The expression is never evaluated; the flag is silently dropped. Only a bare literal `secure="true"` works. (The string attributes in the same arm — `value`, `path`, `expires` — correctly go through `format_attr_value`, per the earlier fixes.)

On current main (v0.149.0):

```
test cfcookie_secure_literal_is_emitted_control ... ok
test cfcookie_secure_expression_is_evaluated ... FAILED          got: exp=v
test cfcookie_httponly_expression_is_evaluated ... FAILED        got: exph=v
test cfcookie_secure_variable_expression_is_evaluated ... FAILED got: var=v
```

**Verified against Lucee 7** — `cfcookie ... secure="#expr#"` evaluates the expression and emits the flag:

```
Set-Cookie: DEVICEID=…; Path=/; Expires=Tue, 14-Jul-2026 07:10:32 GMT; Secure; HttpOnly; SameSite=Lax
```

Real-world hit: an app setting Secure dynamically (`secure="#isHttps#"`, derived from the request scheme / a `BASE_URL` config flag) silently ships **non-Secure** cookies on RustCFML while working on Lucee.

## This is systemic — not just cfcookie

The same raw-text `lower == "true" || lower == "yes"` boolean handling appears in **~8 tag arms**, so an `#expr#` value is dropped for boolean attributes on all of them:

| tag | boolean attribute(s) |
|---|---|
| `cfcookie` | `secure`, `httponly` (this test) |
| `cfcontent` | `reset` |
| `cflocation` | `addtoken` |
| `cfdirectory` | e.g. `recurse` |
| `cfzip` | e.g. `overwrite` / `recurse` |
| `cfprocessingdirective` | `suppresswhitespace` |
| `cfsetting` | its boolean flags |
| `cflock` | its boolean attr |

The test covers cfcookie because its effect (`Set-Cookie`) is the cleanly observable one, but the fix should be applied to all of these.

## Where the fix goes

`crates/cfml-compiler/src/tag_parser.rs` — the boolean-attribute handling across those arms. Mirror what the string-attribute fixes did: send the value through interpolation and **coerce the evaluated result to boolean**, treating only a bare literal (`true/false/yes/no`) as a compile-time constant. `__cfcookie` (and the other handlers) already accept a truthy runtime value, so this is a parse/codegen change. Ideally factored into one shared boolean-attr helper so all the arms above are fixed together.
