### PR TITLE
RED test: Application.cfc lifecycle overrides are case-insensitive

### DIFF
--- a/tests/lifecycle/application_lifecycle_case_override/Application.cfc
+++ b/tests/lifecycle/application_lifecycle_case_override/Application.cfc
@@ -1,0 +1,9 @@
+<cfcomponent extends="BaseApplication" output="false">
+    <cfset this.name = "rustcfml_lifecycle_case_override" />
+
+    <cffunction name="onApplicationStart" returntype="boolean" output="false">
+        <cfset super.onApplicationStart() />
+        <cfset application.lifecycle_case_child = "child-ran" />
+        <cfreturn true />
+    </cffunction>
+</cfcomponent>

--- a/tests/lifecycle/application_lifecycle_case_override/BaseApplication.cfc
+++ b/tests/lifecycle/application_lifecycle_case_override/BaseApplication.cfc
@@ -1,0 +1,6 @@
+<cfcomponent output="false">
+    <cffunction name="OnApplicationStart" returntype="boolean" output="false">
+        <cfset application.lifecycle_case_parent = "parent-ran" />
+        <cfreturn true />
+    </cffunction>
+</cfcomponent>

--- a/tests/lifecycle/application_lifecycle_case_override/index.cfm
+++ b/tests/lifecycle/application_lifecycle_case_override/index.cfm
@@ -1,0 +1,1 @@
+<cfoutput>parent=#application.lifecycle_case_parent ?: "missing"#|child=#application.lifecycle_case_child ?: "missing"#</cfoutput>

--- a/tests/lifecycle/test_application_lifecycle_case_override.cfm
+++ b/tests/lifecycle/test_application_lifecycle_case_override.cfm
@@ -1,0 +1,18 @@
+<cfscript>
+suiteBegin("Lifecycle: Application.cfc method overrides are case-insensitive");
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+
+if (serverPort == "" || serverPort == "0") {
+    assertTrue("application lifecycle case override skipped (no cgi.server_port)", true);
+} else {
+    targetPath = "/tests/lifecycle/application_lifecycle_case_override/index.cfm";
+    http url="http://127.0.0.1:#serverPort##targetPath#" method="GET" result="lifecycleResult";
+    assert("application lifecycle case override status", lifecycleResult.statuscode, "200 OK");
+    assert("child lifecycle override runs despite case mismatch",
+        trim(lifecycleResult.filecontent),
+        "parent=parent-ran|child=child-ran");
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -323,6 +323,7 @@ try { include "includes/test_closure_in_swapped_program.cfm"; } catch (any e) { 
 // --- Lifecycle / server request fixtures ---
 try { include "lifecycle/test_session_app_namespace.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_session_app_namespace.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_mapping_coverage.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_mapping_coverage.cfm | " & e.message & chr(10)); }
+try { include "lifecycle/test_application_lifecycle_case_override.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_lifecycle_case_override.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_load_errors.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_load_errors.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_scope_custom_tag.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_scope_custom_tag.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_onerror_onabort.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_onerror_onabort.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## What

Adds a serve-mode lifecycle fixture proving an `Application.cfc` child method whose casing differs from the parent lifecycle method still overrides it.

The fixture defines the parent method as `OnApplicationStart`, the child method as `onApplicationStart`, calls `super.onApplicationStart()`, and asserts both parent and child startup state are present.

## Why

CFML method dispatch is case-insensitive. RustCFML v0.193.0 currently runs the parent lifecycle method but misses the child override when the method casing differs.

This matters for applications that extend a framework-level `Application.cfc` and use different casing for lifecycle methods across parent and child components. Under Lucee, both methods run. Under RustCFML v0.193.0, only the parent startup runs, so child-level application initialization can be skipped.

A concrete symptom is app-specific startup values not being initialized, which can lead downstream code to build incomplete URLs such as:

```text
redirect_uri=/login/callback
```

Lucee treats the lifecycle override case-insensitively and runs both methods, producing the expected child-level application state.

## Validation

- RustCFML v0.193.0 serve-mode targeted fixture:
  - `parent=parent-ran|child=missing`
- RustCFML v0.193.0 runner with the new test:
  - `FAIL | Lifecycle: Application.cfc method overrides are case-insensitive | 1/2 passed (1 failed)`
  - `child lifecycle override runs despite case mismatch | expected: [parent=parent-ran|child=child-ran] | got: [parent=parent-ran|child=missing]`
- Lucee 7.0.2.106 direct request to the same fixture:
  - `parent=parent-ran|child=child-ran`

This PR is test-only so the Lucee-compatible lifecycle dispatch behavior is pinned before implementation.