### PR TITLE
fix: bind this for case-insensitive super calls

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -5523,7 +5523,7 @@ impl CfmlVirtualMachine {
                         } else if let CfmlValue::Struct(ref s) = object {
                             if s.contains_key("__is_super") {
                                 // Super dispatch — find the parent's function by stored index
-                                let prop = object.get(&method_name).unwrap_or(CfmlValue::Null);
+                                let prop = s.get_ci(method_name.as_str()).unwrap_or(CfmlValue::Null);
                                 if let CfmlValue::Function(ref f) = &prop {
                                     // Extract the stored global_id from the body.
                                     let func_idx =

--- a/tests/lifecycle/application_lifecycle_super_this/Application.cfc
+++ b/tests/lifecycle/application_lifecycle_super_this/Application.cfc
@@ -1,0 +1,9 @@
+<cfcomponent extends="BaseApplication" output="false">
+    <cfset this.name = "rustcfml_lifecycle_super_this" />
+
+    <cffunction name="onApplicationStart" returntype="boolean" output="false">
+        <cfset super.onApplicationStart() />
+        <cfset application.lifecycle_super_this_child = "child-ran" />
+        <cfreturn true />
+    </cffunction>
+</cfcomponent>

--- a/tests/lifecycle/application_lifecycle_super_this/BaseApplication.cfc
+++ b/tests/lifecycle/application_lifecycle_super_this/BaseApplication.cfc
@@ -1,0 +1,8 @@
+<cfcomponent output="false">
+    <cfset this.parentMarker = "parent-this" />
+
+    <cffunction name="OnApplicationStart" returntype="boolean" output="false">
+        <cfset application.lifecycle_super_this_parent = this.parentMarker />
+        <cfreturn true />
+    </cffunction>
+</cfcomponent>

--- a/tests/lifecycle/application_lifecycle_super_this/index.cfm
+++ b/tests/lifecycle/application_lifecycle_super_this/index.cfm
@@ -1,0 +1,2 @@
+<cfcontent type="text/plain" reset="true">
+<cfoutput>parent=#application.lifecycle_super_this_parent ?: "missing"#|child=#application.lifecycle_super_this_child ?: "missing"#</cfoutput>

--- a/tests/lifecycle/test_application_lifecycle_super_this.cfm
+++ b/tests/lifecycle/test_application_lifecycle_super_this.cfm
@@ -1,0 +1,18 @@
+<cfscript>
+suiteBegin("Lifecycle: Application.cfc super calls bind this");
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+
+if (serverPort == "" || serverPort == "0") {
+    assertTrue("application lifecycle super this skipped (no cgi.server_port)", true);
+} else {
+    targetPath = "/tests/lifecycle/application_lifecycle_super_this/index.cfm";
+    http url="http://127.0.0.1:#serverPort##targetPath#" method="GET" result="lifecycleResult";
+    assert("application lifecycle super this status", lifecycleResult.statuscode, "200 OK");
+    assert("inherited lifecycle super call keeps this scope",
+        trim(lifecycleResult.filecontent),
+        "parent=parent-this|child=child-ran");
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -330,6 +330,7 @@ try { include "includes/test_closure_in_swapped_program.cfm"; } catch (any e) { 
 try { include "lifecycle/test_session_app_namespace.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_session_app_namespace.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_mapping_coverage.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_mapping_coverage.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_lifecycle_case_override.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_lifecycle_case_override.cfm | " & e.message & chr(10)); }
+try { include "lifecycle/test_application_lifecycle_super_this.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_lifecycle_super_this.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_load_errors.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_load_errors.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_scope_custom_tag.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_scope_custom_tag.cfm | " & e.message & chr(10)); }
 try { include "lifecycle/test_application_onerror_onabort.cfm"; } catch (any e) { writeOutput("ERROR | lifecycle/test_application_onerror_onabort.cfm | " & e.message & chr(10)); }


### PR DESCRIPTION
## What

Fixes `super.method()` dispatch when the parent method casing differs from the call-site casing.

The `__super` dispatch path now resolves the parent method case-insensitively before invoking the stored parent function. The PR also adds a serve-mode `Application.cfc` lifecycle fixture where:

- the parent defines `OnApplicationStart`
- the child defines `onApplicationStart`
- the child calls `super.onApplicationStart()`
- the parent lifecycle method reads `this.parentMarker`

## Why

CFML method dispatch is case-insensitive, including `super` calls. Before this fix, RustCFML's special `__super` path used an exact-case lookup first. If that lookup missed, execution fell through to generic struct method dispatch, which can call the parent function without binding the child component as `this`.

The visible symptom is a parent lifecycle method reached through `super` failing with:

```text
Variable 'this' is undefined
```

Lucee binds `this` for the same shape, so both parent and child lifecycle startup complete.

## Validation

- Pre-fix RustCFML direct repro:
  - `ERR:Variable 'this' is undefined`
- Lucee 7 direct request to the same fixture:
  - `parent=parent-this|child=child-ran`
- RustCFML direct repro after fix:
  - `parent=parent-this|child=child-ran`
- `cargo build -p rustcfml-cli`
- RustCFML serve-mode runner after fix:
  - `SUMMARY: 4113/4113 passed across 503 suites`
- Linux aarch64 release build in Docker:
  - `RustCFML v0.203.0`
