### PR TITLE
test(oop): bare component name resolves relative to caller package

### DIFF
--- a/tests/oop/relcomp/Maker.cfc
+++ b/tests/oop/relcomp/Maker.cfc
@@ -1,0 +1,18 @@
+component {
+    function init() {
+        return this;
+    }
+
+    // Bare (unqualified) name via createObject("component", "Sibling").
+    // Lucee/ACF/BoxLang resolve a bare component name relative to the
+    // CALLING CFC's package (oop.relcomp) first, so this finds the
+    // sibling. Wrapped so a resolution failure surfaces as a wrong
+    // VALUE ("ERR:..."), keeping the test runtime-level / runner-safe.
+    function viaCreate() {
+        try {
+            return createObject("component", "Sibling").hi();
+        } catch (any e) {
+            return "ERR:" & e.message;
+        }
+    }
+}

--- a/tests/oop/relcomp/Sibling.cfc
+++ b/tests/oop/relcomp/Sibling.cfc
@@ -1,0 +1,9 @@
+component {
+    function init() {
+        return this;
+    }
+
+    function hi() {
+        return "SIBLING-OK";
+    }
+}

--- a/tests/oop/test_relative_component_resolution.cfm
+++ b/tests/oop/test_relative_component_resolution.cfm
@@ -1,0 +1,50 @@
+<cfscript>
+suiteBegin("OOP: relative (bare) component name resolution");
+
+// Background: A bare (unqualified) component name in
+// createObject("component", "Sibling") -- or new Sibling() -- must resolve
+// relative to the CALLING CFC's package first. Maker lives in oop.relcomp
+// alongside Sibling, so from inside Maker the bare name "Sibling" should
+// find oop.relcomp.Sibling. RustCFML 0.153.0 does not search the caller
+// package and throws "Could not find the component [Sibling]" -- viaCreate()
+// catches it and returns "ERR:...". Lucee/ACF/BoxLang return the sibling
+// marker "SIBLING-OK".
+//
+// This is the deepest blocker for the Wheels migrator TableDefinition DSL:
+// createTable / t.string / t.integer / t.references / t.timestamps / t.create
+// and changeTable / addColumn all route through relative createObject of
+// sibling migrator components, so every one of them fails on RustCFML.
+//
+// The `new Sibling()` spelling has the identical defect on RustCFML, but
+// there the resolution failure is UNCATCHABLE (escapes try/catch and would
+// abort the file), so it is intentionally NOT asserted here -- only the
+// catchable, runner-safe createObject form is. The dotted control is
+// resolved from THIS (test-docroot) scope, not from inside Maker, because
+// a dotted path is itself resolved relative to the caller package.
+
+relcompMaker = createObject("component", "oop.relcomp.Maker").init();
+
+// Control: fully-qualified resolution works on RustCFML and Lucee alike.
+// Resolved from the test docroot scope (not from inside Maker).
+controlSibling = "?";
+try {
+    controlSibling = createObject("component", "oop.relcomp.Sibling").hi();
+} catch (any e) {
+    controlSibling = "ERR:" & e.message;
+}
+assert(
+    "qualified createObject('component','oop.relcomp.Sibling') resolves (control)",
+    controlSibling,
+    "SIBLING-OK"
+);
+
+// Gap: bare name via createObject, called from inside Maker, must resolve
+// against Maker's own package (oop.relcomp).
+assert(
+    "bare createObject('component','Sibling') resolves relative to caller package",
+    relcompMaker.viaCreate(),
+    "SIBLING-OK"
+);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -196,6 +196,19 @@ try { include "oop/test_dynamic_lhs_assign.cfm"; } catch (any e) { writeOutput("
 try { include "oop/test_getmetadata_properties.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_getmetadata_properties.cfm | " & e.message & chr(10)); }
 try { include "oop/test_component_bool_attr.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_bool_attr.cfm | " & e.message & chr(10)); }
 try { include "oop/test_chained_writeback_clobber.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_chained_writeback_clobber.cfm | " & e.message & chr(10)); }
+// --- relative_component_resolution: a bare (unqualified) component name in
+//     createObject("component", "Sibling") must resolve against the CALLING
+//     CFC's package first. Maker (in oop.relcomp) calls bare "Sibling" and
+//     should find its package sibling oop.relcomp.Sibling. RustCFML 0.153.0
+//     does not search the caller package -> "Could not find the component
+//     [Sibling]"; Lucee/ACF/BoxLang resolve it. The createObject form is
+//     catchable (viaCreate returns "ERR:..." -> a wrong-VALUE assertion
+//     failure, no file abort), so it is runner-safe; the `new Sibling()`
+//     spelling shares the defect but throws UNCATCHABLY on RustCFML and is
+//     deliberately not asserted. Deepest blocker for the Wheels migrator
+//     TableDefinition DSL (createTable/t.string/t.references/t.timestamps/
+//     changeTable all route through relative createObject of siblings).
+try { include "oop/test_relative_component_resolution.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_relative_component_resolution.cfm | " & e.message & chr(10)); }
 
 // --- Tags ---
 try { include "tags/test_tags_basic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_basic.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

A bare (unqualified) component name in `createObject("component", "Sibling")` (and `new Sibling()`) must resolve relative to the **calling CFC's package** first. RustCFML 0.153.0 does not search the caller package and throws `Could not find the component [Sibling]`; Lucee/Adobe CF/BoxLang all resolve the bare name against the caller package.

Minimal repro -- `oop/relcomp/Maker.cfc` and `oop/relcomp/Sibling.cfc` in the **same** package:

```cfm
// oop/relcomp/Maker.cfc
function viaCreate() {
    try {
        return createObject("component", "Sibling").hi();  // bare name
    } catch (any e) {
        return "ERR:" & e.message;
    }
}
```

```cfm
// from the test docroot
m = createObject("component", "oop.relcomp.Maker").init();
m.viaCreate();   // expected "SIBLING-OK"
```

| Engine | `createObject("component","Sibling")` from Maker | `new Sibling()` from Maker | qualified `oop.relcomp.Sibling` (control) |
|---|---|---|---|
| Lucee 5.4.8.2 | resolves -> `SIBLING-OK` | resolves -> `SIBLING-OK` | resolves |
| RustCFML 0.153.0 | `Could not find the component [Sibling]` (catchable) | `Could not find the component [Sibling]` (uncatchable) | resolves |

## What the test asserts

`tests/oop/test_relative_component_resolution.cfm` instantiates `Maker` by its fully-qualified path, then asserts:

1. **Control** -- `createObject("component","oop.relcomp.Sibling")` resolved from the test (docroot) scope returns `SIBLING-OK` (passes on both engines; proves the fixtures are well-formed). The control is resolved from test scope, not from inside `Maker`, because a *dotted* path is itself resolved relative to the caller package.
2. **Gap** -- `Maker.viaCreate()` (bare `createObject("component","Sibling")` from inside Maker, which lives in `oop.relcomp`) returns `SIBLING-OK`. RED on RustCFML: `viaCreate()`'s `try/catch` catches the resolution miss and returns `ERR:Could not find the component [Sibling].`, so it is a wrong-VALUE assertion failure with no file abort -- runner-safe.

The `new Sibling()` spelling has the identical defect on RustCFML, but there the resolution failure is **uncatchable** (it escapes `try/catch` and aborts the file), so it is documented in the test/fixture comments but intentionally **not** asserted in the registered test. The cross-engine GREEN verify additionally proves the `new Sibling()` form resolves on Lucee.

## Why it matters for Wheels

This is the deepest blocker for the Wheels migrator `TableDefinition` DSL. `createTable` / `t.string` / `t.integer` / `t.references` / `t.timestamps` / `t.create` and `changeTable` / `addColumn` all route through relative `createObject` of sibling migrator components. Until bare-name caller-package resolution works, every migration helper fails on RustCFML.

This is the missing this-scope sibling of the scoped-name-resolution family; it is distinct from #95 (invoke undeclared keys) and #126/#127 (cfinvoke arg drop / query-column type) -- those don't exercise caller-package component resolution.

## Verification

- **RustCFML 0.153.0** (`/tmp/rustcfml-test/rustcfml-0.153.0`): RED reproduced in all three JIT modes (default, `RUSTCFML_JIT=0`, `RUSTCFML_JIT_THRESHOLD=1`). Control passes; gap assertion fails `expected: [SIBLING-OK] | got: [ERR:Could not find the component [Sibling].]`; file does not abort.
- **Lucee 5.4.8.2** (CommandBox 6.3.2 `box task run`): GREEN -- 3/3 pass (control, bare `createObject`, and the `new Sibling()` Lucee-only probe), with `server.lucee.version` cited.
- Full `tests/runner.cfm` on this branch (RustCFML 0.153.0): **3904/3905 across 469 suites** — the only failure is this suite's bare-name assertion; no abort.