### PR TITLE
RED test: cfloop list literal attributes stay strings

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -241,6 +241,7 @@ try { include "oop/test_inherited_bare_component_via_child_method.cfm"; } catch 
 // --- Tags ---
 try { include "tags/test_tags_basic.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_basic.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_control.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_control.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cfloop_list_literal.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfloop_list_literal.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_include.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_include.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfinclude_css.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfinclude_css.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cffunction_hoisting.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cffunction_hoisting.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_cfloop_list_literal.cfm
+++ b/tests/tags/test_cfloop_list_literal.cfm
@@ -1,0 +1,17 @@
+<cfscript>
+suiteBegin("Tags: cfloop list literal");
+
+seen = [];
+</cfscript>
+
+<cfloop list="yyyy-MM-dd HH:mm:ss,yyyy-MM-ddTHH:mm:ss,plain" index="pattern">
+	<cfset arrayAppend(seen, pattern) />
+</cfloop>
+
+<cfscript>
+assert("cfloop list literal is passed to listToArray as a string",
+	arrayToList(seen, "|"),
+	"yyyy-MM-dd HH:mm:ss|yyyy-MM-ddTHH:mm:ss|plain");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a CFML runner test for tag-mode `<cfloop list="literal" index="...">`.

## Why

Lucee treats the `list` attribute as a literal string. RustCFML currently converts the literal directly into `listToArray(...)` without quoting it, so values such as date masks (`yyyy-MM-dd HH:mm:ss`) become identifiers/operators and fail to parse. This surfaced in a Moopa REAXML importer date-pattern loop.

## Validation

- RustCFML v0.189.0 red test:
  - `Parse error ... Expected RParen, found Identifier("HH")`
- Lucee validation not run locally because CommandBox is not installed in this environment.
