### PR TITLE
test(oop): bare component in an inherited method resolves to the defining package when invoked via a child-defined method (follow-on to #133)

### DIFF
--- a/tests/oop/indbase/IndBase.cfc
+++ b/tests/oop/indbase/IndBase.cfc
@@ -1,0 +1,10 @@
+// Base in oop/indbase/. Its method does a BARE CreateObject of its
+// package-sibling IndSibling (also in oop/indbase/). The bare name must
+// resolve relative to THIS file's dir (where the literal is defined),
+// regardless of which subclass — or which OUTER frame — the call runs under.
+component {
+    public string function makeSibling() {
+        try { return CreateObject("component", "IndSibling").hi(); }
+        catch (any e) { return "ERR:" & e.message; }
+    }
+}

--- a/tests/oop/indbase/IndSibling.cfc
+++ b/tests/oop/indbase/IndSibling.cfc
@@ -1,0 +1,1 @@
+component { public string function hi() { return "ind-sibling-ok"; } }

--- a/tests/oop/indleaf/IndChild.cfc
+++ b/tests/oop/indleaf/IndChild.cfc
@@ -1,0 +1,6 @@
+// Subclass in a DIFFERENT dir (oop/indleaf/). go() is defined HERE and calls
+// the INHERITED makeSibling() (defined in oop/indbase/). This is the Wheels
+// migrator shape: a migration's own up() calls the inherited createTable().
+component extends="oop.indbase.IndBase" {
+    public string function go() { return makeSibling(); }
+}

--- a/tests/oop/test_inherited_bare_component_via_child_method.cfm
+++ b/tests/oop/test_inherited_bare_component_via_child_method.cfm
@@ -1,0 +1,38 @@
+<cfscript>
+suiteBegin("OOP: bare component in an inherited method resolves to the defining package even when invoked via a child-defined method");
+
+// Background: a bare CreateObject("component","X") inside a method must resolve
+// X relative to the package of the component that LEXICALLY DEFINES the method.
+// That must hold no matter how the method is reached — including when a
+// child-defined method on a subclass (in a different directory) calls the
+// inherited method. Lucee/ACF/BoxLang do this. RustCFML 0.161.0 resolves the
+// bare name relative to the OUTERMOST child frame's directory in that case.
+//
+// IndBase (oop/indbase/) defines makeSibling() -> CreateObject("component",
+// "IndSibling") [sibling in oop/indbase/]. IndChild (oop/indleaf/) extends it
+// and adds go() -> makeSibling().
+//
+//   childInstance.makeSibling()  (inherited method called DIRECTLY)  -> resolves on BOTH (the #133 fix; CONTROL)
+//   childInstance.go()           (child method calls the inherited)  -> RustCFML 0.161: "Could not find the component [IndSibling]"; Lucee: resolves
+//
+// PR #133 fixed the direct-call case; this is the remaining indirect case.
+// Why it matters: the Wheels migrator runs EXACTLY this shape. A user migration
+// in app/migrator/migrations/ extends wheels.migrator.Migration; the migration's
+// own up() calls the inherited createTable(), which does
+// CreateObject("component","TableDefinition") (sibling in vendor/wheels/migrator/).
+// On RustCFML createTable() resolves TableDefinition against the migration's dir
+// and throws, so the migrator cannot create a table (Migration.cfc lines 62/76/
+// 89/353; TableDefinition.cfc ColumnDefinition/ForeignKeyDefinition).
+
+ibcvChild = createObject("component", "oop.indleaf.IndChild");
+
+// --- CONTROL (green on both engines — the #133 fix): inherited method called DIRECTLY ---
+assert("CONTROL: inherited makeSibling() called directly on the subclass resolves its sibling",
+    ibcvChild.makeSibling(), "ind-sibling-ok");
+
+// --- the gap: a child-defined method calls the inherited method ---
+assert("child-defined go() calling the inherited makeSibling() resolves the bare sibling against the BASE package",
+    ibcvChild.go(), "ind-sibling-ok");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -207,6 +207,15 @@ try { include "oop/test_relative_component_resolution.cfm"; } catch (any e) { wr
 // Inherited-method sibling of #132: a bare CreateObject inside an inherited method must
 // resolve against the PARENT (defining) component's package, not the concrete subclass's dir.
 try { include "oop/test_inherited_bare_component_resolution.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inherited_bare_component_resolution.cfm | " & e.message & chr(10)); }
+//   - inherited_bare_component_via_child_method: follow-on to #133. A bare
+//     CreateObject("component","X") in an inherited method must resolve to the
+//     DEFINING component's package even when reached via a CHILD-defined method
+//     on a subclass in a different dir. #133 fixed the direct-call case (the
+//     CONTROL here passes); RustCFML still resolves against the outermost child
+//     frame's dir for the indirect case. This is the exact Wheels migrator shape
+//     (migration up() -> inherited createTable() -> CreateObject("TableDefinition")),
+//     the sole remaining migrator blocker. Runtime-level, runner-safe.
+try { include "oop/test_inherited_bare_component_via_child_method.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inherited_bare_component_via_child_method.cfm | " & e.message & chr(10)); }
 
 // --- Tags ---
 try { include "tags/test_tags_basic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_basic.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap: bare component resolution in an inherited method fails when the method is reached via a child-defined method

Follow-on to #133. A bare `CreateObject("component", "X")` inside a method must resolve `X` relative to the package of the component that **lexically defines** the method — no matter how the method is reached. #133 fixed the case where an inherited method is called **directly** on a subclass instance. This is the remaining case: a **child-defined** method on a subclass (in a different directory) calls the inherited method, and that inherited method does the bare `CreateObject`. RustCFML 0.161.0 resolves the bare name against the **outermost child frame's** directory instead of the inherited method's defining package.

```cfml
// oop/indbase/IndSibling.cfc  -> hi() returns "ind-sibling-ok"
// oop/indbase/IndBase.cfc:
component {
    function makeSibling() { return CreateObject("component", "IndSibling").hi(); }
}
// oop/indleaf/IndChild.cfc   (DIFFERENT dir):
component extends="oop.indbase.IndBase" {
    function go() { return makeSibling(); }   // child method -> inherited method -> bare CreateObject
}
```

| call on a `IndChild` instance | RustCFML 0.161.0 | Lucee 5.4.8.2 |
|------|------------------|---------------|
| `.makeSibling()` (inherited, called directly — the #133 case, CONTROL) | `ind-sibling-ok` | `ind-sibling-ok` |
| `.go()` (child method calls the inherited method) | **`Could not find the component [IndSibling]`** | `ind-sibling-ok` |

The control passing confirms #133's fix holds; only the indirect path is still broken.

### What the test asserts
- CONTROL (green on both): `child.makeSibling()` — inherited method called directly — resolves its sibling (the #133 fix).
- The gap: `child.go()` — a child-defined method calling the inherited method — resolves the bare sibling against the **base** package. *(red on RustCFML)*

Both use the same instance; the bare-`CreateObject` form is catchable (`makeSibling()` returns `ERR:...`), so the test is runner-safe.

### Why it matters for Wheels
This is the **sole remaining blocker for the Wheels migrator** on RustCFML — and it is exactly this shape. A user migration in `app/migrator/migrations/` extends `wheels.migrator.Migration`; the migration's **own** `up()` (child-defined) calls the **inherited** `createTable()` (defined in `vendor/wheels/migrator/`), which does `CreateObject("component", "TableDefinition")` (sibling in `vendor/wheels/migrator/`). On RustCFML 0.161.0 `createTable()` resolves `TableDefinition` against the migration's directory and throws `Could not find the component [TableDefinition]`, so the migrator cannot create a single table. The same shape recurs at `Migration.cfc` lines 62/76/89/353 (TableDefinition ×2, ViewDefinition, ForeignKeyDefinition) and in `TableDefinition.cfc` (ColumnDefinition, ForeignKeyDefinition). Verified by running the migrator pristine on stock v0.161.0 — every other migrator blocker (#129–#133) is now fixed; this is the last wall. (The whole compat-matrix migrator suite exercises this idiom and runs green on Lucee/Adobe/BoxLang in CI.)

### Verification
- **RustCFML 0.161.0** (release binary, full `tests/runner.cfm`): 1/2 — the indirect (`go()`) assertion fails (`Could not find the component [IndSibling]`); the direct-call control passes. Full runner 3912/3913, no abort.
- **Lucee 5.4.8.2** (served via `box server`, Application.cfc declaring the `/lib`-style mappings — box-task contexts don't honor `this.mappings`): both the direct and indirect calls resolve `ind-sibling-ok`.
- Registered in the OOP block after `test_inherited_bare_component_resolution.cfm` (#133).
