### PR TITLE
RED test: java.util.Date shim must initialize

### DIFF
--- a/tests/java_shims/test_all.cfm
+++ b/tests/java_shims/test_all.cfm
@@ -43,6 +43,20 @@ assertTrue( "System.getProperty user.dir", test5 );
 out = system.out;
 assertTrue( "System.out exists", isObject( out ) );
 
+// Test Date — real-world Lucee code commonly uses java.util.Date(0) as an
+// epoch base date for dateDiff/dateAdd calculations.
+writeOutput( "\n--- Testing Date ---\n" );
+dateError = "";
+dateMillis = "";
+try {
+    epochDate = createObject( "java", "java.util.Date" ).init( javacast( "int", 0 ) );
+    dateMillis = epochDate.getTime();
+} catch ( any e ) {
+    dateError = e.message;
+}
+assert( "Date init does not throw", dateError, "" );
+assert( "Date getTime epoch millis", dateMillis, 0 );
+
 // Test File
 writeOutput( "\n--- Testing File ---\n" );
 file = createObject( "java", "java.io.File" ).init( "/tmp/test.txt" );


### PR DESCRIPTION
## What

Adds a Java shim compatibility assertion for `createObject("java", "java.util.Date").init(javacast("int", 0))` and `getTime()`.

## Why

Lucee supports constructing `java.util.Date` from epoch milliseconds. RustCFML v0.191.0 currently returns null for `createObject("java", "java.util.Date")`, so the chained `.init(...)` call fails with `cannot call method [init] on a null value`.

This surfaced while booting the Moopa `hello` app on RustCFML. `code/shared/lib/encodingUtils.cfc` initializes an epoch base date with:

```cfml
variables.utcBaseDate = createObject( 'java', 'java.util.Date' ).init( javacast( 'int', 0 ) );
```

That utility is loaded during app startup for JWT/date conversion paths. TagTheTrack does not exercise this particular utility path, which is why it works on RustCFML without hitting this shim gap.

## Validation

- RustCFML v0.191.0 targeted red test:
  - `FAIL | Java Shims | 46/48 passed (2 failed)`
  - `Date init does not throw | expected: [] | got: [cannot call method [init] on a null value]`
  - `Date getTime epoch millis | expected: [0] | got: []`
- Lucee 7.0.2.106 targeted suite with the same tests:
  - `PASS | Java Shims | 48/48 passed`

This PR is test-only so the Lucee-compatible shim behavior is pinned before implementation.
