### PR TITLE
RED test: cfsleep tag must parse and execute

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -249,6 +249,7 @@ try { include "tags/test_tags_param.cfm"; } catch (any e) { writeOutput("ERROR |
 try { include "tags/test_tags_param_dynamic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_param_dynamic.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfoutput_query.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfoutput_query.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_misc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_misc.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tags_cfsleep.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfsleep.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_customtag.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_customtag.cfm | " & e.message & chr(10)); }
 try { include "tags/test_custom_tag_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_custom_tag_attribute_collection.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_customtag_lifecycle.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_customtag_lifecycle.cfm | " & e.message & chr(10)); }

--- a/tests/tags/ltsleep.cfm
+++ b/tests/tags/ltsleep.cfm
@@ -1,0 +1,4 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfsleep time="#attributes.time#">
+    <cfset caller[attributes.outVar] = "slept">
+</cfif>

--- a/tests/tags/test_tags_cfsleep.cfm
+++ b/tests/tags/test_tags_cfsleep.cfm
@@ -1,0 +1,18 @@
+<cfscript>suiteBegin("Tags: cfsleep");</cfscript>
+
+<cfset sleepMarker = "">
+<cfset sleepError = "">
+
+<cftry>
+    <cf_ltsleep time="1" outVar="sleepMarker" />
+    <cfcatch type="any">
+        <cfset sleepError = cfcatch.message>
+    </cfcatch>
+</cftry>
+
+<cfscript>
+    assert("cfsleep does not throw", sleepError, "");
+    assert("cfsleep continues executing the current template", sleepMarker, "slept");
+</cfscript>
+
+<cfscript>suiteEnd();</cfscript>


### PR DESCRIPTION
## What

Adds a CFML regression test for `<cfsleep>`. The test runs `cfsleep time="#attributes.time#"` from a custom-tag fixture and asserts it does not throw and execution continues afterward.

## Why

Lucee supports `<cfsleep>` with a millisecond `time` attribute. Moopa uses it during `/init` to briefly let in-flight requests drain before `applicationStop()` in production.

While booting the `hello` Moopa app on RustCFML, `<cfsleep>` was missing and the framework delay had to be removed locally. That should not become an app/framework fork for valid Lucee CFML.

## Evidence

RustCFML v0.182.0 with this test is RED:

```
FAIL | Tags: cfsleep | 0/2 passed (2 failed)
       FAIL: cfsleep does not throw | expected: [] | got: [Tag <cfsleep> is not implemented.]
       FAIL: cfsleep continues executing the current template | expected: [slept] | got: []
SUMMARY: 3954/3956 passed across 485 suites
FAILED:  2 assertion(s) in 1 suite(s)
```

The target suite is GREEN on Lucee 7.0.2.106 using the same checkout mounted into `lucee/lucee:7.0.2.106`:

```
PASS | Tags: cfsleep | 2/2 passed
```

(The full Lucee runner has unrelated RustCFML-harness-specific failures; this PR only relies on the targeted suite result.)

## Where the fix likely goes

The tag parser currently rejects `<cfsleep>` before execution. A fix likely needs a parser arm that evaluates the `time` attribute at runtime and a VM/builtin implementation that sleeps for the requested milliseconds.

This PR is test-only so the basic Lucee-compatible behavior is pinned first.
