### PR TITLE
test(core): SerializeJSON must not leak internal arguments-scope sentinel keys

### DIFF
--- a/tests/core/test_serializejson_arguments_sentinels.cfm
+++ b/tests/core/test_serializejson_arguments_sentinels.cfm
@@ -1,0 +1,39 @@
+<cfscript>
+suiteBegin("Core: SerializeJSON must not leak internal arguments-scope sentinel keys");
+
+// Background: RustCFML tags an arguments-derived struct with internal sentinel
+// keys (__arguments_scope, __arguments_params) — and structKeyList / structCount
+// / structKeyExists / for-in all correctly FILTER them. But SerializeJSON does
+// NOT filter them, so a struct built by structAppend(s, arguments) serializes
+// the sentinels into the JSON. Lucee has no such keys.
+//
+//   function f() { var s = {}; structAppend(s, arguments); return serializeJSON(s); }
+//   f(from="a", template="welcome")
+//     RustCFML 0.161.0 -> {"from":"a","template":"welcome","__arguments_scope":true,"__arguments_params":[]}
+//     Lucee 5.4.8.2    -> {"template":"welcome","from":"a"}
+//
+// Why it matters for Wheels: controller sendEmail() / many helpers build option
+// structs by copying the arguments scope, then serialize/spool them — the
+// leaked sentinels corrupt the output. The fix is the same filtering
+// structKeyList/Count/Exists/for-in already apply, extended to SerializeJSON.
+
+function sjasBuild() {
+    var s = {};
+    structAppend(s, arguments);
+    return serializeJSON(s);
+}
+sjasJson = sjasBuild(from = "a", template = "welcome");
+
+assertFalse("serializeJSON of an arguments-derived struct omits __arguments_scope",
+    findNoCase("__arguments_scope", sjasJson) gt 0);
+assertFalse("serializeJSON of an arguments-derived struct omits __arguments_params",
+    findNoCase("__arguments_params", sjasJson) gt 0);
+assertTrue("the real keys are present", findNoCase("welcome", sjasJson) gt 0 && findNoCase("from", sjasJson) gt 0);
+
+// CONTROL (green on both): the struct funcs already filter the sentinels.
+function sjasKeys() { var s = {}; structAppend(s, arguments); return structKeyList(s); }
+sjasKl = sjasKeys(from = "a", template = "welcome");
+assertFalse("CONTROL: structKeyList already filters __arguments_scope", listFindNoCase(sjasKl, "__arguments_scope") gt 0);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -503,6 +503,13 @@ try { include "core/test_application_metadata.cfm"; } catch (any e) { writeOutpu
 //     option-forwarding. Surfaced while booting Wheels (contentFor section
 //     detection reads StructKeyList(arguments)).
 try { include "core/test_named_args_no_numeric_alias.cfm"; } catch (any e) { writeOutput("ERROR | core/test_named_args_no_numeric_alias.cfm | " & e.message & chr(10)); }
+//   - serializejson_arguments_sentinels: RustCFML tags arguments-derived structs
+//     with internal __arguments_scope/__arguments_params keys; structKeyList/
+//     Count/Exists/for-in filter them but SerializeJSON does not, so
+//     structAppend(s, arguments) then serializeJSON(s) leaks the sentinels.
+//     Lucee has no such keys. Hits Wheels helpers that copy the arguments scope
+//     into option structs and serialize/spool them. Runtime-safe.
+try { include "core/test_serializejson_arguments_sentinels.cfm"; } catch (any e) { writeOutput("ERROR | core/test_serializejson_arguments_sentinels.cfm | " & e.message & chr(10)); }
 //   - named_args_array_view: the arguments scope of a NAMED-argument call must
 //     stay array-addressable (hybrid array/struct) exactly like a positional
 //     call — ArrayLen(arguments) counts the args and arguments[1] reads the


### PR DESCRIPTION
## Gap: SerializeJSON leaks internal arguments-scope sentinel keys

RustCFML tags an arguments-derived struct with internal sentinel keys (`__arguments_scope`, `__arguments_params`). `structKeyList` / `structCount` / `structKeyExists` / `for-in` all correctly **filter** them — but `SerializeJSON` does **not**, so a struct built via `structAppend(s, arguments)` serializes the sentinels into the JSON:

```cfml
function f() { var s = {}; structAppend(s, arguments); return serializeJSON(s); }
f(from = "a", template = "welcome");
```

| engine | result |
|--------|--------|
| RustCFML 0.161.0 | `{"from":"a","template":"welcome","__arguments_scope":true,"__arguments_params":[]}` |
| Lucee 5.4.8.2 | `{"template":"welcome","from":"a"}` |

### What the test asserts
- `serializeJSON` of an arguments-derived struct omits `__arguments_scope` and `__arguments_params`, and includes the real keys. *(red on RustCFML)*
- CONTROL (green on both): `structKeyList` already filters the sentinels — establishing that the filtering exists elsewhere and only `SerializeJSON` is missing it.

### Why it matters for Wheels
Controller `sendEmail()` and many framework helpers build option structs by copying the `arguments` scope (`structAppend(s, arguments)`), then serialize or spool them. On RustCFML the leaked sentinels corrupt that output. The fix is the same filtering `structKeyList`/`Count`/`Exists`/`for-in` already apply, extended to `SerializeJSON`. (Surfaced laddering the mailer.)

### Verification
- **RustCFML 0.161.0** (release binary, full `tests/runner.cfm`): 2/4 — the two sentinel-omission assertions fail (`got: [true]`); the real-keys and structKeyList-control pass.
- **Lucee 5.4.8.2** (CommandBox): 4/4 PASS.
- Registered in the core block after `test_named_args_no_numeric_alias.cfm`.
