### PR TITLE
test(functions): EncodeForHTMLAttribute must encode attribute-dangerous chars (space and =)

### DIFF
--- a/tests/functions/test_encodeforhtmlattribute_space_equals.cfm
+++ b/tests/functions/test_encodeforhtmlattribute_space_equals.cfm
@@ -1,0 +1,23 @@
+<cfscript>
+suiteBegin("Encoding: EncodeForHTMLAttribute must encode attribute-dangerous chars (space and =)");
+
+// Background: in HTML-attribute context the OWASP encoders (Lucee/Adobe ESAPI) encode every
+// non-alphanumeric char below U+0100 — including space (-> &##x20;) and = (-> &##x3d;) — because an
+// UNQUOTED attribute value can be broken out of with a raw space + = (attribute / event-handler
+// injection). RustCFML 0.190.0 leaves space and = RAW in EncodeForHTMLAttribute output. The critical
+// set < > & " ' IS encoded (so QUOTED usage is safe); the exposure is unquoted-attribute breakout.
+
+// --- CONTROL (green on both engines): angle brackets are encoded (no raw < or >) ---
+assertTrue("CONTROL: < and > are encoded (no raw angle brackets)",
+    reFind("[<>]", EncodeForHTMLAttribute("a<b>c")) == 0);
+
+// --- the gap: space must be encoded in attribute context (no raw space remains) ---
+assertTrue("EncodeForHTMLAttribute encodes space (no raw space in output)",
+    findNoCase(" ", EncodeForHTMLAttribute("a b")) == 0);
+
+// --- the gap: = must be encoded in attribute context (no raw = remains) ---
+assertTrue("EncodeForHTMLAttribute encodes = (no raw = in output)",
+    findNoCase("=", EncodeForHTMLAttribute("a=b")) == 0);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -124,6 +124,8 @@ try { include "comments/test_tags_in_block_comments.cfm"; } catch (any e) { writ
 try { include "stdlib/test_string_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_string_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_string_functions_regex.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_string_functions_regex.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_string_functions_encoding.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_string_functions_encoding.cfm | " & e.message & chr(10)); }
+// EncodeForHTMLAttribute must encode attribute-dangerous chars (space, =) per OWASP/Lucee; RustCFML leaves them raw.
+try { include "functions/test_encodeforhtmlattribute_space_equals.cfm"; } catch (any e) { writeOutput("ERROR | functions/test_encodeforhtmlattribute_space_equals.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_array_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_array_functions.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_array_higher_order.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_array_higher_order.cfm | " & e.message & chr(10)); }
 try { include "stdlib/test_struct_functions.cfm"; } catch (any e) { writeOutput("ERROR | stdlib/test_struct_functions.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## Gap

In HTML-attribute context the OWASP encoders (Lucee/Adobe ESAPI) encode **every** non-alphanumeric char below U+0100 — including space (→ `&#x20;`) and `=` (→ `&#x3d;`) — because an **unquoted** attribute value can be broken out of with a raw space + `=` (attribute / event-handler injection).

**RustCFML 0.190.0** leaves space and `=` **raw** in `EncodeForHTMLAttribute` output. (The critical set `< > & " '` *is* encoded, so quoted usage is safe; the exposure is unquoted-attribute breakout.)

| input | Lucee 5.4 | RustCFML 0.190 |
|---|---|---|
| `EncodeForHTMLAttribute("a<b>c")` | `a&lt;b&gt;c` | `a&lt;b&gt;c` ✅ (CONTROL) |
| `EncodeForHTMLAttribute("a b")` | `a&#x20;b` | **`a b` (raw space)** ❌ |
| `EncodeForHTMLAttribute("a=b")` | `a&#x3d;b` | **`a=b` (raw =)** ❌ |

## Test

`tests/functions/test_encodeforhtmlattribute_space_equals.cfm`, registered in `runner.cfm`. One CONTROL assertion (angle brackets encoded) + two gap assertions (no raw space / no raw `=` remains). On 0.190.0: **1/3 pass**.

## Why it matters

Wheels' `hAttr()` view helper wraps `EncodeForHTMLAttribute`; an app that emits `<div title=#hAttr(x)#>` (unquoted) is exploitable on RustCFML where it is safe on Lucee. Surfaced in the Tier-4 security/view-surface sweep.