### PR TITLE
RED test: cfset expression bodies ignore CFML comments

### DIFF
--- a/tests/comments/test_cfset_expression_comments.cfm
+++ b/tests/comments/test_cfset_expression_comments.cfm
@@ -1,0 +1,17 @@
+<cfscript>
+suiteBegin("Comments: cfset expression comments");
+</cfscript>
+
+<cfset records = [
+	{ name: "before" },
+	<!--- Lucee ignores CFML comments inside tag-mode expression bodies. --->
+	{ name: "after" }
+] />
+
+<cfscript>
+assert("cfset expression comments are ignored inside array literals",
+	records[2].name,
+	"after");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -119,6 +119,7 @@ try { include "types/test_binary.cfm"; } catch (any e) { writeOutput("ERROR | ty
 try { include "types/test_hash_in_strings.cfm"; } catch (any e) { writeOutput("ERROR | types/test_hash_in_strings.cfm | " & e.message & chr(10)); }
 try { include "comments/test_hash_in_comments.cfm"; } catch (any e) { writeOutput("ERROR | comments/test_hash_in_comments.cfm | " & e.message & chr(10)); }
 try { include "comments/test_tags_in_block_comments.cfm"; } catch (any e) { writeOutput("ERROR | comments/test_tags_in_block_comments.cfm | " & e.message & chr(10)); }
+try { include "comments/test_cfset_expression_comments.cfm"; } catch (any e) { writeOutput("ERROR | comments/test_cfset_expression_comments.cfm | " & e.message & chr(10)); }
 
 // --- Standard Library ---
 try { include "stdlib/test_string_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_string_functions.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## What

Adds a CFML runner test for CFML comments inside a tag-mode `<cfset>` expression body.

## Why

Lucee ignores `<!--- ... --->` comments embedded inside multi-line expression literals. RustCFML currently leaves the comment marker in the generated expression, so array/struct literals fail to parse. This surfaced while loading a Moopa table definition with section comments inside an array literal.

## Validation

- RustCFML v0.189.0 red test:
  - `Parse error ... Expected RBracket, found Bang`
- Lucee validation not run locally because CommandBox is not installed in this environment.
