### PR TITLE
RED test: Application.cfc instantiation forms a self-reference Arc cycle (per-request leak)

### DIFF
--- a/crates/cfml-vm/tests/component_no_self_cycle.rs
+++ b/crates/cfml-vm/tests/component_no_self_cycle.rs
@@ -1,0 +1,128 @@
+//! Regression coverage for the per-request Application.cfc reference-cycle leak.
+//!
+//! When an Application.cfc is loaded, its component instance is visible in its
+//! own body locals under the component's (often auto-generated, e.g.
+//! "Anonymous") name. The VM stores the component body's data variables back
+//! ON the template as `__variables`. If that self-alias is copied into
+//! `__variables`, the template ends up owning a pointer to itself
+//! (`template → __variables → <self-alias> → template`): an `Arc` reference
+//! cycle that is never freed when the per-request VM drops. Under serve mode
+//! that is a steady per-request heap leak (every request re-instantiates
+//! Application.cfc), confirmed via a dhat heap profile that attributed ~16
+//! still-live blocks per request to `load_application_cfc`.
+//!
+//! `load_application_cfc` now skips any body local that aliases the component
+//! itself when building `__variables`. This test asserts the loaded component
+//! graph contains no reference cycle.
+
+use cfml_codegen::{compiler::CfmlCompiler, BytecodeProgram};
+use cfml_common::dynamic::CfmlValue;
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlVirtualMachine, ServerState};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+fn fixture() -> HashMap<String, Vec<u8>> {
+    let mut files = HashMap::new();
+    files.insert(
+        "Application.cfc".to_string(),
+        include_str!("../../../tests/lifecycle/component_no_self_cycle/Application.cfc")
+            .as_bytes()
+            .to_vec(),
+    );
+    files.insert(
+        "index.cfm".to_string(),
+        include_str!("../../../tests/lifecycle/component_no_self_cycle/index.cfm")
+            .as_bytes()
+            .to_vec(),
+    );
+    files
+}
+
+fn compile_page(vfs: &Arc<dyn Vfs>, path: &str) -> BytecodeProgram {
+    let source = vfs.read_to_string(path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    CfmlCompiler::new().compile(ast)
+}
+
+/// Depth-first walk that reports `true` if any struct/array reachable from `v`
+/// is revisited while still ON the current recursion path — i.e. a genuine
+/// reference cycle. Struct identity is the backing-store pointer.
+fn has_cycle(v: &CfmlValue, on_path: &mut Vec<usize>) -> bool {
+    match v {
+        CfmlValue::Struct(s) => {
+            let p = s.backing_ptr();
+            if on_path.contains(&p) {
+                return true;
+            }
+            on_path.push(p);
+            let cyclic = s.snapshot().into_iter().any(|(_, val)| has_cycle(&val, on_path));
+            on_path.pop();
+            cyclic
+        }
+        CfmlValue::Array(a) => a.iter().any(|val| has_cycle(&val, on_path)),
+        _ => false,
+    }
+}
+
+#[test]
+fn application_cfc_instance_has_no_self_reference_cycle() {
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(fixture(), VROOT.to_string()));
+    let page_path = format!("{}/index.cfm", VROOT);
+    let program = compile_page(&vfs, &page_path);
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+    vm.globals
+        .entry("url".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("cgi".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.globals
+        .entry("form".to_string())
+        .or_insert_with(|| CfmlValue::strukt(IndexMap::new()));
+    vm.server_state = Some(ServerState::with_production(false));
+
+    vm.execute_with_lifecycle().unwrap();
+    assert_eq!("ok", vm.output_buffer.trim());
+
+    // The instantiated Application.cfc component is left in `globals` (under its
+    // name or the auto-generated "Anonymous" key) as a Struct carrying __name.
+    // Locate it and assert its object graph contains no reference cycle.
+    let component = vm
+        .globals
+        .iter()
+        .find(|(_, v)| match v {
+            CfmlValue::Struct(s) => s.snapshot().iter().any(|(k, _)| k == "__name"),
+            _ => false,
+        })
+        .map(|(_, v)| v.clone())
+        .expect("Application.cfc component should be present in globals after load");
+
+    let mut on_path = Vec::new();
+    assert!(
+        !has_cycle(&component, &mut on_path),
+        "loaded Application.cfc component must not contain a reference cycle \
+         (regression: the component's self-alias was copied into __variables, \
+         forming template → __variables → self and leaking the instance every request)"
+    );
+}

--- a/tests/lifecycle/component_no_self_cycle/Application.cfc
+++ b/tests/lifecycle/component_no_self_cycle/Application.cfc
@@ -1,0 +1,4 @@
+component {
+    this.name = "component-no-self-cycle-test";
+    this.sessionManagement = false;
+}

--- a/tests/lifecycle/component_no_self_cycle/index.cfm
+++ b/tests/lifecycle/component_no_self_cycle/index.cfm
@@ -1,0 +1,1 @@
+<cfoutput>ok</cfoutput>


### PR DESCRIPTION
## Summary

Under sustained load, a RustCFML serve-mode process leaks memory linearly with no plateau and almost no release on idle. We traced it to a **per-request `Arc` reference cycle** created when `Application.cfc` is instantiated: the component owns a pointer to itself, so the entire per-request component instance is never freed.

This PR adds a **RED regression test** that asserts the loaded `Application.cfc` component graph contains no reference cycle. It fails on `v0.182.0` and passes once the cycle is broken (suggested fix below).

## Symptom

`hub` serve process, in-memory sessions, hammered across normal nav pages:

```
~24 MiB cold  ->  ~233 MiB after ~21,000 requests   (linear, no plateau, ~2 MiB released on idle)
```

Reproduces with a **methodless bare `component {}` Application.cfc** and a trivial `<cfoutput>ok</cfoutput>` page — independent of JIT, sessions, DB, and `--production`. Static (non-CFML) asset requests do **not** leak; only requests that run the CFML lifecycle do.

## Root cause

In `load_application_cfc`, after running the pseudo-constructor, the component body's data variables are stored back ON the template as `__variables` (so `variables.*` is visible to methods). The component instance is itself visible in its own body locals under its (auto-generated) name `"Anonymous"`. That self-alias gets copied into `__variables`:

```
template (Struct)
  └─ "__variables" (Struct)
        └─ "Anonymous" ──▶ template      ← back-edge: Arc cycle
```

The cycle keeps the whole instance alive after the per-request VM drops. Every request re-instantiates `Application.cfc`, so every request leaks one component instance (+ its `__variables`/strings).

## dhat evidence

dhat heap profile, 4,000 requests of the trivial page, `bytes/blocks live at process end`:

```
At t-end (pre-fix):  4,267,509 bytes in 64,098 blocks   (~16 blocks / ~1 KB per request)
```

Ranking allocation points by bytes-live-at-end, **every** top site shares the stack:

```
CfmlStruct::new / CfmlValue::string / IndexMap::insert
  └─ execute_function_with_args
       └─ load_application_cfc            (crates/cfml-vm/src/lib.rs)
            └─ execute_with_lifecycle
                 └─ compile_and_run        (per HTTP request)
```

A backing-pointer cycle walk of the loaded component confirms the back-edge:

```
template keys = ["__name","name","sessionManagement","setClientCookies","__variables"]
CYCLE via struct 0x… at path: <template>.__variables.Anonymous
```

## This PR (test only)

`crates/cfml-vm/tests/component_no_self_cycle.rs` loads an `Application.cfc`, runs the lifecycle, locates the component in `globals`, and asserts its object graph has no reference cycle (DFS over `backing_ptr` on the recursion path). **RED on `v0.182.0`.**

## Suggested fix (verified locally — not included in this PR)

Skip body locals that alias the component itself when building `__variables`:

```rust
// in load_application_cfc, where __variables is built from component_variables
let self_ptr = template.as_cfml_struct().map(|s| s.backing_ptr());
// … inside the per-key loop, after the this/arguments/__/Function skips:
if let (Some(sp), CfmlValue::Struct(vs)) = (self_ptr, v) {
    if vs.backing_ptr() == sp {
        continue; // self-reference — would form a cycle
    }
}
```

With this applied locally:

- dhat blocks-live-at-end via `load_application_cfc`: **64,098 → 0**.
- End-to-end RSS over 16,000 requests on a real app: pre-fix climbs 132→208 MiB with no plateau; post-fix **plateaus and releases on idle**.
- The new test goes GREEN; `cfml-vm` lib (101) + component/Application.cfc/session/xreq integration tests all still pass.

(Happy to adjust the guard — e.g. broaden to any self-aliasing value, not just `Struct` — however you prefer to land it.)
