### PR TITLE
test(tags): cfscript transaction action="commit"/"rollback" statement form

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -415,6 +415,13 @@ try { include "tags/test_cfinvoke_tag_marshaling.cfm"; } catch (any e) { writeOu
 //   - script_transaction_attrs: cfscript `transaction action="begin" { ... }`
 //     (the attribute form of the transaction tag, with a body).
 try { include "tags/test_script_transaction_attrs.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_script_transaction_attrs.cfm | " & e.message & chr(10)); }
+//   - transaction_action_statement: the body-less cfscript transaction
+//     STATEMENT form `transaction action="commit";` / `="rollback";` /
+//     `="begin";` (no `{ ... }` block) — the spelling every Wheels migration
+//     template emits inside up()/down(). Distinct from script_transaction_attrs
+//     above (which has a body). A bare transaction{} block is the in-suite
+//     control.
+try { include "tags/test_transaction_action_statement.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_transaction_action_statement.cfm | " & e.message & chr(10)); }
 //   - component_declaration_attributes: follow-on to component_soft_keyword.
 //     Component-header metadata attributes are order-independent and may be
 //     written quoted or unquoted on Lucee/ACF/BoxLang. Two shapes the Wheels

--- a/tests/tags/test_transaction_action_statement.cfm
+++ b/tests/tags/test_transaction_action_statement.cfm
@@ -1,0 +1,79 @@
+<cfscript>
+suiteBegin("Tags: cfscript transaction action statement form");
+
+// ============================================================
+// Background  (gap surfaced laddering the Wheels migrator on RustCFML 0.153.0)
+// ============================================================
+// The cfscript `transaction` statement supports a body-less ATTRIBUTE-STATEMENT
+// form that issues an explicit boundary against the current transaction:
+//   transaction action="commit";
+//   transaction action="rollback";
+//   transaction action="begin";
+// These are statements (terminated by a semicolon, no `{ ... }` block), and are
+// the spelling every Wheels migration template emits inside up()/down():
+//   transaction { ... ; transaction action="rollback"; }
+//
+// RustCFML supports the bare `transaction { ... }` block, and (as of PR #32) the
+// attribute form WITH a body `transaction action="begin" { ... }`. But the
+// body-less STATEMENT form is parsed as a plain expression — the leading token
+// `transaction` is read as a variable reference, so at runtime it throws
+// "Variable 'transaction' is undefined" (type=expression). Lucee/ACF/BoxLang
+// treat `transaction action="..."` as a transaction-control statement and run
+// the block to completion. No datasource is required: with no query inside, the
+// commit/rollback/begin are no-ops on both engines, so the surrounding code
+// simply runs.
+//
+// catch-body locals don't persist on every engine (BoxLang discards a nested
+// `local` on exit), so each probe records its outcome in a struct FIELD.
+// ============================================================
+
+// ---- commit statement inside a transaction block ----
+txnState_commit = {flag = false};
+try {
+	transaction {
+		txnState_commit.flag = true;
+		transaction action="commit";
+	}
+} catch (any e) {
+	txnState_commit.flag = false;
+}
+assertTrue("transaction{ ...; transaction action=commit; } runs to completion", txnState_commit.flag);
+
+// ---- rollback statement inside a transaction block ----
+txnState_rollback = {flag = false};
+try {
+	transaction {
+		txnState_rollback.flag = true;
+		transaction action="rollback";
+	}
+} catch (any e) {
+	txnState_rollback.flag = false;
+}
+assertTrue("transaction{ ...; transaction action=rollback; } runs to completion", txnState_rollback.flag);
+
+// ---- begin/commit statement pair (no enclosing block) ----
+txnState_pair = {flag = false};
+try {
+	transaction action="begin";
+	txnState_pair.flag = true;
+	transaction action="commit";
+} catch (any e) {
+	txnState_pair.flag = false;
+}
+assertTrue("transaction action=begin; ... transaction action=commit; pair runs to completion", txnState_pair.flag);
+
+// ---- CONTROL: bare transaction{} block (no action statement) ----
+// Works on RustCFML and Lucee alike — isolates the gap to the action STATEMENT
+// form, not transaction blocks in general.
+txnState_bare = {flag = false};
+try {
+	transaction {
+		txnState_bare.flag = true;
+	}
+} catch (any e) {
+	txnState_bare.flag = false;
+}
+assertTrue("CONTROL: bare transaction{} block runs to completion", txnState_bare.flag);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Gap

The cfscript `transaction` statement has a body-less **attribute-statement** form that issues an explicit boundary against the current transaction:

```cfm
transaction {
    // ... work ...
    transaction action="commit";   // or "rollback", or "begin"
}
```

RustCFML supports the bare `transaction { ... }` block, and (since PR #32 / `test_script_transaction_attrs.cfm`) the attribute form **with a body** `transaction action="begin" { ... }`. But the body-less **statement** form is parsed as a plain expression: the leading `transaction` token is read as a variable reference, so at runtime it throws `Variable 'transaction' is undefined` (type `expression`). Lucee/Adobe CF/BoxLang treat `transaction action="..."` as a transaction-control statement and run to completion.

Minimal repro (no datasource — with no query inside, commit/rollback/begin are no-ops on both engines):

```cfm
var state = {flag = false};
try {
    transaction {
        state.flag = true;
        transaction action="commit";
    }
} catch (any e) {
    state.flag = false;   // RustCFML lands here: "Variable 'transaction' is undefined"
}
// state.flag => true on Lucee, false on RustCFML 0.153.0
```

| Engine | `transaction action="commit";` statement | bare `transaction { }` block |
|---|---|---|
| Lucee 5.4.8.2 | runs to completion | runs to completion |
| RustCFML 0.153.0 | throws `expression :: Variable 'transaction' is undefined` | runs to completion |

## What the test asserts

`tests/tags/test_transaction_action_statement.cfm` (4 assertions):

1. `transaction{ ...; transaction action="commit"; }` runs to completion (flag set after the inner statement stays true / no throw).
2. Same for `transaction action="rollback";`.
3. A `transaction action="begin"; ... transaction action="commit";` statement pair (no enclosing block) runs to completion.
4. **Control:** a bare `transaction{}` block (no action statement) runs to completion — passes on both engines, isolating the gap to the action *statement* form rather than transaction blocks in general.

Each sequence is wrapped in its own `try/catch` and records its outcome in a struct field (catch-body `local` does not persist on BoxLang). Distinct from the pre-existing `test_script_transaction_attrs.cfm`, which exercises the attribute form *with a body block*.

## Why it matters for Wheels

This was surfaced laddering the Wheels migrator on RustCFML. Every framework migration **template** — `cli/lucli/templates/migrations/*` and `vendor/wheels/migrator/templates/*` — emits `transaction action="rollback"` / `transaction action="commit"` statements inside the generated `up()`/`down()` methods. So every generator-produced migration (`wheels generate migration`, `wheels g model`, scaffolds) fails to run on RustCFML purely on this parse/dispatch gap, independent of any database work.

## Verification

- **RED — RustCFML 0.153.0** (`rustcfml-0.153.0`): `1/4 passed (3 failed)` — only the bare-transaction control passes; the three action-statement assertions throw `expression :: Variable 'transaction' is undefined`. Identical under default, `RUSTCFML_JIT=0`, and `RUSTCFML_JIT_THRESHOLD=1`. Runtime (catchable) error, not a parse abort — runner-safe.
- **GREEN — Lucee 5.4.8.2** (CommandBox 6.3.2): `4/4 passed` (`assert`->`chk` rename, savecontent capture, `server.lucee.version` cited).
- Full `tests/runner.cfm` on this branch (RustCFML 0.153.0): **3904/3907 across 469 suites** — the only 3 failures are this suite's action-statement assertions; no abort.