### PR TITLE
RED test: cfhtmlhead/cfhtmlbody tags must parse and execute

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -252,6 +252,7 @@ try { include "tags/test_tags_misc.cfm"; } catch (any e) { writeOutput("ERROR | 
 try { include "tags/test_tags_customtag.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_customtag.cfm | " & e.message & chr(10)); }
 try { include "tags/test_custom_tag_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_custom_tag_attribute_collection.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_customtag_lifecycle.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_customtag_lifecycle.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tags_cfhtmlhead_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhtmlhead_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_buffer_recovery.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_buffer_recovery.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfexecute.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfexecute.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfmail.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfmail.cfm | " & e.message & chr(10)); }

--- a/tests/tags/lthtmlinjection.cfm
+++ b/tests/tags/lthtmlinjection.cfm
@@ -1,0 +1,5 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfhtmlhead text='<meta name="x-rustcfml-head" content="head-value">'>
+    <cfhtmlbody text='<script id="x-rustcfml-body">window.__rustcfmlBody = true;</script>'>
+    <cfset caller[attributes.outVar] = "ran">
+</cfif>

--- a/tests/tags/test_tags_cfhtmlhead_body.cfm
+++ b/tests/tags/test_tags_cfhtmlhead_body.cfm
@@ -1,0 +1,18 @@
+<cfscript>suiteBegin("Tags: cfhtmlhead / cfhtmlbody");</cfscript>
+
+<cfset htmlInjectionMarker = "">
+<cfset htmlInjectionError = "">
+
+<cftry>
+    <cf_lthtmlinjection outVar="htmlInjectionMarker" />
+    <cfcatch type="any">
+        <cfset htmlInjectionError = cfcatch.message>
+    </cfcatch>
+</cftry>
+
+<cfscript>
+    assert("cfhtmlhead/cfhtmlbody do not throw", htmlInjectionError, "");
+    assert("cfhtmlhead/cfhtmlbody continue executing the current template", htmlInjectionMarker, "ran");
+</cfscript>
+
+<cfscript>suiteEnd();</cfscript>


### PR DESCRIPTION
## What

Adds a CFML regression test for `<cfhtmlhead>` and `<cfhtmlbody>`. The test runs both tags from a custom-tag fixture and asserts they do not throw and that execution continues after the tags.

## Why

Lucee supports these tags for injecting content into the response `<head>` and body. Moopa uses them in its `cf_once` tag so route-local scripts/styles can be rendered once while still landing in the correct document region.

While booting the `hello` Moopa app on RustCFML, these tags were missing and had to be worked around locally by replacing `cfhtmlhead`/`cfhtmlbody` with a request queue plus explicit layout flush tags. That is exactly the kind of Lucee-vs-RustCFML fork we want to avoid in the app/framework.

## Evidence

RustCFML v0.182.0 with this test is RED:

```
FAIL | Tags: cfhtmlhead / cfhtmlbody | 0/2 passed (2 failed)
       FAIL: cfhtmlhead/cfhtmlbody do not throw | expected: [] | got: [Tag <cfhtmlhead> is not implemented.]
       FAIL: cfhtmlhead/cfhtmlbody continue executing the current template | expected: [ran] | got: []
SUMMARY: 3954/3956 passed across 485 suites
FAILED:  2 assertion(s) in 1 suite(s)
```

The target suite is GREEN on Lucee 7.0.2.106 using the same checkout mounted into `lucee/lucee:7.0.2.106`:

```
PASS | Tags: cfhtmlhead / cfhtmlbody | 2/2 passed
```

(The full Lucee runner has unrelated RustCFML-harness-specific failures; this PR only relies on the targeted suite result.)

## Scope

This PR intentionally pins the first compatibility contract: the tags are accepted and template execution continues. Lucee injects the actual head/body output into the HTTP response stream outside local `cfsavecontent`, so deeper placement assertions likely belong in a follow-up serve-mode/HTTP test once the basic tags exist.

## Where the fix likely goes

The tag parser currently rejects `<cfhtmlhead>` before execution. A fix likely needs parser arms for `cfhtmlhead` / `cfhtmlbody` and VM/request-output plumbing for queued head/body injection in serve mode.

This PR is test-only so the basic Lucee-compatible behavior is pinned first.
