### PR TITLE
test(oop): component iteration/serialization must not leak engine-internal keys

### DIFF
--- a/tests/oop/SerializeLeakProbe.cfc
+++ b/tests/oop/SerializeLeakProbe.cfc
@@ -1,0 +1,4 @@
+// Fixture for the component-internals serialize/for-in leak test.
+component {
+    public string function greet() { return "hi"; }
+}

--- a/tests/oop/test_component_internals_serialize_leak.cfm
+++ b/tests/oop/test_component_internals_serialize_leak.cfm
@@ -1,0 +1,45 @@
+<cfscript>
+suiteBegin("OOP: component iteration / serialization must not leak engine-internal keys");
+
+// Background: iterating a component (for(k in obj)) or SerializeJSON(obj) must
+// expose only its data members — never engine-internal bookkeeping keys. On
+// Lucee/ACF/BoxLang for-in yields the public members (and functions) but NO
+// engine internals, and SerializeJSON(component) emits only the data
+// properties (no functions, no internals). RustCFML 0.161.0 leaks
+// __name / __source_file / __variables into both for-in and SerializeJSON,
+// and SerializeJSON additionally emits every method as a null-valued key.
+//
+//   o = new Probe(); o.id = 7; o.title = "Hello";
+//   for (k in o) ...          RustCFML: __name,greet,__source_file,__variables,id,title
+//                             Lucee:    ID,GREET,TITLE   (no __* internals)
+//   serializeJSON(o)          RustCFML: {"__name":..,"greet":null,"__source_file":..,"__variables":{..},"id":7,"title":"Hello"}
+//                             Lucee:    {"ID":7,"TITLE":"Hello"}
+//
+// Why it matters for Wheels: model/properties.cfc::properties() does
+// for(local.key in this) to collect a model's properties, and the canonical
+// REST pattern renderWith(data=modelObject) runs SerializeJSON on the model.
+// On RustCFML a single-record JSON response comes back with ~379 keys of
+// engine internals + null methods instead of the model's columns.
+
+slpObj = createObject("component", "oop.SerializeLeakProbe");
+slpObj.id = 7;
+slpObj.title = "Hello";
+
+// --- for-in must not yield engine-internal __* keys ---
+slpKeys = "";
+for (slpK in slpObj) { slpKeys = listAppend(slpKeys, slpK); }
+assertFalse("for-in over a component does not yield __name", listFindNoCase(slpKeys, "__name") gt 0);
+assertFalse("for-in over a component does not yield __source_file", listFindNoCase(slpKeys, "__source_file") gt 0);
+assertFalse("for-in over a component does not yield __variables", listFindNoCase(slpKeys, "__variables") gt 0);
+assertTrue("for-in over a component DOES yield its data members", listFindNoCase(slpKeys, "id") gt 0 && listFindNoCase(slpKeys, "title") gt 0);
+
+// --- SerializeJSON of a component must emit only data, no internals/functions ---
+slpJson = serializeJSON(slpObj);
+assertFalse("serializeJSON(component) omits __name", findNoCase("__name", slpJson) gt 0);
+assertFalse("serializeJSON(component) omits __source_file", findNoCase("__source_file", slpJson) gt 0);
+assertFalse("serializeJSON(component) omits __variables", findNoCase("__variables", slpJson) gt 0);
+assertFalse("serializeJSON(component) omits method members", findNoCase("greet", slpJson) gt 0);
+assertTrue("serializeJSON(component) includes data members", findNoCase("Hello", slpJson) gt 0);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -172,6 +172,13 @@ try { include "members/test_number_members.cfm"; } catch (any e) { writeOutput("
 
 // --- OOP ---
 try { include "oop/test_components.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_components.cfm | " & e.message & chr(10)); }
+//   - component_internals_serialize_leak: iterating a component (for(k in obj))
+//     or SerializeJSON(obj) must expose only data members, never engine
+//     internals. RustCFML leaks __name/__source_file/__variables into both, and
+//     SerializeJSON emits methods as null keys. Breaks Wheels model
+//     properties() (for-in over `this`) and renderWith(data=modelObject) — a
+//     single-record JSON response comes back as ~379 internal keys. Runtime-safe.
+try { include "oop/test_component_internals_serialize_leak.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_internals_serialize_leak.cfm | " & e.message & chr(10)); }
 try { include "oop/test_component_method_builtin_name.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_method_builtin_name.cfm | " & e.message & chr(10)); }
 try { include "oop/test_component_return_type.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_component_return_type.cfm | " & e.message & chr(10)); }
 try { include "oop/test_inheritance.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inheritance.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap: component iteration / serialization leaks engine-internal keys

Iterating a component (`for (k in obj)`) or `SerializeJSON(obj)` must expose only its data members — never engine-internal bookkeeping. On Lucee/Adobe CF/BoxLang `for-in` yields the public members (and functions) but no internals, and `SerializeJSON(component)` emits only the data properties (no functions, no internals). RustCFML 0.161.0 leaks `__name` / `__source_file` / `__variables` into both, and `SerializeJSON` additionally emits every method as a `null`-valued key.

```cfml
o = new Probe(); o.id = 7; o.title = "Hello";   // Probe has a greet() method
```

| | RustCFML 0.161.0 | Lucee 5.4.8.2 |
|---|---|---|
| `for (k in o)` keys | `__name,greet,__source_file,__variables,id,title` | `ID,GREET,TITLE` |
| `serializeJSON(o)` | `{"__name":..,"greet":null,"__source_file":..,"__variables":{..},"id":7,"title":"Hello"}` | `{"ID":7,"TITLE":"Hello"}` |

### What the test asserts
- `for-in` over a component yields neither `__name`, `__source_file`, nor `__variables` (but does yield the data members). *(red on RustCFML)*
- `serializeJSON(component)` omits `__name`/`__source_file`/`__variables` and method members, and includes the data. *(red on RustCFML)*

### Why it matters for Wheels
Two high-traffic paths hit this:
- `vendor/wheels/model/properties.cfc::properties()` collects a model's properties with `for (local.key in this)` — on RustCFML the internal `__*` keys come through as bogus "properties".
- The canonical REST pattern `renderWith(data=modelObject)` runs `SerializeJSON` on the model. On RustCFML a single-record JSON response comes back with ~379 keys of engine internals + null methods instead of the model's columns. (A `findAll()` **query** serializes fine — query rows have no component internals; only single-model serialization is broken.)

### Verification
- **RustCFML 0.161.0** (release binary, full `tests/runner.cfm`): 2/9 — the seven leak assertions fail (`got: [true]` for the `__*` presence checks); the data-presence controls pass. Full runner 3913/3920, no abort.
- **Lucee 5.4.8.2** (CommandBox): 9/9 PASS.
- Registered in the OOP block after `test_components.cfm`.
