### PR TITLE
test(types): a query cell value must be a simple value (IsSimpleValue + SerializeJSON)

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -111,6 +111,10 @@ try { include "types/test_ordered_struct_literals.cfm"; } catch (any e) { writeO
 try { include "types/test_nested_writeback.cfm"; } catch (any e) { writeOutput("ERROR | types/test_nested_writeback.cfm | " & e.message & chr(10)); }
 try { include "types/test_query.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query.cfm | " & e.message & chr(10)); }
 try { include "types/test_query_column.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_column.cfm | " & e.message & chr(10)); }
+// A query cell must be a SIMPLE value: IsSimpleValue()=true and SerializeJSON of a
+// struct holding it preserves the value. RustCFML 0.161.0 returns boxed cells
+// (IsSimpleValue=false, SerializeJSON drops to null) even though PR #127 fixed numeric typing.
+try { include "types/test_query_cell_simple_value.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_cell_simple_value.cfm | " & e.message & chr(10)); }
 try { include "types/test_query_reference.cfm"; } catch (any e) { writeOutput("ERROR | types/test_query_reference.cfm | " & e.message & chr(10)); }
 try { include "types/test_binary.cfm"; } catch (any e) { writeOutput("ERROR | types/test_binary.cfm | " & e.message & chr(10)); }
 try { include "types/test_hash_in_strings.cfm"; } catch (any e) { writeOutput("ERROR | types/test_hash_in_strings.cfm | " & e.message & chr(10)); }

--- a/tests/types/test_query_cell_simple_value.cfm
+++ b/tests/types/test_query_cell_simple_value.cfm
@@ -1,0 +1,39 @@
+<cfscript>
+suiteBegin("Types: a query cell value is a simple value (IsSimpleValue + SerializeJSON)");
+
+// Background: reading a column cell from a query (q.col, or q["col"][row]) must
+// yield a SIMPLE value — IsSimpleValue() is true, and placing it into a struct/
+// array that is then SerializeJSON'd preserves the value. On Lucee/ACF/BoxLang a
+// query cell IS a simple string/number.
+//
+// RustCFML 0.161.0 returns query cells as non-simple BOXED objects:
+// IsSimpleValue(q.id) is false, and SerializeJSON({v: q.id}) renders {"v":null}
+// (the value is dropped). The value is still USABLE directly — it stringifies,
+// participates in arithmetic, and IsNumeric() is true (PR #127 fixed the numeric
+// typing) — but it is not a *simple* value, so any code that serializes a
+// structure/array built from query cells silently loses the data.
+//
+// Why it matters: this is the single root cause behind several Wheels symptoms on
+// RustCFML — renderWith(modelObject)/properties() REST output serializing as null,
+// a freshly create()'d record's .id serializing null, and association/include
+// columns nulling out in JSON. Wheels' demo app already works around it
+// (Posts.cfc copies cells through Val()/concat; model.key() JavaCasts to int).
+
+q = queryNew("id,name", "integer,varchar", [[1, "a"], [2, "b"]]);
+
+// --- CONTROL (green on both engines): the value is present and usable ---
+assert("CONTROL: q.id participates in arithmetic", q.id + 10, 11);
+assert("CONTROL: q.id stringifies to its value", q.id & "", "1");
+
+// --- the gap: a query cell must be a simple value ---
+assertTrue("IsSimpleValue(q.id) is true for an integer query column", IsSimpleValue(q.id));
+assertTrue("IsSimpleValue(q.name) is true for a varchar query column", IsSimpleValue(q.name));
+
+// --- the gap manifests in serialization: a struct holding a query cell must not serialize to null ---
+assertTrue("SerializeJSON of a struct holding q.id does not drop the value to null",
+    findNoCase("null", SerializeJSON({v: q.id})) == 0);
+assertTrue("SerializeJSON of a struct holding q.name does not drop the value to null",
+    findNoCase("null", SerializeJSON({v: q.name})) == 0);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Gap

Reading a column cell from a query (`q.col`) must yield a **simple** value: `IsSimpleValue()` is true, and placing it into a struct/array that is then `SerializeJSON`'d preserves the value. On Lucee/ACF/BoxLang a query cell is a simple string/number.

**RustCFML 0.161.0** returns query cells as non-simple **boxed** objects: `IsSimpleValue(q.id)` is false, and `SerializeJSON({v: q.id})` renders `{"v":null}` — the value is dropped on serialization. The value is still usable *directly* (it stringifies, does arithmetic, `IsNumeric()`=true after PR #127's numeric-typing fix), but it is not a *simple* value.

```cfml
q = queryNew("id,name", "integer,varchar", [[1,"a"],[2,"b"]]);   // queryNew, no datasource
```

| expression | Lucee 5.4.8.2 | RustCFML 0.161.0 |
|---|---|---|
| `q.id + 10` | `11` | `11` ✅ (CONTROL — value present) |
| `IsSimpleValue(q.id)` | `true` | **`false`** ❌ |
| `SerializeJSON({v: q.id})` | `{"V":1}` | **`{"v":null}`** ❌ |
| `SerializeJSON({v: q.name})` | `{"V":"a"}` | **`{"v":null}`** ❌ |

(Reproduces identically with a datasource-backed `queryExecute` over SQLite — stored INTEGER, `COUNT(*)`, `MAX()`, `last_insert_rowid()`.)

## Test

`tests/types/test_query_cell_simple_value.cfm`, registered in `runner.cfm`. Two CONTROL assertions (value participates in arithmetic / stringifies) bracket four gap assertions. On 0.161.0: **2/6 pass**.

## Why it matters

This is the single root cause behind several Wheels symptoms on RustCFML — `renderWith(modelObject)`/`properties()` REST output serializing null, a freshly `create()`'d record's `.id` serializing null, association/include columns nulling out in JSON. Distinct from #127 (which fixed numeric *typing*); this is the remaining boxed-ness on the `IsSimpleValue`/`SerializeJSON` surface.