### PR TITLE
RED test: cfhttp must honor attributeCollection

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -264,6 +264,7 @@ try { include "tags/test_tags_cfcache.cfm"; } catch (any e) { writeOutput("ERROR
 try { include "tags/test_tags_cfstoredproc.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfstoredproc.cfm | " & e.message & chr(10)); }
 try { include "tags/test_tags_cfqueryparam_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_tags_cfqueryparam_attribute_collection.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfhttp_multiparam_url.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttp_multiparam_url.cfm | " & e.message & chr(10)); }
+try { include "tags/test_cfhttp_attribute_collection.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfhttp_attribute_collection.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfqueryparam_interpolated_value.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_interpolated_value.cfm | " & e.message & chr(10)); }
 try { include "tags/test_cfqueryparam_in_transaction.cfm"; } catch (any e) { writeOutput("ERROR | tags/test_cfqueryparam_in_transaction.cfm | " & e.message & chr(10)); }
 //   - cfqueryparam_script_form: cfqueryparam must be callable as a script

--- a/tests/tags/test_cfhttp_attribute_collection.cfm
+++ b/tests/tags/test_cfhttp_attribute_collection.cfm
@@ -1,0 +1,41 @@
+<cfscript>
+suiteBegin("Tags: cfhttp attributeCollection");
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+if (skip) {
+    assertTrue("cfhttp attributeCollection skipped (no cgi.server_port)", true);
+} else {
+    target = "http://127.0.0.1:" & serverPort & "/tests/tags/http_statements_target.cfm?test=echo";
+    httpAttrs = {
+        url = target,
+        method = "GET",
+        timeout = 15
+    };
+    httpError = "";
+}
+</cfscript>
+
+<cfif NOT skip>
+    <cftry>
+        <cfhttp attributeCollection="#httpAttrs#" result="httpResult" />
+        <cfcatch type="any">
+            <cfset httpError = cfcatch.message />
+        </cfcatch>
+    </cftry>
+
+    <cfscript>
+    assert("cfhttp attributeCollection url/method error", httpError, "");
+    assert("cfhttp attributeCollection url/method status",
+        structKeyExists(variables, "httpResult") ? httpResult.statuscode : "",
+        "200 OK");
+    assert("cfhttp attributeCollection url/method body",
+        structKeyExists(variables, "httpResult") ? trim(httpResult.filecontent) : "",
+        "echo-ok");
+    </cfscript>
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a server-mode CFML runner test proving `<cfhttp attributeCollection="#attrs#" ...>` reads `url`, `method`, and `timeout` from the supplied struct.

The test calls an existing local test target and asserts the request returns `200 OK` with the expected body.

## Why

Lucee supports passing `cfhttp` attributes through `attributeCollection`. RustCFML v0.193.0 currently ignores the collected `url` for tag-mode `cfhttp`, then throws:

```text
cfhttp: url is required
```

This matters for code that builds HTTP request attributes dynamically, then passes them into `cfhttp` as one struct. A representative OAuth token exchange builds a struct containing the token endpoint URL and method, then calls:

```cfml
<cfhttp attributeCollection="#stAttr#" result="stResponse">
```

Under RustCFML, the request fails before it is made because `cfhttp` does not read `stAttr.url`.

## Validation

- RustCFML v0.193.0 runner with the new test:
  - `FAIL | Tags: cfhttp attributeCollection | 0/3 passed (3 failed)`
  - `cfhttp attributeCollection url/method error | expected: [] | got: [cfhttp: url is required]`
- Lucee 7.0.2.106 direct compatibility check against a tiny HTTP target:
  - `status=200 OK|body=echo-ok`

This PR is test-only so the Lucee-compatible `cfhttp attributeCollection` behavior is pinned before implementation.