### PR TITLE
test(oop): bare component name in an inherited method resolves to the defining component's package

### DIFF
--- a/tests/oop/inh/InhParent.cfc
+++ b/tests/oop/inh/InhParent.cfc
@@ -1,0 +1,13 @@
+// Defines a method that reaches its package-sibling by BARE name. The bare
+// name must resolve relative to THIS component's directory (oop/inh/) — the
+// directory where the CreateObject literal is lexically defined — regardless
+// of which subclass instance the method runs on.
+component {
+    public string function viaCreate() {
+        try {
+            return CreateObject("component", "InhSibling").hi();
+        } catch (any e) {
+            return "ERR:" & e.message;
+        }
+    }
+}

--- a/tests/oop/inh/InhSibling.cfc
+++ b/tests/oop/inh/InhSibling.cfc
@@ -1,0 +1,3 @@
+// Sibling co-located with InhParent (tests/oop/inh/). Reached by a bare
+// CreateObject("component","InhSibling") from InhParent's method.
+component { public string function hi() { return "inh-sibling-ok"; } }

--- a/tests/oop/inhsub/InhChild.cfc
+++ b/tests/oop/inhsub/InhChild.cfc
@@ -1,0 +1,4 @@
+// Empty subclass in a DIFFERENT directory (oop/inhsub/) than its parent
+// (oop/inh/). Inherits viaCreate(); calling it must still resolve the bare
+// "InhSibling" against the PARENT's dir, not this subclass's dir.
+component extends="oop.inh.InhParent" {}

--- a/tests/oop/test_inherited_bare_component_resolution.cfm
+++ b/tests/oop/test_inherited_bare_component_resolution.cfm
@@ -1,0 +1,39 @@
+<cfscript>
+suiteBegin("OOP: bare component name in an inherited method resolves to the defining component's package");
+
+// Background: a bare (unqualified) CreateObject("component","Sibling") inside a
+// method must resolve relative to the package of the component that LEXICALLY
+// DEFINES the method, not the runtime instance's concrete-class package. When
+// the method is inherited by a subclass that lives in a DIFFERENT directory,
+// the bare name must still be found next to the PARENT. Lucee/ACF/BoxLang do
+// this. RustCFML 0.160.0 resolves the bare name against the concrete subclass's
+// directory instead, so it fails: "Could not find the component [InhSibling]".
+//
+// This is the inherited-method sibling of #132 (which fixed bare resolution
+// when the caller IS the defining component, co-located with the sibling).
+// Here InhParent (oop/inh/) defines viaCreate() -> CreateObject("component",
+// "InhSibling"); InhChild (oop/inhsub/) is an empty subclass in another dir.
+//
+// Why it matters for Wheels: the migrator's TableDefinition DSL runs entirely
+// through this shape. User migrations live in app/migrator/migrations/ and
+// extend wheels.migrator.Migration; Migration.createTable() does a bare
+// CreateObject("component","TableDefinition") to reach its package-sibling in
+// vendor/wheels/migrator/. On RustCFML the inherited createTable() resolves
+// "TableDefinition" against the user-migration directory and throws, so the
+// migrator cannot create a single table (Migration.cfc TableDefinition x2 /
+// ViewDefinition / ForeignKeyDefinition; TableDefinition.cfc ColumnDefinition /
+// ForeignKeyDefinition). Surfaced running the migrator pristine on stock.
+
+ibcrChild = createObject("component", "oop.inhsub.InhChild");
+ibcrParent = createObject("component", "oop.inh.InhParent");
+
+// --- the gap: inherited method on a subclass in another dir ---
+assert("inherited viaCreate() on a subclass resolves the bare sibling against the PARENT package",
+    ibcrChild.viaCreate(), "inh-sibling-ok");
+
+// --- CONTROL (green on both engines): caller IS the defining component (the #132 case) ---
+assert("CONTROL: viaCreate() called directly on the defining parent resolves the bare sibling",
+    ibcrParent.viaCreate(), "inh-sibling-ok");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -196,6 +196,15 @@ try { include "oop/test_dynamic_lhs_assign.cfm"; } catch (any e) { writeOutput("
 try { include "oop/test_getmetadata_properties.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_getmetadata_properties.cfm | " & e.message & chr(10)); }
 try { include "oop/test_component_bool_attr.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_bool_attr.cfm | " & e.message & chr(10)); }
 try { include "oop/test_chained_writeback_clobber.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_chained_writeback_clobber.cfm | " & e.message & chr(10)); }
+//   - inherited_bare_component_resolution: a bare CreateObject("component","X")
+//     in an INHERITED method must resolve relative to the package of the
+//     component that lexically DEFINES the method (the parent), not the runtime
+//     subclass's package. RustCFML resolves against the concrete subclass dir
+//     and fails when the subclass lives elsewhere. Inherited-method sibling of
+//     #132. Blocks the Wheels migrator: user migrations (app/migrator/) extend
+//     wheels.migrator.Migration whose inherited createTable() bare-resolves its
+//     sibling TableDefinition (vendor/wheels/migrator/). Runtime-level, runner-safe.
+try { include "oop/test_inherited_bare_component_resolution.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inherited_bare_component_resolution.cfm | " & e.message & chr(10)); }
 // Bare component name resolves relative to the CALLING CFC's package. From
 // inside oop.relcomp.Maker, createObject("component","Sibling") must find
 // oop.relcomp.Sibling. Was the deepest blocker for the Wheels migrator


### PR DESCRIPTION
## Gap: a bare component name in an INHERITED method resolves against the subclass's package, not the defining component's

A bare (unqualified) `CreateObject("component", "Sibling")` (or `new Sibling()`) inside a method must resolve relative to the package of the component that **lexically defines** the method. When that method is **inherited** by a subclass living in a **different directory**, the bare name must still be found next to the **parent**. Lucee/Adobe CF/BoxLang do this. RustCFML 0.160.0 resolves the bare name against the runtime **subclass's** directory and fails.

```cfml
// oop/inh/InhSibling.cfc      -> hi() returns "inh-sibling-ok"
// oop/inh/InhParent.cfc:
component {
    function viaCreate() { return CreateObject("component", "InhSibling").hi(); }
}
// oop/inhsub/InhChild.cfc  (DIFFERENT dir):
component extends="oop.inh.InhParent" {}
```

| call | RustCFML 0.160.0 | Lucee 5.4.8.2 |
|------|------------------|---------------|
| `createObject("oop.inhsub.InhChild").viaCreate()` (inherited) | **`Could not find the component [InhSibling]`** | `inh-sibling-ok` |
| `createObject("oop.inh.InhParent").viaCreate()` (caller is the definer — control) | `inh-sibling-ok` | `inh-sibling-ok` |

This is the **inherited-method sibling of #132** (which fixed bare resolution when the caller *is* the defining component, co-located with the sibling). #132 keyed resolution off the caller package correctly for the direct case; this remaining case keys off the concrete subclass's directory instead of the defining (parent) component's directory.

### What the test asserts
- Inherited `viaCreate()` invoked on a subclass in another directory resolves the bare sibling against the **parent's** package. *(red on RustCFML)*
- CONTROL (green on both engines): `viaCreate()` called directly on the defining parent resolves the bare sibling (the #132 case).

The bare-`CreateObject` form is catchable (`viaCreate()` returns `ERR:...` → a wrong-value assertion, no file abort), so the test is runner-safe.

### Why it matters for Wheels
This is the last blocker for the Wheels **migrator** on RustCFML. User migrations live in `app/migrator/migrations/` and extend `wheels.migrator.Migration`; `Migration.createTable()` does a bare `CreateObject("component", "TableDefinition")` to reach its package-sibling in `vendor/wheels/migrator/`. On RustCFML the inherited `createTable()` resolves `"TableDefinition"` against the user-migration directory and throws `Could not find the component [TableDefinition]`, so the migrator cannot create a single table. The same shape recurs across `Migration.cfc` (TableDefinition ×2, ViewDefinition, ForeignKeyDefinition) and `TableDefinition.cfc` (ColumnDefinition, ForeignKeyDefinition). Surfaced running the migrator pristine on stock v0.160.0 — every other migrator blocker (#129/#130/#131/#132) is now fixed; this is the one remaining wall. (The whole compat-matrix migrator suite exercises this idiom and runs green on Lucee/Adobe/BoxLang in CI.)

### Verification
- **RustCFML 0.160.0** (release binary, full `tests/runner.cfm`): 1/2 — the inherited-method assertion fails (`ERR:Could not find the component [InhSibling]`); the direct-parent control passes. Full runner 3910/3911, no abort.
- **Lucee 5.4.8.2** (served via `box server`, Application.cfc declaring the `/lib` + `/sub` mappings — box-task contexts don't honor `this.mappings`, so the served instance is the faithful comparison): inherited-on-subclass and control both resolve `inh-sibling-ok`.
- Registered in the OOP block after `test_chained_writeback_clobber.cfm`.
