### PR TITLE
test(oop): cfinvoke method=<name> must dispatch an unknown method to onMissingMethod

### DIFF
--- a/tests/oop/CfInvokeOmmTarget.cfc
+++ b/tests/oop/CfInvokeOmmTarget.cfc
@@ -1,0 +1,8 @@
+component {
+    public string function doSomething() {
+        return "did-something";
+    }
+    public any function onMissingMethod(required string missingMethodName, struct missingMethodArguments = {}) {
+        return "omm:" & arguments.missingMethodName;
+    }
+}

--- a/tests/oop/test_cfinvoke_onmissingmethod.cfm
+++ b/tests/oop/test_cfinvoke_onmissingmethod.cfm
@@ -1,0 +1,45 @@
+<cfscript>
+suiteBegin("OOP: cfinvoke method=<name> dispatches an unknown method to onMissingMethod");
+
+// Background: invoking a method by name via cfinvoke must follow the same dispatch
+// rules as a direct call — if the named method is not declared on the component but
+// the component defines onMissingMethod(), cfinvoke must route through it. Lucee,
+// Adobe CF and BoxLang all dispatch an unknown cfinvoke target to onMissingMethod.
+//
+// RustCFML 0.161.0 throws "Method '<name>' not found in component" from cfinvoke
+// for an undeclared method, even though a DIRECT dot-call to the same undeclared
+// method on the same object correctly routes through onMissingMethod.
+//
+//   obj.deleteAllWidgets()                                  -> onMissingMethod on BOTH (CONTROL)
+//   cfinvoke(component=obj, method="deleteAllWidgets", ...) -> Lucee: onMissingMethod; RustCFML 0.161: THROWS
+//
+// Why it matters: Wheels dispatches association cascade methods by name via cfinvoke.
+// hasMany(dependent="delete"|"deleteAll"|"removeAll") builds a "deleteAll<assoc>"/
+// "removeAll<assoc>" method name and invokes it through $invoke()'s cfinvoke
+// (Global.cfc), which lands in the model's onMissingMethod. On RustCFML the whole
+// parent .delete() throws ("Method 'deleteAllcomments' not found") — the parent is
+// not deleted and children are not cascaded — confirmed on the demo blog's own
+// Post hasMany Comment dependent="delete".
+
+obj = createObject("component", "oop.CfInvokeOmmTarget");
+
+// --- CONTROL (green on both engines): cfinvoke to a DECLARED method works ---
+cfinvoke(component = obj, method = "doSomething", returnVariable = "declaredResult");
+assert("CONTROL: cfinvoke to a declared method returns its value", declaredResult, "did-something");
+
+// --- CONTROL (green on both engines): a dot-call to an UNDECLARED method routes to onMissingMethod ---
+assert("CONTROL: dot-call to an undeclared method routes through onMissingMethod",
+    obj.deleteAllWidgets(), "omm:deleteAllWidgets");
+
+// --- the gap: cfinvoke to an UNDECLARED method must ALSO route through onMissingMethod ---
+ivResult = "(threw)";
+try {
+    cfinvoke(component = obj, method = "deleteAllWidgets", returnVariable = "ivResult");
+} catch (any e) {
+    ivResult = "THREW: " & e.message;
+}
+assert("cfinvoke to an undeclared method routes through onMissingMethod (does not throw)",
+    ivResult, "omm:deleteAllWidgets");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -207,6 +207,10 @@ try { include "oop/test_relative_component_resolution.cfm"; } catch (any e) { wr
 // Inherited-method sibling of #132: a bare CreateObject inside an inherited method must
 // resolve against the PARENT (defining) component's package, not the concrete subclass's dir.
 try { include "oop/test_inherited_bare_component_resolution.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_inherited_bare_component_resolution.cfm | " & e.message & chr(10)); }
+// cfinvoke method="<name>" must dispatch an unknown method to onMissingMethod (as a
+// direct dot-call does). RustCFML 0.161.0 throws "Method not found"; breaks Wheels
+// hasMany dependent=delete/deleteAll/removeAll cascade (deleteAll<assoc> via cfinvoke).
+try { include "oop/test_cfinvoke_onmissingmethod.cfm"; } catch (any e) { writeOutput("ERROR | oop/test_cfinvoke_onmissingmethod.cfm | " & e.message & chr(10)); }
 
 // --- Tags ---
 try { include "tags/test_tags_basic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_basic.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

Invoking a method by name via `cfinvoke` must follow the same dispatch rules as a direct call: if the named method is not declared but the component defines `onMissingMethod()`, `cfinvoke` must route through it. Lucee/ACF/BoxLang all do.

**RustCFML 0.161.0** throws `Method '<name>' not found in component` from `cfinvoke` for an undeclared method — even though a **direct dot-call** to the same undeclared method on the same object correctly routes through `onMissingMethod`.

| invocation | Lucee 5.4.8.2 | RustCFML 0.161.0 |
|---|---|---|
| `cfinvoke(component=obj, method="doSomething")` (declared) | `did-something` | `did-something` ✅ (CONTROL) |
| `obj.deleteAllWidgets()` (undeclared, dot-call) | `omm:deleteAllWidgets` | `omm:deleteAllWidgets` ✅ (CONTROL) |
| `cfinvoke(component=obj, method="deleteAllWidgets")` (undeclared) | `omm:deleteAllWidgets` | **throws "Method not found"** ❌ |

## Test

`tests/oop/test_cfinvoke_onmissingmethod.cfm` (+ `CfInvokeOmmTarget.cfc`), registered in `runner.cfm`. Two CONTROL assertions (declared cfinvoke works; dot-call routes to onMissingMethod) bracket the gap assertion. On 0.161.0: **2/3 pass**.

## Why it matters

Wheels dispatches association cascade methods **by name via cfinvoke**. `hasMany(dependent="delete"|"deleteAll"|"removeAll")` builds a `deleteAll<assoc>`/`removeAll<assoc>` method name and invokes it through `$invoke()`'s `cfinvoke` (`Global.cfc`), landing in the model's `onMissingMethod`. On RustCFML the whole parent `.delete()` throws (`Method 'deleteAllcomments' not found`) — the parent is not deleted and children are not cascaded — confirmed on the demo blog's own `Post hasMany Comment dependent="delete"`. Distinct from #126 (argumentCollection numeric-key marshaling) and #129 (onMissingMethod argument key names).