### PR TITLE
test(tags): cfhtmlhead must be script-callable (BIF form), not only the tag form

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -292,6 +292,8 @@ try { include "tags/test_cffile_script_form.cfm"; } catch (any e) { writeOutput(
 try { include "tags/test_cfhttpparam_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttpparam_runtime_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfmail_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfmail_runtime_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfmailpart_script_form.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfmailpart_script_form.cfm | " & e.message & chr(10)); }
+// cfhtmlhead exists as a tag (v0.186) but must ALSO be script-callable (cfhtmlhead(text=)); RustCFML throws "undefined".
+try { include "tags/test_cfhtmlhead_script_callable.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhtmlhead_script_callable.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfstoredproc_runtime_body.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfstoredproc_runtime_body.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfimport.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfimport.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfthread.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfthread.cfm | " & e.message & chr(10)); }

--- a/tests/tags/test_cfhtmlhead_script_callable.cfm
+++ b/tests/tags/test_cfhtmlhead_script_callable.cfm
@@ -1,0 +1,22 @@
+<cfscript>
+suiteBegin("Tags: cfhtmlhead is script-callable (BIF form), not only the tag form");
+
+// Background: cfhtmlhead exists as a TAG on RustCFML (implemented v0.186, injects into <head>
+// at flush). But the cfscript STATEMENT call form cfhtmlhead(text="...") is not a callable
+// builtin on RustCFML 0.190.0 — it throws "Variable 'cfhtmlhead' is undefined". Lucee/Adobe
+// expose cfhtmlhead(text=) / cfhtmlhead(attributeCollection=) as a script-callable builtin
+// (same as the other tag-in-script call forms). Wheels view/asset helpers call it in cfscript.
+
+state = {called = false, err = ""};
+try {
+    cfhtmlhead(text = "injected-head-content");
+    state.called = true;
+} catch (any e) {
+    state.err = e.message;
+}
+
+// the gap: cfhtmlhead(text=) must be callable in cfscript (not resolve to an undefined variable)
+assertTrue("cfhtmlhead(text=) is callable in cfscript (not 'undefined')", state.called);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Gap

`cfhtmlhead` exists as a **tag** on RustCFML (implemented v0.186, injects into `<head>` at flush). But the cfscript **statement** call form `cfhtmlhead(text="...")` is not a callable builtin on **v0.190.0** — it throws `Variable 'cfhtmlhead' is undefined`. Lucee/Adobe expose `cfhtmlhead(text=)` / `cfhtmlhead(attributeCollection=)` as a script-callable builtin (same as the other tag-in-script call forms — cf. the #141 family that fixed cfheader/cflocation/etc.).

| form | Lucee 5.4 | RustCFML 0.190 |
|---|---|---|
| `<cfhtmlhead text="...">` (tag) | works | works ✅ (v0.186) |
| `cfhtmlhead(text="...")` (script) | callable | **throws "undefined"** ❌ |

## Test

`tests/tags/test_cfhtmlhead_script_callable.cfm`, registered in `runner.cfm`. On 0.190.0: **0/1** (cfhtmlhead(text=) not callable in cfscript).

## Why it matters

Wheels view/asset helpers (head-injection for stylesheets/scripts) call `cfhtmlhead` in cfscript. The tag form landing in v0.186 covered the angle-bracket usage; this is the script-BIF complement. Surfaced in the Tier-4 view-surface sweep.