### PR TITLE
RED test: escaped hash tag attributes stay literal

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -305,6 +305,7 @@ try { include "tags/test_tag_attribute_interpolation_sweep.cfm"; } catch (any e)
 try { include "tags/test_tags_cfhttpparam_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfhttpparam_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_string_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_string_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tag_attribute_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_attribute_interpolation.cfm | " & e.message & chr(10)); }
+try { include "tags/test_tag_attribute_escaped_hash.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tag_attribute_escaped_hash.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cffinally_tag_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cffinally_tag_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cflog_cfmail_attribute_interpolation.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cflog_cfmail_attribute_interpolation.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfzip.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfzip.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_tag_attribute_escaped_hash.cfm
+++ b/tests/tags/test_tag_attribute_escaped_hash.cfm
@@ -1,0 +1,20 @@
+<cfscript>
+suiteBegin("Tags: escaped hash in attributes");
+
+caughtMessage = "";
+</cfscript>
+
+<cftry>
+	<cfthrow message="literal ##278" />
+	<cfcatch>
+		<cfset caughtMessage = cfcatch.message />
+	</cfcatch>
+</cftry>
+
+<cfscript>
+assert("escaped hash in a tag attribute stays literal after tag conversion",
+	caughtMessage,
+	"literal " & chr(35) & "278");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a CFML runner test for escaped literal hashes in tag attributes.

## Why

Lucee preserves `##` as a literal `#` inside tag attributes. RustCFML currently converts the tag to script with a single `#`, then the CFScript parser treats it as the start of interpolation and consumes the rest of the generated script. This surfaced in a `cflog text="... ##278"` attribute during Moopa startup.

## Validation

- RustCFML v0.189.0 red test:
  - `Parse error ... Expected RParen, found Eof`
- Lucee validation not run locally because CommandBox is not installed in this environment.
