### PR TITLE
RED test: cffinally without cfcatch must parse

### DIFF
--- a/tests/tags/CffinallyWithoutCatchFixture.cfc
+++ b/tests/tags/CffinallyWithoutCatchFixture.cfc
@@ -1,0 +1,20 @@
+<!---
+    Gap fixture: a tag-form <cftry>/<cffinally> with no <cfcatch>, written with
+    normal multi-line formatting. Lucee accepts a catchless try/finally and runs
+    the finally block on the normal path; RustCFML 0.191.0 rejects this shape at
+    parse time with "Expected RBrace, found Semicolon". hello hits this in
+    apps/hub/routes/_import/nsw_land_values.cfc and
+    apps/www/routes/easy/[sell_id]/instant_offer/step1.cfc.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset var steps = [] />
+        <cftry>
+            <cfset arrayAppend(steps, "try") />
+            <cffinally>
+                <cfset arrayAppend(steps, "finally") />
+            </cffinally>
+        </cftry>
+        <cfreturn arrayToList(steps) />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/test_cffinally_tag_body.cfm
+++ b/tests/tags/test_cffinally_tag_body.cfm
@@ -6,10 +6,11 @@ suiteBegin("Tags: cffinally tag body");
     ============================================================
     Background
     ============================================================
-    The tag form <cftry> ... <cfcatch> ... <cffinally> ... </cftry> transpiles
-    to a CFScript try/catch/finally. On Lucee 5/6/7, Adobe ColdFusion, and
-    BoxLang the finally block parses and always runs (after normal completion
-    and after a caught exception).
+    The tag form <cftry> ... <cfcatch> ... <cffinally> ... </cftry> and the
+    catchless <cftry> ... <cffinally> ... </cftry> form both transpile to
+    CFScript try/finally shapes. On Lucee 5/6/7, Adobe ColdFusion, and BoxLang
+    the finally block parses and always runs (after normal completion and after
+    a caught exception).
 
     On RustCFML the whitespace (newlines/indentation) between </cfcatch> and
     <cffinally> -- and between a <cftry> body and <cffinally> -- was emitted as
@@ -60,6 +61,8 @@ assert("try/catch/finally (no exception) parses and runs finally",
     loadRun("CffinallyHappyPathFixture"), "try,finally");
 assert("try/catch/finally (caught exception) runs catch then finally",
     loadRun("CffinallyAfterThrowFixture"), "try,catch,finally");
+assert("try/finally without catch parses and runs finally",
+    loadRun("CffinallyWithoutCatchFixture"), "try,finally");
 
 suiteEnd();
 </cfscript>


### PR DESCRIPTION
## What

Adds a CFML runner fixture proving tag-mode `<cftry> ... <cffinally> ... </cftry>` parses and runs when there is no `<cfcatch>` block.

## Why

Lucee accepts catchless try/finally and runs the `cffinally` body on the normal path. RustCFML v0.191.0 currently rejects this shape at parse time with `Expected RBrace, found Semicolon`; when loaded as a CFC fixture it surfaces as `Could not find the component`.

This surfaced while booting the Moopa `hello` app on RustCFML:

- `apps/hub/routes/_import/nsw_land_values.cfc` uses `cftry` + `cffinally` for temp-folder cleanup.
- `apps/www/routes/easy/[sell_id]/instant_offer/step1.cfc` uses `cftry` + `cffinally` to restore `request.data` after a nested save.

TagTheTrack did not hit this edge because its current `cffinally` usage is the already-covered `cftry` + `cfcatch` + `cffinally` form.

## Validation

- RustCFML v0.191.0 targeted red test:
  - `FAIL | Tags: cffinally tag body | 3/4 passed (1 failed)`
  - `try/finally without catch parses and runs finally | expected: [try,finally] | got: [THREW: Could not find the component [CffinallyWithoutCatchFixture].]`
- Lucee 7.0.2.106 targeted suite with the same tests:
  - `PASS | Tags: cffinally tag body | 4/4 passed`

This PR is test-only so the Lucee-compatible behavior is pinned before choosing the parser fix.
