### PR TITLE
test(tags): cfmailpart script-statement form must parse inside a script cfmail block

### DIFF
--- a/tests/tags/test_cfmailpart_script_form.cfm
+++ b/tests/tags/test_cfmailpart_script_form.cfm
@@ -1,0 +1,44 @@
+<cfscript>
+suiteBegin("Tags: cfmailpart script-statement form parses inside a script cfmail block");
+
+// Background: inside a script cfmail(){} block, cfmailpart is callable as a
+// script statement to declare a multipart (text + html) body — the same as the
+// <cfmailpart> tag inside <cfmail>. Lucee/Adobe CF/BoxLang PARSE it (the
+// function below compiles and is defined). RustCFML 0.161.0 fails to PARSE the
+// script-form cfmailpart:
+//   "Parse error: Expected RBrace, found Semicolon"
+//
+//   function buildMultipart() {
+//       cfmail(to="a@x.com", from="b@x.com", subject="S") {
+//           cfmailpart(type="text") { writeOutput("text part"); }
+//           cfmailpart(type="html") { writeOutput("<b>html part</b>"); }
+//       }
+//   }
+//
+// The test exercises PARSE-ABILITY only (the function is defined, never called)
+// so it needs no SMTP server. Because the gap is a PARSE error (not runtime),
+// it aborts the whole file at compile time and cannot be caught — so this test
+// is filed UNREGISTERED in tests/runner.cfm (registering it would abort the
+// entire suite at the include). Register it once the parse support lands.
+//
+// Why it matters for Wheels: vendor/wheels/Global.cfc $mail() emits
+// cfmailpart(attributeCollection=local.i){...} and cfmailparam(attributeCollection=local.i)
+// in script form, so every multipart Wheels email (the default text+html
+// mailer output) fails to COMPILE on RustCFML. (Plain single-part cfmail works
+// — RustCFML implements cfmail end-to-end with a spool; only the script-form
+// cfmailpart/cfmailparam sub-statements are unparsed.)
+
+function cmpsfBuildMultipart() {
+    cfmail(to = "a@example.com", from = "b@example.com", subject = "parts test") {
+        cfmailpart(type = "text") { writeOutput("text-part-body"); }
+        cfmailpart(type = "html") { writeOutput("<b>html-part-body</b>"); }
+    }
+    return "defined";
+}
+
+// Reaching here means the file PARSED (on RustCFML it parse-aborts before this).
+assertTrue("script-form cfmailpart inside cfmail compiles (function is defined)",
+    isCustomFunction(cmpsfBuildMultipart));
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Gap: the script-statement form of `cfmailpart` fails to parse inside a script `cfmail` block

Inside a script `cfmail(){}` block, `cfmailpart` is callable as a script statement to declare a multipart (text + html) body — the same as `<cfmailpart>` inside `<cfmail>`. Lucee/Adobe CF/BoxLang parse it. RustCFML 0.161.0 fails to **parse** it:

```cfml
function buildMultipart() {
    cfmail(to="a@x.com", from="b@x.com", subject="S") {
        cfmailpart(type="text") { writeOutput("text part"); }
        cfmailpart(type="html") { writeOutput("<b>html part</b>"); }
    }
}
```

```
RustCFML 0.161.0:  Parse error: Expected RBrace, found Semicolon   (at the cfmailpart line)
Lucee 5.4.8.2:     compiles — function defined (isCustomFunction = true)
```

(Plain single-part `cfmail` works — RustCFML implements `cfmail` end-to-end with a spool. Only the script-form `cfmailpart`/`cfmailparam` sub-statements are unparsed.)

### Filed UNREGISTERED
Because this is a **parse error** (not a runtime error), it aborts the whole file at compile time and cannot be caught with `try/catch`. The RustCFML test runner resolves literal `include`s at compile time, so registering this test in `tests/runner.cfm` would abort the **entire suite** at the include line. Per the established convention for parse-level gaps (e.g. PR #83), the test file is committed but **left out of `tests/runner.cfm`** — please register it once the parse support lands. The test asserts parse-ability only (the function is defined, never called), so it needs no SMTP server.

### Why it matters for Wheels
`vendor/wheels/Global.cfc` `$mail()` emits `cfmailpart(attributeCollection=local.i){...}` and `cfmailparam(attributeCollection=local.i)` in script form. Every multipart Wheels email — the default text+html mailer output from `sendEmail()` — fails to **compile** on RustCFML. (Related runtime manifestation, not in this test: the `<cfmailpart>` *tag* form parses but is emitted as literal text into the mail body rather than recognized as a `cfmail` child — so `cfmailpart`/`cfmailparam` appear unimplemented in both script and tag forms.)

### Verification
- **RustCFML 0.161.0** (release binary): the file parse-aborts at the `cfmailpart(...)` line (`Expected RBrace, found Semicolon`).
- **Lucee 5.4.8.2** (CommandBox): the function compiles and is defined (`isCustomFunction` → true), no SMTP needed.
