### PR TITLE
test(types): IsNumeric() must return false for a boolean

### DIFF
--- a/tests/core/test_isnumeric_boolean.cfm
+++ b/tests/core/test_isnumeric_boolean.cfm
@@ -1,0 +1,28 @@
+<cfscript>
+suiteBegin("IsNumeric: boolean is not numeric");
+
+// Background: A CFML boolean is NOT a numeric value. On Lucee, Adobe CF, and
+// BoxLang, IsNumeric(true) and IsNumeric(false) both return false — only an
+// actual number (or a numeric string) is numeric. RustCFML 0.153.0 reports a
+// boolean as numeric (IsNumeric(true)=true, IsNumeric(false)=true), which
+// silently flips any "is this argument a number?" guard that defaults to a
+// boolean. Wheels relies on exactly such a guard: the finder parameterize
+// flag (default boolean `true`) is checked with IsNumeric(arguments.parameterize)
+// in vendor/wheels/model/sql.cfc, so the divergence breaks multi-condition and
+// subquery finders on RustCFML.
+
+// --- Boolean literals are not numeric ---
+assertFalse("isNumeric(true) is false", isNumeric(true));
+assertFalse("isNumeric(false) is false", isNumeric(false));
+
+// --- Boolean-typed variable is not numeric ---
+isnumboolB = true;
+assertFalse("isNumeric(boolean var) is false", isNumeric(isnumboolB));
+
+// --- Controls: agree on both engines ---
+assertTrue("isNumeric(1) is true", isNumeric(1));
+assertTrue("isNumeric('123') is true", isNumeric("123"));
+assertFalse("isNumeric('abc') is false", isNumeric("abc"));
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -96,6 +96,7 @@ try { include "core/test_pagecontext_request_response.cfm"; } catch (any e) { wr
 try { include "core/test_localmode.cfm"; } catch (any e) { writeOutput("ERROR | core/test_localmode.cfm | " & e.message & chr(10)); }
 try { include "core/test_error_context.cfm"; } catch (any e) { writeOutput("ERROR | core/test_error_context.cfm | " & e.message & chr(10)); }
 try { include "core/test_null_coalescing.cfm"; } catch (any e) { writeOutput("ERROR | core/test_null_coalescing.cfm | " & e.message & chr(10)); }
+try { include "core/test_isnumeric_boolean.cfm"; } catch (any e) { writeOutput("ERROR | core/test_isnumeric_boolean.cfm | " & e.message & chr(10)); }
 
 // --- Data Types ---
 try { include "types/test_null.cfm"; } catch (any e) { writeOutput("ERROR | types/test_null.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

A CFML boolean is not a numeric value. On Lucee, Adobe CF, and BoxLang, `IsNumeric(true)` and `IsNumeric(false)` both return `false` — only an actual number or a numeric string is numeric. RustCFML 0.153.0 reports a boolean as numeric.

```cfm
isNumeric(true)   // RustCFML: true   | Lucee/Adobe/BoxLang: false
isNumeric(false)  // RustCFML: true   | Lucee/Adobe/BoxLang: false
isNumeric(1)      // both: true   (control)
isNumeric("abc")  // both: false  (control)
```

| Expression | RustCFML 0.153.0 | Lucee 5.4.8.2 | Adobe/BoxLang |
|---|---|---|---|
| `isNumeric(true)` | `true` | `false` | `false` |
| `isNumeric(false)` | `true` | `false` | `false` |
| `isNumeric(1)` | `true` | `true` | `true` |
| `isNumeric("abc")` | `false` | `false` | `false` |

## What the test asserts

`tests/core/test_isnumeric_boolean.cfm`:
- `isNumeric(true)` is false, `isNumeric(false)` is false (literal booleans).
- `isNumeric(b)` is false for a boolean-typed variable `b = true`.
- Controls that agree on both engines: `isNumeric(1)` true, `isNumeric("123")` true, `isNumeric("abc")` false — so a failure pinpoints boolean coercion, not a broader `IsNumeric` regression.

## Why it matters for Wheels

Wheels guards the finder `parameterize` flag with `IsNumeric(arguments.parameterize)` in `vendor/wheels/model/sql.cfc` (also referenced in `read.cfc`). `parameterize` defaults to the boolean `true`. On a correct engine `IsNumeric(true)` is `false`, so the guard takes the intended branch. On RustCFML `IsNumeric(true)=true` flips that branch, and every `findAll(where=...)` whose WHERE string carries other-than-one bind value (two-plus literals in a multi-condition finder, or zero for a subquery-only WHERE on a calculated property) throws `Wheels.ParameterMismatch`. This breaks multi-condition finders and calculated-property subquery finders — a high-traffic path in any Wheels app.

## Verification

- RustCFML 0.153.0 (`/tmp/rustcfml-test/rustcfml-0.153.0`): RED, 3/6 passed (the three boolean assertions fail: `got: [true]`). Identical under default JIT, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`.
- Lucee 5.4.8.2 (CommandBox 6.3.2): GREEN, 6/6 passed.
- Full `tests/runner.cfm` on this branch (RustCFML 0.153.0): **3906/3909 across 469 suites** — the only 3 failures are this suite's boolean assertions; no abort.