### PR TITLE
RED test: cfexit method="exittag" must stop custom tag execution

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -252,6 +252,7 @@ try { include "tags/test_tags_misc.cfm"; } catch (any e) { writeOutput("ERROR | 
 try { include "tags/test_tags_customtag.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_customtag.cfm | " & e.message & chr(10)); }
 try { include "tags/test_custom_tag_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_custom_tag_attribute_collection.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_customtag_lifecycle.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_customtag_lifecycle.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tags_cfexit.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfexit.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_buffer_recovery.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_buffer_recovery.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfexecute.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfexecute.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfmail.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfmail.cfm | " & e.message & chr(10)); }

--- a/tests/tags/ltcfexit.cfm
+++ b/tests/tags/ltcfexit.cfm
@@ -1,0 +1,10 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfset caller[attributes.outVar] = caller[attributes.outVar] & "[start]">
+    <cfexit method="exittag">
+    <cfset caller[attributes.outVar] = caller[attributes.outVar] & "[after-start]">
+</cfif>
+
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.outVar] = caller[attributes.outVar] & "[end:" & trim(thisTag.generatedContent) & "]">
+    <cfset thisTag.generatedContent = "">
+</cfif>

--- a/tests/tags/test_tags_cfexit.cfm
+++ b/tests/tags/test_tags_cfexit.cfm
@@ -1,0 +1,20 @@
+<cfscript>suiteBegin("Tags: cfexit");</cfscript>
+
+<cfset ltExitOut = "">
+<cfset ltExitLog = "">
+<cfset ltExitError = "">
+
+<cftry>
+    <cfsavecontent variable="ltExitOut"><cf_ltcfexit outVar="ltExitLog">BODY</cf_ltcfexit></cfsavecontent>
+    <cfcatch type="any">
+        <cfset ltExitError = cfcatch.message>
+    </cfcatch>
+</cftry>
+
+<cfscript>
+    assert('cfexit method="exittag" does not throw', ltExitError, "");
+    assert('start-phase cfexit method="exittag" skips caller body output', trim(ltExitOut), "");
+    assert('start-phase cfexit method="exittag" skips remaining tag code and end phase', ltExitLog, "[start]");
+</cfscript>
+
+<cfscript>suiteEnd();</cfscript>


### PR DESCRIPTION
## What

Adds a CFML regression test for `<cfexit method="exittag">` inside the start phase of a body custom tag.

The fixture records that the custom tag start phase began, calls `cfexit method="exittag"`, then has code after the `cfexit` and an end-phase branch that should not run. The caller wraps the custom tag in `cfsavecontent` and asserts:

- `cfexit method="exittag"` does not throw
- the caller body content is not emitted
- code after `cfexit` and the custom tag end phase are skipped

## Why

Lucee supports this shape and Moopa uses it in custom tags that intentionally exit early, for example one-time include/dedupe tags. On RustCFML v0.182.0 the tag parser rejects `<cfexit>` outright, which means otherwise-valid Lucee/Moopa code either 500s or needs engine-specific shims.

This is one of the compatibility gaps hit while booting the `hello` Moopa app on RustCFML: we do not want the app/framework to carry separate Lucee-vs-RustCFML code paths for valid CFML behavior.

## Evidence

RustCFML v0.182.0 with this test is RED:

```
FAIL | Tags: cfexit | 1/3 passed (2 failed)
       FAIL: cfexit method="exittag" does not throw | expected: [] | got: [Tag <cfexit> is not implemented.]
       FAIL: start-phase cfexit method="exittag" skips remaining tag code and end phase | expected: [[start]] | got: []
SUMMARY: 3955/3957 passed across 485 suites
FAILED:  2 assertion(s) in 1 suite(s)
```

The target suite is GREEN on Lucee 7.0.2.106 using the same checkout mounted into `lucee/lucee:7.0.2.106`:

```
PASS | Tags: cfexit | 3/3 passed
```

(The full RustCFML runner is expectedly RED only for this new suite. The full Lucee runner has unrelated RustCFML-harness-specific failures, so the relevant signal is the targeted `Tags: cfexit` suite.)

## Where the fix likely goes

This probably needs both parser and custom-tag control-flow support, not only a builtin stub. The tag preprocessor currently emits body custom tags as:

```rust
__cfcustomtag_start(path, attrs);
body_script
__cfcustomtag_end();
```

For start-phase `cfexit method="exittag"`, RustCFML needs to stop the current custom tag and prevent the caller body / end phase from running. That likely means adding `cfexit` parsing plus a VM sentinel/state that `__cfcustomtag_start` can surface to the generated wrapper so the body/end calls are skipped.

This PR is test-only so the desired Lucee behavior is pinned before choosing that implementation shape.
