### PR TITLE
RED test: imp is a soft keyword in expression contexts

### DIFF
--- a/tests/core/test_reserved_word_identifiers.cfm
+++ b/tests/core/test_reserved_word_identifiers.cfm
@@ -35,5 +35,15 @@ bareNames = function(string extends = "", string implements = "") {
 };
 assert("`extends`/`implements` resolve as bare parameter references", bareNames("x", "y"), "x/y");
 
+// `imp` is legal as an ordinary local variable name on Lucee. It appears in
+// short-lived impersonation-context locals (for example, `var imp = ...`) and
+// must not be tokenized as a hard keyword in expression contexts.
+function impIdentifierProbe() {
+	var imp = "ok";
+	return imp;
+}
+
+assert("`imp` is usable as a local variable name", impIdentifierProbe(), "ok");
+
 suiteEnd();
 </cfscript>


### PR DESCRIPTION
## What

Adds a CFML runner test proving `imp` is usable as an ordinary local variable name.

## Why

Lucee treats `imp` as an identifier in expression contexts. RustCFML currently tokenizes it as `ImpKeyword`, so code like `var imp = application.lib.auth.getImpersonatorContext()` fails to parse. This surfaced while booting Moopa routes that keep impersonation context in a short `imp` local.

## Validation

- RustCFML v0.189.0 red test:
  - `Parse error ... Expected identifier (found ImpKeyword)`
- Lucee validation not run locally because CommandBox is not installed in this environment.
