### PR TITLE
RED test: SessionCommit must be callable

### DIFF
--- a/tests/core/test_session_commit.cfm
+++ b/tests/core/test_session_commit.cfm
@@ -1,0 +1,17 @@
+<cfscript>
+suiteBegin("SessionCommit");
+
+session.sessionCommitProbe = "before";
+sessionCommitError = "";
+
+try {
+    SessionCommit();
+} catch (any e) {
+    sessionCommitError = e.message;
+}
+
+assert("SessionCommit is callable", sessionCommitError, "");
+assert("SessionCommit leaves session data intact", session.sessionCommitProbe, "before");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -549,6 +549,7 @@ try { include "core/test_switch_braced_case.cfm"; } catch (any e) { writeOutput(
 try { include "core/test_switch_fallthrough.cfm"; } catch (any e) { writeOutput("ERROR | core/test_switch_fallthrough.cfm | " & e.message & chr(10)); }
 try { include "core/test_application_scope_persist.cfm"; } catch (any e) { writeOutput("ERROR | core/test_application_scope_persist.cfm | " & e.message & chr(10)); }
 try { include "core/test_session_scope_persist.cfm"; } catch (any e) { writeOutput("ERROR | core/test_session_scope_persist.cfm | " & e.message & chr(10)); }
+try { include "core/test_session_commit.cfm"; } catch (any e) { writeOutput("ERROR | core/test_session_commit.cfm | " & e.message & chr(10)); }
 try { include "core/test_application_metadata.cfm"; } catch (any e) { writeOutput("ERROR | core/test_application_metadata.cfm | " & e.message & chr(10)); }
 //   - named_args_no_numeric_alias: a named-argument call to a function that
 //     DECLARES params must populate the arguments scope by name only. When a


### PR DESCRIPTION
## What

Adds a core test proving `SessionCommit()` is callable and leaves existing session data intact.

## Why

Lucee exposes `SessionCommit()` as a built-in function. RustCFML v0.200.0 currently treats it as an undefined variable/function:

```text
Variable 'SessionCommit' is undefined
```

This matters for request flows that mutate `session` and then immediately redirect or abort. `SessionCommit()` is used to force the current session state to persistent storage before that control-flow boundary.

## Validation

- RustCFML v0.200.0 targeted suite:
  - `FAIL | SessionCommit | 1/2 passed (1 failed)`
  - `SessionCommit is callable | expected: [] | got: [Variable 'SessionCommit' is undefined]`
- Lucee 7.0.2.106 direct check:
  - `SessionCommit OK|probe=before`

This PR is test-only so the Lucee-compatible session function behavior is pinned before implementation.