### PR TITLE
test(oop): `new Comp(args)` must propagate the exception thrown by init()

### DIFF
--- a/tests/oop/NewInitThrowFixture.cfc
+++ b/tests/oop/NewInitThrowFixture.cfc
@@ -1,0 +1,17 @@
+component {
+
+    // init() guards its argument and throws on an invalid value — the classic
+    // constructor-validation pattern. A valid value returns a usable instance.
+    function init(numeric windowSeconds = 60) {
+        if (arguments.windowSeconds <= 0) {
+            throw(type = "Fixture.InvalidConfiguration", message = "windowSeconds must be > 0");
+        }
+        variables.windowSeconds = arguments.windowSeconds;
+        return this;
+    }
+
+    public numeric function getWindowSeconds() {
+        return variables.windowSeconds;
+    }
+
+}

--- a/tests/oop/test_new_constructor_init_throw.cfm
+++ b/tests/oop/test_new_constructor_init_throw.cfm
@@ -1,0 +1,41 @@
+<cfscript>
+suiteBegin("OOP: `new Comp(args)` must propagate an exception thrown by init()");
+
+// Background: the `new Component(args)` constructor sugar is defined to run
+// init(args) and return the initialized instance — and if init() throws, that
+// exception must propagate to the caller, exactly as the explicit
+// createObject("component", "X").init(args) form does. This is what makes
+// constructor-guard validation work: a CFC whose init() rejects bad arguments
+// can be trusted never to hand back a half-built object.
+//
+// RustCFML 0.161.0 runs init() under `new X(args)` but SWALLOWS any exception
+// it throws and returns the partially-initialized object instead. The explicit
+// createObject(...).init(args) path propagates the exception correctly, so the
+// divergence is specific to the `new` sugar.
+//
+//   createObject("component","F").init(windowSeconds=0)  -> throws on BOTH (CONTROL)
+//   new NewInitThrowFixture(windowSeconds=0)             -> Lucee: throws; RustCFML 0.161: NO throw (object built)
+//
+// Why it matters: Wheels uses constructor-arg validation across the framework.
+// e.g. wheels.middleware.RateLimiter init() throws Wheels.RateLimiter.
+// InvalidConfiguration when windowSeconds<=0 / maxRequests<0; middleware is
+// registered as `new wheels.middleware.RateLimiter(maxRequests=..,windowSeconds=..)`.
+// On RustCFML the guard never fires through the `new` path, so misconfiguration
+// silently yields a broken, half-initialized instance instead of failing fast.
+
+// --- CONTROL (green on both engines): explicit createObject().init() propagates ---
+assertThrows("CONTROL: createObject(...).init(windowSeconds=0) propagates the init() exception", function() {
+    var c = createObject("component", "oop.NewInitThrowFixture").init(windowSeconds = 0);
+});
+
+// --- CONTROL (green on both engines): a VALID arg builds a usable instance via `new` ---
+nitOk = new oop.NewInitThrowFixture(windowSeconds = 30);
+assert("CONTROL: `new Fixture(windowSeconds=30)` builds a usable instance", nitOk.getWindowSeconds(), 30);
+
+// --- the gap: `new Fixture(badArg)` must propagate the exception from init() ---
+assertThrows("`new NewInitThrowFixture(windowSeconds=0)` must propagate the exception thrown by init()", function() {
+    var bad = new oop.NewInitThrowFixture(windowSeconds = 0);
+});
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -207,6 +207,10 @@ try { include "oop/test_relative_component_resolution.cfm"; } catch (any e) { wr
 // Inherited-method sibling of #132: a bare CreateObject inside an inherited method must
 // resolve against the PARENT (defining) component's package, not the concrete subclass's dir.
 try { include "oop/test_inherited_bare_component_resolution.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inherited_bare_component_resolution.cfm | " & e.message & chr(10)); }
+// `new Comp(args)` must propagate an exception thrown by init() (constructor-guard
+// validation). RustCFML 0.161.0 swallows it under the `new` sugar and returns a
+// half-built object; createObject(...).init() propagates correctly.
+try { include "oop/test_new_constructor_init_throw.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_new_constructor_init_throw.cfm | " & e.message & chr(10)); }
 
 // --- Tags ---
 try { include "tags/test_tags_basic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_basic.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

The `new Component(args)` constructor sugar must run `init(args)` and, if `init()` throws, **propagate** that exception — exactly as `createObject("component","X").init(args)` does. A CFC whose `init()` rejects bad arguments can then be trusted never to hand back a half-built object.

**RustCFML 0.161.0** runs `init()` under `new X(args)` but **swallows** any exception it throws and returns the partially-initialized object. The explicit `createObject(...).init()` path propagates correctly, so the divergence is specific to the `new` sugar.

| invocation | Lucee 5.4.8.2 | RustCFML 0.161.0 |
|---|---|---|
| `createObject("component","F").init(windowSeconds=0)` | throws | throws ✅ (CONTROL) |
| `new F(windowSeconds=30)` (valid) | builds | builds ✅ (CONTROL) |
| `new F(windowSeconds=0)` (invalid) | **throws** | **no throw — object built** ❌ |

## Test

`tests/oop/test_new_constructor_init_throw.cfm` (+ `NewInitThrowFixture.cfc`), registered in `runner.cfm`. Two CONTROL assertions (green on both engines) bracket the gap assertion. On 0.161.0: **2/3 pass** — the gap assertion (`new F(0)` must throw) fails because no exception propagates.

## Why it matters

Constructor-guard validation is defeated through the `new` path. Wheels relies on it framework-wide — e.g. `wheels.middleware.RateLimiter` `init()` throws `Wheels.RateLimiter.InvalidConfiguration` on `windowSeconds<=0` / `maxRequests<0`, and middleware is registered as `new wheels.middleware.RateLimiter(maxRequests=.., windowSeconds=..)`. On RustCFML a misconfiguration silently yields a broken, half-initialized instance instead of failing fast.