### PR TITLE
test(oop): onMissingMethod must preserve named-argument NAMES in missingMethodArguments

### DIFF
--- a/tests/core/OnMissingMethodNamedKeysFixture.cfc
+++ b/tests/core/OnMissingMethodNamedKeysFixture.cfc
@@ -1,0 +1,49 @@
+// Fixture for the onMissingMethod named-argument-key test.
+//
+// onMissingMethod receives the call's arguments in `missingMethodArguments`.
+// For a NAMED-argument call (obj.probe(label="world")) the engines key that
+// struct by the argument NAMES; for a POSITIONAL call (obj.probe("x")) they
+// key it by numeric position ("1", "2", ...). RustCFML 0.153.0 keys the
+// named-call struct by numeric position too, losing the names — so a handler
+// that reads missingMethodArguments.label sees nothing.
+//
+// Each probe reports the shape of missingMethodArguments back to the caller
+// without depending on key ORDER (Lucee uppercases/reorders struct keys, so
+// any order-sensitive assertion would false-fail on a conforming engine).
+component {
+
+	// The component declares NO `probe`/`byStatus`/etc. method, so every call
+	// to one of those falls through to onMissingMethod.
+	public any function onMissingMethod(
+		required string missingMethodName,
+		required struct missingMethodArguments
+	) {
+		var mma = arguments.missingMethodArguments;
+		return {
+			// Sorted key list so the caller can do presence checks via
+			// listFindNoCase without caring about engine key order.
+			keyList   = structKeyList(mma),
+			count     = structCount(mma),
+			// Direct by-NAME reads — these are what a real handler does
+			// (arguments.status, arguments.label, ...).
+			hasLabel  = structKeyExists(mma, "label"),
+			labelVal  = structKeyExists(mma, "label") ? mma.label : "(absent)",
+			hasExtra  = structKeyExists(mma, "extra"),
+			extraVal  = structKeyExists(mma, "extra") ? mma.extra : "(absent)",
+			hasStatus = structKeyExists(mma, "status"),
+			statusVal = structKeyExists(mma, "status") ? mma.status : "(absent)",
+			// Control: numeric key presence (the positional shape).
+			has1      = structKeyExists(mma, "1"),
+			val1      = structKeyExists(mma, "1") ? mma["1"] : "(absent)"
+		};
+	}
+
+	// Mirrors the Wheels dynamic-scope handler shape: a scope registered as
+	// scope(name="byStatus", handler="scopeByStatus") is dispatched as
+	// model("Post").byStatus(status="published"), arriving here as a missing
+	// method whose handler reads arguments.status BY NAME.
+	public any function scopeByStatus(required string status) {
+		return "where=status='" & arguments.status & "'";
+	}
+
+}

--- a/tests/core/test_onmissingmethod_named_keys.cfm
+++ b/tests/core/test_onmissingmethod_named_keys.cfm
@@ -1,0 +1,107 @@
+<cfscript>
+suiteBegin("OOP: onMissingMethod preserves named-argument NAMES in missingMethodArguments");
+
+// ============================================================
+// Background
+// ============================================================
+// When a method call falls through to onMissingMethod, the engine hands the
+// call's arguments to the handler as `missingMethodArguments`. The KEYS of
+// that struct depend on HOW the method was called:
+//
+//   * NAMED call    obj.probe(label="world")  -> keyed by NAME   ("label")
+//   * POSITIONAL    obj.probe("world")        -> keyed by POSITION ("1")
+//
+// Lucee 5/6/7 and Adobe ColdFusion honor this for both shapes. RustCFML
+// 0.153.0 keys the NAMED-call struct by numeric position as well, dropping
+// the argument names entirely:
+//
+//   component {
+//     function onMissingMethod(missingMethodName, missingMethodArguments){
+//       return structKeyList(missingMethodArguments);
+//     }
+//   }
+//   obj.probe(label = "world")
+//     Lucee 5.4.8.2    -> "label"
+//     RustCFML 0.153.0 -> "1"          (name lost; structKeyExists(...,"label") false)
+//
+//   obj.probe(label = "a", extra = "b")
+//     Lucee 5.4.8.2    -> "label,extra"
+//     RustCFML 0.153.0 -> "1,2"
+//
+// The POSITIONAL call is correct on BOTH engines (numeric keys), so it serves
+// as the CONTROL that guards the wiring.
+//
+// SIBLINGS (no assertion overlap): this is NOT
+//   - #126 cfinvoke argumentCollection positional binding,
+//   - #95  invoke() dropping undeclared argument-struct keys, nor
+//   - #82  named-arg numeric-alias leak on a DECLARED-param call.
+// Those concern the invoke()/cfinvoke marshaling path and declared-param
+// frames. THIS gap is specifically onMissingMethod failing to preserve the
+// NAMES of named arguments in the missingMethodArguments struct.
+//
+// WHEELS IMPACT: Wheels' dynamic query scopes — the CLAUDE.md pattern
+//   scope(name="byStatus", handler="scopeByStatus")
+//   model("Post").byStatus(status="published")
+// dispatch the named call through onMissingMethod; the handler reads the
+// option BY NAME (arguments.status). On RustCFML the struct arrives as
+// {1="published"}, so arguments.status is undefined and the scope's WHERE
+// clause is empty -> the query returns the wrong rows (0, or all). Surfaced
+// laddering named query scopes.
+//
+// Assertions key on PRESENCE / VALUE, never on key ORDER: Lucee uppercases
+// and reorders struct keys, so any order-sensitive assert would false-fail on
+// a conforming engine.
+// ============================================================
+
+ommnk_fixture = createObject("component", "OnMissingMethodNamedKeysFixture");
+
+// ---- (1) single NAMED arg: the NAME key must be present ----
+ommnk_one = ommnk_fixture.probe(label = "world");
+
+assertTrue("single named arg: 'label' key present in missingMethodArguments",
+	ommnk_one.hasLabel);
+assert("single named arg: missingMethodArguments.label == 'world'",
+	ommnk_one.labelVal, "world");
+assertTrue("single named arg: StructKeyList contains 'label'",
+	listFindNoCase(ommnk_one.keyList, "label") gt 0);
+// The name must not have been replaced by a numeric position key.
+assertFalse("single named arg: no numeric key '1' substituted for the name",
+	ommnk_one.has1);
+
+// ---- (2) two NAMED args: BOTH names must be present ----
+ommnk_two = ommnk_fixture.probe(label = "a", extra = "b");
+
+assertTrue("two named args: 'label' present", ommnk_two.hasLabel);
+assertTrue("two named args: 'extra' present", ommnk_two.hasExtra);
+assert("two named args: label value", ommnk_two.labelVal, "a");
+assert("two named args: extra value", ommnk_two.extraVal, "b");
+assert("two named args: StructCount == 2", ommnk_two.count, 2);
+assertTrue("two named args: StructKeyList contains 'label'",
+	listFindNoCase(ommnk_two.keyList, "label") gt 0);
+assertTrue("two named args: StructKeyList contains 'extra'",
+	listFindNoCase(ommnk_two.keyList, "extra") gt 0);
+
+// ---- (3) WHEELS-shaped dynamic scope: named 'status' read BY NAME ----
+// The on-disk Wheels pattern: model("Post").byStatus(status="published").
+ommnk_scope = ommnk_fixture.byStatus(status = "published");
+
+assertTrue("dynamic scope: 'status' present by name in missingMethodArguments",
+	ommnk_scope.hasStatus);
+assert("dynamic scope: missingMethodArguments.status == 'published'",
+	ommnk_scope.statusVal, "published");
+
+// ---- CONTROL: POSITIONAL call uses numeric keys on BOTH engines ----
+// Guards the wiring so a regression in the named-arg path can't masquerade as
+// the gap under test.
+ommnk_pos = ommnk_fixture.probe("world");
+
+assertTrue("CONTROL: positional call -> numeric key '1' present",
+	ommnk_pos.has1);
+assert("CONTROL: positional call -> missingMethodArguments['1'] == 'world'",
+	ommnk_pos.val1, "world");
+// A positional call carries no name, so 'label' must be ABSENT on both.
+assertFalse("CONTROL: positional call has no 'label' key",
+	ommnk_pos.hasLabel);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -495,6 +495,18 @@ try { include "core/test_named_args_no_numeric_alias.cfm"; } catch (any e) { wri
 //     setting as an empty value and the ORM introspected the wrong (default
 //     in-memory) database.
 try { include "core/test_named_args_array_view.cfm"; } catch (any e) { writeOutput("ERROR | core/test_named_args_array_view.cfm | " & e.message & chr(10)); }
+//   - onmissingmethod_named_keys: when a call falls through to onMissingMethod,
+//     the missingMethodArguments struct must key NAMED args by their NAMES
+//     (obj.probe(label="x") -> "label"), not by numeric position. RustCFML
+//     0.153.0 keys the named-call struct by position ("1","2"), dropping the
+//     names, so a handler that reads missingMethodArguments.status sees
+//     nothing. Positional calls correctly use numeric keys on both engines
+//     (CONTROL). Distinct from invoke()/cfinvoke marshaling (#95, #126) and
+//     the declared-param numeric-alias leak (#82). Surfaced laddering Wheels'
+//     dynamic query scopes scope(name=,handler=) — model("Post").byStatus(
+//     status="published") delivers {1="published"}, so arguments.status is
+//     undefined and the scope's WHERE clause is empty.
+try { include "core/test_onmissingmethod_named_keys.cfm"; } catch (any e) { writeOutput("ERROR | core/test_onmissingmethod_named_keys.cfm | " & e.message & chr(10)); }
 //   - param_dotted_lhs: the cfscript `param` shorthand must accept a dotted /
 //     scoped lvalue (`param arguments.obj.key = default`), not just a bare
 //     identifier. Surfaced while booting WireBox (Injector.cfc uses


### PR DESCRIPTION
## Gap

When a method call falls through to `onMissingMethod`, the engine hands the call's arguments to the handler as `missingMethodArguments`. The KEYS of that struct depend on how the method was called:

- **NAMED** call `obj.probe(label="world")` → keyed by NAME (`"label"`)
- **POSITIONAL** call `obj.probe("world")` → keyed by POSITION (`"1"`)

Lucee 5/6/7 and Adobe ColdFusion honor both shapes. RustCFML 0.153.0 keys the NAMED-call struct by numeric position as well, dropping the argument names entirely.

```cfm
component {
  function onMissingMethod(missingMethodName, missingMethodArguments){
    return structKeyList(missingMethodArguments);
  }
}
obj.probe(label = "world")          // Lucee: "label"      | RustCFML 0.153.0: "1"
obj.probe(label = "a", extra = "b") // Lucee: "label,extra" | RustCFML 0.153.0: "1,2"
```

A positional call (`obj.probe("world")`) is correct on both engines — that's the CONTROL.

| Call shape | Lucee 5.4.8.2 | RustCFML 0.153.0 |
|---|---|---|
| `probe(label="world")` | `structKeyList` = `label`; `mma.label` = `world` | `structKeyList` = `1`; `mma.label` undefined |
| `probe(label="a", extra="b")` | keys `label,extra` | keys `1,2` |
| `byStatus(status="published")` | `mma.status` = `published` | `mma.status` undefined |
| `probe("world")` (positional CONTROL) | key `1` = `world` | key `1` = `world` |

## What the test asserts

- Single named arg → the NAME key (`label`) is present, its value round-trips, and no numeric `1` key is substituted for the name.
- Two named args → BOTH names (`label`, `extra`) are present with correct values; `StructCount == 2`.
- A Wheels-shaped dynamic scope `byStatus(status="published")` → `missingMethodArguments.status` is readable BY NAME.
- CONTROL: a positional call still uses numeric keys (`1`) on both engines and carries no `label` name — guards the wiring so a named-arg regression can't masquerade as this gap.

Assertions key on PRESENCE/VALUE, never key order (Lucee uppercases and reorders struct keys).

## Why it matters for Wheels

Wheels' dynamic query scopes use the documented pattern:

```cfm
scope(name="byStatus", handler="scopeByStatus");
model("Post").byStatus(status="published");
```

That named call dispatches through `onMissingMethod`, and the handler reads the option BY NAME (`arguments.status`). On RustCFML the struct arrives as `{1="published"}`, so `arguments.status` is undefined and the scope's `WHERE` clause is built empty — the query returns the wrong rows (0, or all). Surfaced laddering named query scopes.

## Siblings (no assertion overlap)

This is distinct from:
- **#126** — `cfinvoke argumentCollection` positional binding
- **#95** — `invoke()` dropping undeclared argument-struct keys
- **#82** — named-arg numeric-alias leak on a DECLARED-param call

Those concern the `invoke()`/`cfinvoke` marshaling path and declared-param frames. This gap is specifically `onMissingMethod` failing to preserve the NAMES of named arguments in `missingMethodArguments`.

## Verification

- **RED** — RustCFML 0.153.0 (`/tmp/rustcfml-test/rustcfml-0.153.0`), staged with harness + run.cfm + fixture: `SUMMARY: 4/16 passed` / `FAILED: 12` on the default JIT, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`. The only 4 passing assertions are the positional CONTROL asserts.
- **GREEN** — Lucee 5.4.8.2 via CommandBox 6.3.2 (`box task run Task.cfc`, `assert`→`chk` to avoid CommandBox's `assert` shadow, test included inside `savecontent`, version from `server.lucee.version`): `PASS: 16  FAIL: 0  ALL GREEN`.
- Full `tests/runner.cfm` on this branch (RustCFML 0.153.0): **3907/3919 across 469 suites** — the only 12 failures are this suite's named-key assertions; no abort.