### PR TITLE
test(core): a named exclusive lock must be reentrant within the same request/thread

### DIFF
--- a/tests/core/test_named_lock_reentrant.cfm
+++ b/tests/core/test_named_lock_reentrant.cfm
@@ -1,0 +1,41 @@
+<cfscript>
+suiteBegin("Concurrency: a named exclusive lock is reentrant within the same request/thread");
+
+// Background: a thread that already holds an exclusive named lock must be able to
+// re-acquire the SAME named lock without blocking — named locks are reentrant per
+// thread. Lucee/ACF/BoxLang all let the inner block run immediately.
+//
+// RustCFML 0.161.0 is NOT reentrant: the inner re-acquire of an already-held named
+// lock blocks until the timeout elapses and then throws a lock-timeout error. The
+// inner block never runs.
+//
+//   lock name="x" { lock name="x" { ... } }   -> Lucee: inner runs; RustCFML 0.161: inner times out + throws
+//
+// Why it matters: same-name re-entry is a normal CFML pattern (a locked section
+// calling a helper that locks the same name). On RustCFML it self-deadlocks until
+// the timeout, surfacing as request hangs/errors.
+
+lockTrace = "OUTER_BEFORE ";
+lockErr = "";
+try {
+    lock name="reentLockTest" timeout="1" type="exclusive" {
+        lockTrace &= "OUTER_IN ";
+        lock name="reentLockTest" timeout="1" type="exclusive" {
+            lockTrace &= "INNER_IN ";
+        }
+        lockTrace &= "OUTER_AFTER";
+    }
+} catch (any e) {
+    lockErr = e.message;
+}
+
+// --- CONTROL (green on both engines): the outer lock body executes ---
+assertTrue("outer lock body executes", findNoCase("OUTER_IN", lockTrace) GT 0);
+
+// --- the gap: the inner re-acquire of the same named lock must succeed (reentrant) ---
+assertTrue("inner re-acquire of the same named lock succeeds (reentrant)",
+    findNoCase("INNER_IN", lockTrace) GT 0);
+assert("no lock-timeout error on re-entry", lockErr, "");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -19,6 +19,10 @@ try { include "core/test_bare_call_caller_stack_leak.cfm"; } catch (any e) { wri
 try { include "core/test_null_return_no_key.cfm"; } catch (any e) { writeOutput("ERROR | core/test_null_return_no_key.cfm | " & e.message & chr(10)); }
 try { include "core/test_bare_call_shadowing_semantics.cfm"; } catch (any e) { writeOutput("ERROR | core/test_bare_call_shadowing_semantics.cfm | " & e.message & chr(10)); }
 try { include "core/test_closure_env_leak.cfm"; } catch (any e) { writeOutput("ERROR | core/test_closure_env_leak.cfm | " & e.message & chr(10)); }
+// A named exclusive lock must be reentrant within the same thread: re-acquiring an
+// already-held named lock must not block. RustCFML 0.161.0 self-deadlocks (inner
+// re-acquire times out + throws), surfacing as request hangs.
+try { include "core/test_named_lock_reentrant.cfm"; } catch (any e) { writeOutput("ERROR | core/test_named_lock_reentrant.cfm | " & e.message & chr(10)); }
 try { include "core/test_compound_assignment.cfm"; } catch (any e) { writeOutput("ERROR | core/test_compound_assignment.cfm | " & e.message & chr(10)); }
 try { include "core/test_undeclared_named_args.cfm"; } catch (any e) { writeOutput("ERROR | core/test_undeclared_named_args.cfm | " & e.message & chr(10)); }
 //   - invoke_undeclared_keys: the argument struct of the positional BIF


### PR DESCRIPTION
## Gap

A thread that already holds an exclusive named lock must be able to re-acquire the **same** named lock without blocking — named locks are reentrant per thread. Lucee/ACF/BoxLang all let the inner block run immediately.

**RustCFML 0.161.0** is **not** reentrant: the inner re-acquire of an already-held named lock blocks until the timeout elapses, then throws a lock-timeout error. The inner block never runs.

```cfml
lock name="x" timeout="1" type="exclusive" {
    lock name="x" timeout="1" type="exclusive" { /* inner */ }
}
```

| | Lucee 5.4.8.2 | RustCFML 0.161.0 |
|---|---|---|
| outer block runs | yes | yes ✅ (CONTROL) |
| inner re-acquire | runs immediately | **times out after 1s, throws `cflock timeout`** ❌ |

## Test

`tests/core/test_named_lock_reentrant.cfm`, registered in `runner.cfm` (1s timeout to bound the failure). One CONTROL assertion (outer body runs) + two gap assertions. On 0.161.0: **1/3 pass**.

## Why it matters

Same-name re-entry is a normal CFML pattern — a locked section calling a helper that locks the same name. On RustCFML it self-deadlocks until the timeout, surfacing as request hangs/errors.