### PR TITLE
RED test: string toString member must return receiver

### DIFF
--- a/tests/members/test_string_members.cfm
+++ b/tests/members/test_string_members.cfm
@@ -47,6 +47,9 @@ assert("string.ucFirst()", "hello world".ucFirst(), "Hello world");
 // --- compare ---
 assert("string.compare() equal", "Hello".compare("Hello"), 0);
 
+// --- toString ---
+assert("string.toString() returns receiver text", "hello".toString(), "hello");
+
 // --- getToken (member form; string-first signature, no arg swap) ---
 // Regression: the member form returned empty while the standalone getToken()
 // worked. WireBox's delegate shorthand parser uses `item.getToken(1, "=")`.


### PR DESCRIPTION
## What

Adds one assertion to the existing string member suite proving `"hello".toString()` returns `"hello"`.

## Why

Lucee returns the receiver text for the string member `toString()` call. RustCFML v0.200.0 currently returns an empty string:

```text
direct=hello|member=|len=0
```

This matters for code that calls `.toString()` before parsing or passing string content. For example, an HTTP response body may be present in `fileContent`, but `fileContent.toString()` becomes empty before JSON parsing.

## Validation

- RustCFML v0.200.0 targeted suite:
  - `FAIL | String Member Functions | 24/25 passed (1 failed)`
  - `string.toString() returns receiver text | expected: [hello] | got: []`
- Lucee 7.0.2.106 direct check:
  - `direct=hello|member=hello|len=5`

This PR is test-only so the Lucee-compatible string member behavior is pinned before implementation.