### PR TITLE
test(oop): getMetadata() must not propagate a parent's displayName onto a child's leaf metadata

### DIFF
--- a/tests/oop/MetaDisplayBase.cfc
+++ b/tests/oop/MetaDisplayBase.cfc
@@ -1,0 +1,5 @@
+component displayName="MetaDisplayBaseLabel" {
+    function init() {
+        return this;
+    }
+}

--- a/tests/oop/MetaDisplayChild.cfc
+++ b/tests/oop/MetaDisplayChild.cfc
@@ -1,0 +1,6 @@
+component extends="oop.MetaDisplayBase" {
+    // Deliberately declares NO displayName attribute of its own.
+    function init() {
+        return this;
+    }
+}

--- a/tests/oop/test_getmetadata_inherited_displayname.cfm
+++ b/tests/oop/test_getmetadata_inherited_displayname.cfm
@@ -1,0 +1,40 @@
+<cfscript>
+suiteBegin("OOP: getMetadata() must not propagate a parent's displayName onto a child's leaf metadata");
+
+// Background: component attributes such as displayName are NOT inherited onto a
+// subclass's own metadata struct. getMetadata(child) reports the child's own
+// declared attributes; the parent's displayName lives on the PARENT's metadata
+// (reachable via the metadata's `extends` chain), not copied onto the leaf.
+// Lucee, Adobe CF and BoxLang all leave displayName ABSENT from a child's
+// metadata when the child declares none of its own.
+//
+// RustCFML 0.161.0 copies the parent's displayName onto the child's leaf
+// metadata, so getMetadata(child).displayName erroneously reports the parent's
+// label as if the child declared it.
+//
+//   getMetadata(new MetaDisplayBase())  -> displayName="MetaDisplayBaseLabel" on BOTH (CONTROL)
+//   getMetadata(new MetaDisplayChild()) -> Lucee: displayName ABSENT; RustCFML 0.161: present="MetaDisplayBaseLabel"
+//
+// Why it matters: framework introspection that walks getMetadata() to decide
+// behavior per concrete component (Wheels integrates controller/model mixins
+// and inspects component metadata at startup) must see the leaf's OWN
+// attributes, not silently inherited ones — an inherited attribute leaking onto
+// every subclass changes what introspection observes.
+
+mdBase  = getMetadata(new oop.MetaDisplayBase());
+mdChild = getMetadata(new oop.MetaDisplayChild());
+
+// --- CONTROL (green on both engines): the parent DOES carry its own displayName ---
+assertTrue("CONTROL: parent metadata carries its own displayName",
+    structKeyExists(mdBase, "displayName") && mdBase.displayName == "MetaDisplayBaseLabel");
+
+// --- CONTROL (green on both engines): the child's metadata still reports the inheritance link ---
+assertTrue("CONTROL: child metadata exposes its extends chain to the parent",
+    structKeyExists(mdChild, "extends"));
+
+// --- the gap: the child declares no displayName, so its leaf metadata must not have one ---
+assertFalse("child metadata must NOT carry the parent's inherited displayName",
+    structKeyExists(mdChild, "displayName"));
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -361,6 +361,9 @@ try { include "core/test_local_at_template_scope.cfm"; } catch (any e) { writeOu
 try { include "core/test_local_scope_absence_leak.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_scope_absence_leak.cfm | " & e.message & chr(10)); }
 try { include "core/test_local_arguments_scope_independence.cfm"; } catch (any e) { writeOutput("ERROR | core/test_local_arguments_scope_independence.cfm | " & e.message & chr(10)); }
 try { include "oop/test_metadata_name_value.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_metadata_name_value.cfm | " & e.message & chr(10)); }
+// A parent's displayName attribute must NOT be copied onto a child's leaf metadata.
+// RustCFML 0.161.0 propagates it; Lucee/ACF/BoxLang leave it absent on the leaf.
+try { include "oop/test_getmetadata_inherited_displayname.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_getmetadata_inherited_displayname.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_script_syntax_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_script_syntax_body.cfm | " & e.message & chr(10)); }
 try { include "functions/test_expandpath_trailing_slash.cfm"; } catch (any e) { writeOutput("ERROR | functions/test_expandpath_trailing_slash.cfm | " & e.message & chr(10)); }
 try { include "core/test_forin_member_loop_var.cfm"; } catch (any e) { writeOutput("ERROR | core/test_forin_member_loop_var.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

Component attributes such as `displayName` are **not** inherited onto a subclass's own metadata struct. `getMetadata(child)` reports the child's *declared* attributes; the parent's `displayName` lives on the parent's metadata (reachable via the metadata's `extends` chain), not copied onto the leaf. Lucee, Adobe CF and BoxLang all leave `displayName` **absent** from a child that declares none of its own.

**RustCFML 0.161.0** copies the parent's `displayName` onto the child's leaf metadata.

| call | Lucee 5.4.8.2 | RustCFML 0.161.0 |
|---|---|---|
| `getMetadata(new MetaDisplayBase())` → `displayName` | `MetaDisplayBaseLabel` | `MetaDisplayBaseLabel` ✅ (CONTROL) |
| `getMetadata(new MetaDisplayChild())` → `structKeyExists(md,"displayName")` | **false (absent)** | **true (="MetaDisplayBaseLabel")** ❌ |

## Test

`tests/oop/test_getmetadata_inherited_displayname.cfm` (+ `MetaDisplayBase.cfc` / `MetaDisplayChild.cfc`), registered in `runner.cfm`. Two CONTROL assertions (parent carries its own `displayName`; child still exposes its `extends` chain) bracket the gap assertion. On 0.161.0: **2/3 pass** — the child-leaf-must-not-carry-displayName assertion fails.

## Why it matters

Surfaced while inspecting controller metadata during package/mixin integration. Framework introspection that walks `getMetadata()` to decide behavior per concrete component (Wheels inspects component metadata at startup) must observe the leaf's **own** attributes, not silently inherited ones.