### PR TITLE
test(tags): cfinvoke argumentCollection forwards positional (numeric-keyed) args

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -404,6 +404,16 @@ try { include "core/test_component_soft_keyword.cfm"; } catch (any e) { writeOut
 //     also accepts the ACF-style cf-prefixed `cfinvoke` spelling, but Lucee
 //     rejects it, so the cross-engine test uses the cf-less `invoke`.)
 try { include "tags/test_cfinvoke_statement.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfinvoke_statement.cfm | " & e.message & chr(10)); }
+//   - cfinvoke_argumentcollection_positional: cfinvoke's argumentCollection is
+//     a full argument collection — NUMERIC string keys forward as POSITIONAL
+//     args (named keys as named), like fn(argumentCollection=st) / invoke().
+//     RustCFML forwards named keys but DROPS numeric-keyed (positional)
+//     entries. Wheels' Global.cfc $invoke() rebuilds the dynamic call's
+//     positional args as a numeric-keyed argumentCollection, so onMissingMethod
+//     association methods (post.createComment(struct), dependent=delete's
+//     deleteAll<Assoc>()) lose their positional arg — the FK (named) survives,
+//     the attributes struct (positional) is dropped. Runtime gap, runner-safe.
+try { include "tags/test_cfinvoke_argumentcollection_positional.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfinvoke_argumentcollection_positional.cfm | " & e.message & chr(10)); }
 //   - cfinvoke_call_form_marshaling: the cf-PREFIXED parenthesized CALL form
 //     cfinvoke(...) — the spelling Lucee accepts and Wheels' Global.cfc
 //     $invoke() uses — must marshal attributeCollection, deliver

--- a/tests/tags/CfInvokeArgCollPosFixture.cfc
+++ b/tests/tags/CfInvokeArgCollPosFixture.cfc
@@ -1,0 +1,10 @@
+// Fixture for cfinvoke argumentCollection positional/numeric-key forwarding.
+// take() has a positional first param + a named param; the test confirms a
+// numeric-keyed argumentCollection entry arrives as the positional arg.
+component {
+	public string function take(any a, string named = "DEF") {
+		var aDesc = isStruct(arguments.a) ? ("struct:" & (arguments.a.body ?: "?"))
+			: (isNull(arguments.a) ? "(null)" : toString(arguments.a));
+		return "a=" & aDesc & "|named=" & arguments.named;
+	}
+}

--- a/tests/tags/test_cfinvoke_argumentcollection_positional.cfm
+++ b/tests/tags/test_cfinvoke_argumentcollection_positional.cfm
@@ -1,0 +1,54 @@
+<cfscript>
+suiteBegin("Tags: cfinvoke argumentCollection forwards positional (numeric-keyed) args");
+
+// ============================================================
+// Background
+// ============================================================
+// cfinvoke's argumentCollection is a full argument collection, exactly like
+// fn(argumentCollection=st) and the invoke() BIF: NUMERIC string keys ("1",
+// "2", ...) are forwarded as POSITIONAL arguments and named keys as named
+// arguments. Lucee, Adobe CF, and BoxLang all honor numeric keys positionally.
+//
+// RustCFML 0.153.0 forwards the NAMED keys but silently DROPS the numeric/
+// positional keys — the callee's positional param keeps its default:
+//
+//   function take(any a, string named="DEF") {...}
+//   cfinvoke(component=o, method="take", returnVariable="r",
+//            argumentCollection = { 1: {body:"POS"}, named: "N" });
+//     Lucee 5.4.8.2    -> r = "a=struct:POS|named=N"  (positional 1 -> a)
+//     RustCFML 0.153.0 -> r = "a=|named=N"            (positional 1 DROPPED)
+//
+// Why it matters for Wheels: Global.cfc $invoke() ends in
+//   cfinvoke(attributeCollection="#local.args#")
+// where local.args.argumentCollection is rebuilt from the dynamic call's
+// positional args as a numeric-keyed struct (Global.cfc ~289-305). It is the
+// dispatch path behind onMissingMethod, so association create/new dynamic
+// methods (post.createComment(struct), post.deleteAllComments() for
+// dependent=delete) lose their positional argument: the foreign key (a named
+// key) survives but the attributes struct (positional) is dropped, so
+// validatesPresenceOf fails and dependent-cascade deletes never receive their
+// args. Surfaced laddering hasMany/belongsTo associations on the blog app.
+// ============================================================
+
+cfiacObj = createObject("component", "CfInvokeArgCollPosFixture");
+
+// --- the gap: a numeric-keyed argumentCollection entry must arrive positionally ---
+cfinvoke(component = cfiacObj, method = "take", returnVariable = "local.cfiacR1",
+	argumentCollection = { 1: {body: "POS"}, named: "N" });
+assert("numeric-keyed argumentCollection entry forwards as the positional arg",
+	local.cfiacR1, "a=struct:POS|named=N");
+
+// --- the Wheels shape: positional struct arg + a named foreign-key-style arg ---
+cfinvoke(component = cfiacObj, method = "take", returnVariable = "local.cfiacR2",
+	argumentCollection = { 1: {body: "hello"}, named: "fk" });
+assert("positional struct survives alongside a named key (Wheels $invoke shape)",
+	local.cfiacR2, "a=struct:hello|named=fk");
+
+// --- CONTROL (green on both engines): all-named argumentCollection ---
+cfinvoke(component = cfiacObj, method = "take", returnVariable = "local.cfiacR3",
+	argumentCollection = { a: {body: "NAMED"}, named: "X" });
+assert("CONTROL: all-named argumentCollection forwards correctly",
+	local.cfiacR3, "a=struct:NAMED|named=X");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Gap: `cfinvoke` argumentCollection drops positional (numeric-keyed) args

`cfinvoke`'s `argumentCollection` is a full argument collection, exactly like `fn(argumentCollection=st)` and the `invoke()` BIF: NUMERIC string keys (`"1"`, `"2"`, …) forward as **positional** arguments, named keys as named arguments. Lucee, Adobe CF, and BoxLang all honor numeric keys positionally. RustCFML 0.153.0 forwards the named keys but silently **drops** the numeric/positional keys — the callee's positional param keeps its default:

```cfml
function take(any a, string named = "DEF") {
    return "a=" & (isStruct(a) ? "struct:" & a.body : toString(a)) & "|named=" & named;
}
cfinvoke(component=o, method="take", returnVariable="r",
         argumentCollection = { 1: {body:"POS"}, named: "N" });
```

| engine | `r` |
|--------|-----|
| RustCFML 0.153.0 | `"a=\|named=N"` — positional `1` dropped (param keeps default) |
| Lucee 5.4.8.2 | `"a=struct:POS\|named=N"` — positional `1` → `a` |

All-named `argumentCollection` already forwards correctly on both engines (asserted as the control).

### What the test asserts
- A numeric-keyed `argumentCollection` entry arrives as the positional arg. *(red on RustCFML)*
- The positional struct survives alongside a named key — the Wheels `$invoke` shape. *(red on RustCFML)*
- CONTROL (green on both engines): all-named `argumentCollection` forwards correctly.

### Why it matters for Wheels
`Global.cfc::$invoke()` ends in `cfinvoke(attributeCollection="#local.args#")`, where `local.args.argumentCollection` is rebuilt from a dynamic call's positional args as a **numeric-keyed** struct (Global.cfc ~289–305). This is the dispatch path behind `onMissingMethod`, so association dynamic methods lose their positional argument: `post.createComment(commentStruct)` injects the foreign key as a *named* key (survives) but passes the attributes as a *positional* struct (dropped), so `validatesPresenceOf` fails; and `dependent="delete"` cascade (`deleteAll<Assoc>()`) never receives its args. Surfaced laddering hasMany/belongsTo associations on the blog tutorial app — the blog CRUD itself works, this is the association-create / dependent-delete layer.

### Verification
- **RustCFML 0.153.0** (release binary, full `tests/runner.cfm`): 1/3 — the two positional-forwarding assertions fail with `a=(null)`; the all-named control passes. Suite contributes exactly its 2 failures, no abort (runtime gap). Full runner 3863/3865 across 468 suites.
- **Lucee 5.4.8.2** (CommandBox): 3/3 PASS.
- Registered in the tags block after `test_cfinvoke_statement.cfm`.
