### PR TITLE
test(core): this-scope nested write must auto-vivify its container (residual of #111)

### DIFF
--- a/tests/core/ThisScopeAutoVivFixture.cfc
+++ b/tests/core/ThisScopeAutoVivFixture.cfc
@@ -1,0 +1,81 @@
+// Fixture for the THIS-scope nested auto-vivification test. Each probe runs
+// inside a CFC method (the Wheels Migrator.cfc init() context) and reports the
+// exact state the `this` scope ended up in, so a silent-loss engine fails with
+// a diagnosis instead of a bare value mismatch.
+//
+// Mirrors ScopedAutoVivFixture.cfc (the variables/local/request residual from
+// PR #111) -- this fixture isolates the one scope #111 MISSED: `this`.
+component {
+
+	// The exact Wheels Migrator.cfc init() shape: this.paths.migrate = "..."
+	// where this.paths is never pre-seeded. Reports container state + value.
+	public string function vivThisNested() {
+		try {
+			this.zzpThisViv.migrate = "viv-this";
+		} catch (any e) {
+			return "THREW: " & e.message;
+		}
+		if (!StructKeyExists(this, "zzpThisViv")) {
+			return "NO-CONTAINER";
+		}
+		if (!IsStruct(this.zzpThisViv)) {
+			return "NOT-A-STRUCT";
+		}
+		if (!StructKeyExists(this.zzpThisViv, "migrate")) {
+			return "KEY-LOST";
+		}
+		return "migrate=[" & this.zzpThisViv.migrate & "]";
+	}
+
+	// Two-level chain (Migrator stores several path keys; a deep mixin shape):
+	// this.X.a.b must vivify EVERY missing level as a struct.
+	public string function vivThisDeep() {
+		try {
+			this.zzpThisDeep.a.b = "deep-this";
+		} catch (any e) {
+			return "THREW: " & e.message;
+		}
+		if (!StructKeyExists(this, "zzpThisDeep")) {
+			return "NO-CONTAINER";
+		}
+		if (!IsStruct(this.zzpThisDeep)) {
+			return "OUTER-NOT-A-STRUCT";
+		}
+		if (!StructKeyExists(this.zzpThisDeep, "a") || !IsStruct(this.zzpThisDeep.a)) {
+			return "INNER-NOT-A-STRUCT";
+		}
+		return "b=[" & this.zzpThisDeep.a.b & "]";
+	}
+
+	// CONTROL A -- pins that PR #111 still holds inside a CFC method: a
+	// variables-scope nested write on an undeclared key must auto-vivify
+	// (this is the fix that shipped in v0.136 and survives on 0.153.0).
+	public string function vivVariablesControl() {
+		try {
+			variables.zzvThisCtl.k = "viv-vars";
+		} catch (any e) {
+			return "THREW: " & e.message;
+		}
+		if (!StructKeyExists(variables, "zzvThisCtl") || !IsStruct(variables.zzvThisCtl)) {
+			return "NOT-A-STRUCT";
+		}
+		return "k=[" & variables.zzvThisCtl.k & "]";
+	}
+
+	// CONTROL B -- pins that the failure is auto-VIVIFICATION, not this-scope
+	// writes in general: a PRE-INITIALIZED this container takes a nested write
+	// just fine. Isolates the missing implicit `this.X = {}` step.
+	public string function vivThisPreInit() {
+		this.zzqThisPre = {};
+		try {
+			this.zzqThisPre.k = "pre-this";
+		} catch (any e) {
+			return "THREW: " & e.message;
+		}
+		if (!StructKeyExists(this.zzqThisPre, "k")) {
+			return "KEY-LOST";
+		}
+		return "k=[" & this.zzqThisPre.k & "]";
+	}
+
+}

--- a/tests/core/test_this_scope_nested_autoviv.cfm
+++ b/tests/core/test_this_scope_nested_autoviv.cfm
@@ -1,0 +1,75 @@
+<cfscript>
+suiteBegin("Core: auto-vivify a nested write on a THIS-scope member (residual of ##111)");
+
+// ============================================================
+// Background  (follow-on to test_scoped_nested_autoviv.cfm / PR #111)
+// ============================================================
+// On Lucee 5/6/7, Adobe ColdFusion 2018-2025, and BoxLang, assigning to a
+// member path of an undeclared THIS-scope key auto-creates the container as
+// a struct, exactly as for any other scope:
+//
+//     this.paths.migrate = "X";   // this.paths never initialized
+//
+// The engine implicitly performs `this.paths = {}` on the first nested write.
+//
+// PR #111 (merged v0.136) fixed this contract for variables / local / request
+// (test_scoped_nested_autoviv.cfm) and those STILL pass on 0.153.0. But that
+// fix MISSED the `this` scope. On RustCFML 0.153.0 a nested write to an
+// undeclared `this.X` is LOST SILENTLY: no throw at the write, the scope key
+// may register (StructKeyExists(this,"X") -> true) but it is bound to a
+// non-struct value -- IsStruct(this.X) -> false, the written member vanishes,
+// and reading it back yields "" instead of the value.
+//
+// Wheels hits this on the FIRST real exercise of the migrator. vendor/wheels/
+// Migrator.cfc init() does, with no prior `this.paths = {}`:
+//
+//     this.paths.migrate    = expandPath(arguments.migratePath);
+//     this.paths.sql        = ...;
+//     this.paths.templates  = ...;
+//
+// On RustCFML every one of those writes evaporates, so this.paths is not a
+// struct and carries none of the path keys. getAvailableMigrations() and every
+// other migrator entry point that reads this.paths.* then fails -- the entire
+// migrator is unusable. This is the first place the THIS-scope gap surfaces in
+// a real Wheels workload.
+//
+// All assertions below PASS on Lucee/ACF/BoxLang. The risky write is performed
+// inside a CFC method (try/catch wrapped in the fixture) so a silent-loss or
+// throwing engine fails its assertions gracefully instead of aborting the run.
+// ============================================================
+
+zsnaObj = createObject("component", "ThisScopeAutoVivFixture");
+
+// ------------------------------------------------------------
+// (1) THE GAP: this.X.migrate on an undeclared this.X must auto-vivify as a
+//     struct carrying the written key (Wheels Migrator init() shape).
+//     RustCFML 0.153.0 returns "NOT-A-STRUCT" / "KEY-LOST" here.
+// ------------------------------------------------------------
+assert("CFC method: this.X.migrate auto-vivifies as a struct (Migrator init() shape)",
+    zsnaObj.vivThisNested(), "migrate=[viv-this]");
+
+// ------------------------------------------------------------
+// (2) Two-level chain on the THIS scope: this.X.a.b must vivify EVERY level.
+// ------------------------------------------------------------
+assert("CFC method: deep chain this.X.a.b vivifies every level",
+    zsnaObj.vivThisDeep(), "b=[deep-this]");
+
+// ------------------------------------------------------------
+// (3) CONTROL A -- PR #111 still holds: variables-scope nested autoviv inside
+//     a CFC method works on RustCFML 0.153.0 today. Pins that the residual is
+//     SPECIFIC to `this`, not a regression of the shipped fix.
+// ------------------------------------------------------------
+assert("control: variables.X.k autoviv inside the same fixture works (##111 holds)",
+    zsnaObj.vivVariablesControl(), "k=[viv-vars]");
+
+// ------------------------------------------------------------
+// (4) CONTROL B -- isolates the missing implicit `this.X = {}`: a
+//     PRE-INITIALIZED this container takes the same nested write fine, so the
+//     failure is auto-VIVIFICATION, not this-scope writes in general.
+//     Passes on RustCFML today.
+// ------------------------------------------------------------
+assert("control: nested write on a PRE-INITIALIZED this container works",
+    zsnaObj.vivThisPreInit(), "k=[pre-this]");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -45,6 +45,14 @@ try { include "core/test_subscript_autovivify.cfm"; } catch (any e) { writeOutpu
 // auto-viv gap that blocked Wheels $initControllerClass. Fixed in the compiler by routing
 // multi-level scope-rooted nested writes through the runtime scope-path store.
 try { include "core/test_scoped_nested_autoviv.cfm"; } catch (any e) { writeOutput("ERROR | core/test_scoped_nested_autoviv.cfm | " & e.message & chr(10)); }
+// THIS-scope nested auto-vivification (this.paths.migrate = ...): the residual auto-viv
+// gap that #111 left behind. #111 (v0.136) fixed variables/local/request and those still
+// pass on 0.153.0, but the `this` scope was MISSED -- a nested write to an undeclared
+// this.X is lost silently (key registers, IsStruct(this.X) -> false, member vanishes).
+// Blocks Wheels Migrator.cfc init() (this.paths.migrate/sql/templates with no prior
+// this.paths = {}), making the whole migrator unusable. Runtime-level (wrong value, no
+// parse error) so registration is safe. Controls pin that #111 holds + isolate THIS scope.
+try { include "core/test_this_scope_nested_autoviv.cfm"; } catch (any e) { writeOutput("ERROR | core/test_this_scope_nested_autoviv.cfm | " & e.message & chr(10)); }
 try { include "core/test_control_flow.cfm"; } catch (any e) { writeOutput("ERROR | core/test_control_flow.cfm | " & e.message & chr(10)); }
 try { include "core/test_cfloop_negative_step.cfm"; } catch (any e) { writeOutput("ERROR | core/test_cfloop_negative_step.cfm | " & e.message & chr(10)); }
 try { include "core/test_cfloop_array_item_index.cfm"; } catch (any e) { writeOutput("ERROR | core/test_cfloop_array_item_index.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

Assigning to a member path of an **undeclared `this`-scope key** must auto-create the container as a struct on the first nested write, exactly as for every other scope:

```cfm
component {
    function init() {
        this.paths.migrate = "X";   // this.paths never pre-seeded
    }
}
```

On Lucee/ACF/BoxLang the engine implicitly performs `this.paths = {}` and the member lands. PR #111 (merged v0.136) fixed this auto-viv contract for `variables` / `local` / `request` — and those **still pass on 0.153.0** — but the fix **missed the `this` scope**. On RustCFML 0.153.0 the nested write to an undeclared `this.X` is **lost silently**: no throw at the write, the scope key may register (`StructKeyExists(this, "X")` → true) but it is bound to a non-struct value, so `IsStruct(this.X)` → false, the written member vanishes, and reading it back yields `""`.

| Engine | `this.X.y = v` on undeclared `this.X` |
|---|---|
| Lucee 5.4.8.2 | auto-vivifies — `IsStruct(this.X)` true, `this.X.y == v` |
| Adobe CF 2018-2025 | auto-vivifies (same contract) |
| BoxLang | auto-vivifies (same contract) |
| **RustCFML 0.153.0** | **silently lost — `IsStruct(this.X)` false, member gone** |

## What the test asserts

A fixture CFC performs the writes inside methods (the real Wheels context) and returns a diagnosis string:

- **Gap 1** — `this.X.migrate = "viv-this"` on an undeclared `this.X` → expects `migrate=[viv-this]`; RustCFML returns `NOT-A-STRUCT`.
- **Gap 2** — two-level chain `this.X.a.b = "deep-this"` must vivify every level → expects `b=[deep-this]`; RustCFML returns `OUTER-NOT-A-STRUCT`.
- **Control A** — `variables.X.k` autoviv inside the same CFC method still works (pins that PR #111 holds and this is a *residual* specific to `this`, not a regression).
- **Control B** — a **pre-initialized** `this` container takes the same nested write fine (isolates the failure to the missing implicit `this.X = {}` — i.e. auto-vivification, not `this`-scope writes in general).

Both controls pass on RustCFML 0.153.0 today; both gap assertions fail.

## Why it matters for Wheels

`vendor/wheels/Migrator.cfc` `init()` sets up its path table with no prior `this.paths = {}`:

```cfm
this.paths.migrate   = expandPath(arguments.migratePath);
this.paths.sql       = ...;
this.paths.templates = ...;
```

On RustCFML every one of those writes evaporates, so `this.paths` is not a struct and carries none of the path keys. `getAvailableMigrations()` and every other migrator entry point that reads `this.paths.*` then fails — the entire migrator is unusable. This is the first place the missed-`this`-scope gap surfaces in a real Wheels workload, and it is the direct sibling of the `variables.$class.*` shape #111 fixed for controller/model initialization.

## Verification

- **RED — RustCFML 0.153.0** (`/tmp/rustcfml-test/rustcfml-0.153.0`): 2/4 passed (2 failed) — the two gap assertions fail with `NOT-A-STRUCT` / `OUTER-NOT-A-STRUCT`; both controls pass. Reproduced identically in default mode, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`.
- **GREEN — Lucee 5.4.8.2** (CommandBox `box task run`, `assert`→`chk` rename, savecontent capture, `server.lucee.version` cited): 4/4 passed.

Full `tests/runner.cfm` on this branch (RustCFML 0.153.0): **3905/3907 across 469 suites** — the only 2 failures are this suite's this-scope assertions; no abort.