### PR TITLE
test(types): bare query-column access returns a native-typed (numeric) scalar

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -111,6 +111,15 @@ try { include "types/test_ordered_struct_literals.cfm"; } catch (any e) { writeO
 try { include "types/test_nested_writeback.cfm"; } catch (any e) { writeOutput("ERROR | types/test_nested_writeback.cfm | " & e.message & chr(10)); }
 try { include "types/test_query.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query.cfm | " & e.message & chr(10)); }
 try { include "types/test_query_column.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_column.cfm | " & e.message & chr(10)); }
+//   - query_bare_column_scalar_type: bare query-column access (q.col / q["col"]
+//     without a row index) returns the current-row value as a native-typed
+//     simple value — a numeric column IsNumeric and does arithmetic. RustCFML
+//     returns the right string but non-numeric-typed (IsNumeric false, q.n+1
+//     concatenates to "51"); the row-indexed form q.col[1] IS numeric. Breaks
+//     Wheels model.count()/sum()/avg()/min()/max() ($calculate reads the
+//     aggregate bare, count() zeroes it via an IsNumeric guard → paginated
+//     indexes return zero rows). Runtime gap, runner-safe.
+try { include "types/test_query_bare_column_scalar_type.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_bare_column_scalar_type.cfm | " & e.message & chr(10)); }
 try { include "types/test_query_reference.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_reference.cfm | " & e.message & chr(10)); }
 try { include "types/test_binary.cfm"; } catch (any e) { writeOutput("ERROR | types/test_binary.cfm | " & e.message & chr(10)); }
 try { include "types/test_hash_in_strings.cfm"; } catch (any e) { writeOutput("ERROR | types/test_hash_in_strings.cfm | " & e.message & chr(10)); }

--- a/tests/types/test_query_bare_column_scalar_type.cfm
+++ b/tests/types/test_query_bare_column_scalar_type.cfm
@@ -1,0 +1,46 @@
+<cfscript>
+suiteBegin("Types: bare query-column access returns a native-typed scalar (numeric preserved)");
+
+// ============================================================
+// Background
+// ============================================================
+// Accessing a query column WITHOUT a row index (q.col / q["col"]) returns the
+// value at the CURRENT row (row 1 outside a cfloop) as a native simple value
+// carrying the column's type. On Lucee/Adobe CF/BoxLang a numeric column read
+// this way IsNumeric() and participates in arithmetic. The row-INDEXED form
+// (q.col[1]) is equivalent.
+//
+// RustCFML 0.153.0 returns the right string for bare access (q.n stringifies
+// to "5") but it is NOT numeric-typed: IsNumeric(q.n) is false and q.n + 1
+// concatenates ("51") instead of adding (6). The row-indexed form q.n[1] IS
+// numeric on RustCFML, so the gap is specifically the BARE (current-row
+// scalar) access losing the native numeric type. Holds for queryNew, QoQ
+// (queryExecute and cfquery), and datasource queries alike.
+//
+// Why it matters for Wheels: model.count() / sum() / average() / minimum() /
+// maximum() all end in vendor/wheels/model/calculations.cfc::$calculate with
+//   local.rv = local.rv[local.alias];   // BARE scalar read of the aggregate
+// and count() then guards `if (!IsNumeric(local.rv)) local.rv = 0;`. On
+// RustCFML the bare aggregate is non-numeric, so the guard forces every count
+// to 0 — which makes findAll(page=,perPage=) compute zero total pages and
+// return NO rows, breaking every paginated index. Surfaced laddering pagination.
+// ============================================================
+
+qbcQ = queryNew("n,label", "integer,varchar", [{n: 5, label: "x"}, {n: 9, label: "y"}]);
+
+// --- the gap: bare column access is numeric-typed ---
+assertTrue("bare q.col on an integer column IsNumeric", isNumeric(qbcQ.n));
+assert("bare q.col participates in arithmetic (not string concat)", qbcQ.n + 1, 6);
+assertTrue("bare q['col'] on an integer column IsNumeric", isNumeric(qbcQ["n"]));
+
+// --- a QoQ COUNT aggregate read bare (the exact Wheels $calculate shape) ---
+qbcC = queryExecute("SELECT COUNT(*) AS cnt FROM qbcQ", {}, {dbtype: "query"});
+assertTrue("bare aggregate (COUNT) read IsNumeric", isNumeric(qbcC.cnt));
+assert("bare COUNT participates in arithmetic", qbcC.cnt + 0, 2);
+
+// --- CONTROL (green on both engines): the row-indexed form is numeric ---
+assertTrue("CONTROL: row-indexed q.col[1] IsNumeric", isNumeric(qbcQ.n[1]));
+assert("CONTROL: row-indexed arithmetic", qbcQ.n[1] + 1, 6);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Gap: bare query-column access (`q.col`) loses the cell's native numeric type

Accessing a query column **without a row index** (`q.col` / `q["col"]`) returns the value at the current row (row 1 outside a `cfloop`) as a native simple value carrying the column's type. On Lucee/Adobe CF/BoxLang a numeric column read this way is `IsNumeric()` and participates in arithmetic; the row-indexed form `q.col[1]` is equivalent.

RustCFML 0.153.0 returns the right *string* for bare access but it is **not numeric-typed**:

```cfml
q = queryNew("n", "integer", [{n: 5}]);
q.n            // "5" (displays fine)
isNumeric(q.n) // RustCFML: false   | Lucee: true
q.n + 1        // RustCFML: "51"     | Lucee: 6
q.n[1]         // row-indexed: numeric on BOTH (the control)
```

| access | RustCFML 0.153.0 | Lucee 5.4.8.2 |
|--------|------------------|---------------|
| `isNumeric(q.n)` (bare) | **false** | true |
| `q.n + 1` (bare) | **"51"** (concat) | 6 |
| `isNumeric(q.n[1])` (indexed) | true | true |

Holds across query sources — `queryNew`, QoQ (`queryExecute` and `cfquery`), and datasource queries. The divergence is specifically the **bare (current-row scalar)** access dropping the native numeric type; the row-indexed form is correct.

### What the test asserts
- Bare `q.col` / `q["col"]` on an integer column `IsNumeric` and does arithmetic (`q.n + 1 == 6`). *(red on RustCFML)*
- A bare COUNT aggregate read `IsNumeric` and does arithmetic — the exact Wheels `$calculate` shape. *(red on RustCFML)*
- CONTROL (green on both engines): the row-indexed `q.col[1]` is numeric and does arithmetic.

### Why it matters for Wheels
`model.count()` / `sum()` / `average()` / `minimum()` / `maximum()` all end in `vendor/wheels/model/calculations.cfc::$calculate` with `local.rv = local.rv[local.alias];` — a **bare** scalar read of the aggregate column — and `count()` then guards `if (!IsNumeric(local.rv)) local.rv = 0;`. On RustCFML the bare aggregate is non-numeric, so the guard forces every count to **0**, which makes `findAll(page=, perPage=)` compute zero total pages and return **no rows** — breaking every paginated index. (Display/CRUD are unaffected because the value stringifies correctly; only `IsNumeric`/arithmetic break.) Surfaced laddering pagination on the blog tutorial app.

### Verification
- **RustCFML 0.153.0** (release binary, full `tests/runner.cfm`): 2/7 — the five bare-access assertions fail (`IsNumeric` false, `q.n+1`→"51", `COUNT+0`→"20"); the two row-indexed controls pass. Identical with `RUSTCFML_JIT=0` / `RUSTCFML_JIT_THRESHOLD=1`. Full runner 3905/3910, no abort.
- **Lucee 5.4.8.2** (CommandBox): 7/7 PASS.
- Registered in the types block after `test_query_column.cfm`.
