### PR TITLE
[codex] Handle PostgreSQL DML RETURNING rows

### DIFF
--- a/crates/cfml-stdlib/src/builtins.rs
+++ b/crates/cfml-stdlib/src/builtins.rs
@@ -7476,6 +7476,135 @@ fn is_select_query(sql: &str) -> bool {
     )
 }
 
+/// PostgreSQL also returns rows from DML statements with a top-level
+/// `RETURNING` clause. Those must run through `query`, not `execute`; the
+/// postgres crate rejects row-returning statements on the execute path.
+#[cfg(feature = "postgres_db")]
+fn postgres_returns_rows(sql: &str) -> bool {
+    let trimmed = strip_leading_sql_noise(sql);
+    let kw_len = trimmed
+        .as_bytes()
+        .iter()
+        .take_while(|b| b.is_ascii_alphabetic())
+        .count();
+    let kw = trimmed[..kw_len].to_ascii_uppercase();
+
+    if matches!(
+        kw.as_str(),
+        "SELECT" | "WITH" | "CALL" | "EXEC" | "EXECUTE" | "VALUES" | "SHOW" | "PRAGMA"
+            | "EXPLAIN" | "DESCRIBE" | "DESC"
+    ) {
+        return true;
+    }
+
+    matches!(kw.as_str(), "INSERT" | "UPDATE" | "DELETE" | "MERGE")
+        && sql_has_top_level_keyword(trimmed, "RETURNING")
+}
+
+#[cfg(feature = "postgres_db")]
+fn sql_has_top_level_keyword(sql: &str, target: &str) -> bool {
+    let chars: Vec<char> = sql.chars().collect();
+    let mut i = 0usize;
+    let mut depth = 0i32;
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if c == '\'' || c == '"' {
+            i = skip_sql_quoted(&chars, i, c);
+            continue;
+        }
+
+        if c == '-' && chars.get(i + 1) == Some(&'-') {
+            i += 2;
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        if c == '/' && chars.get(i + 1) == Some(&'*') {
+            i += 2;
+            while i + 1 < chars.len() && !(chars[i] == '*' && chars[i + 1] == '/') {
+                i += 1;
+            }
+            i = (i + 2).min(chars.len());
+            continue;
+        }
+
+        if c == '$' {
+            if let Some(next) = skip_postgres_dollar_quote(&chars, i) {
+                i = next;
+                continue;
+            }
+        }
+
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                if depth > 0 {
+                    depth -= 1;
+                }
+            }
+            _ => {
+                if depth == 0 && (c.is_ascii_alphabetic() || c == '_') {
+                    let start = i;
+                    i += 1;
+                    while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+                        i += 1;
+                    }
+                    let word: String = chars[start..i].iter().collect();
+                    if word.eq_ignore_ascii_case(target) {
+                        return true;
+                    }
+                    continue;
+                }
+            }
+        }
+
+        i += 1;
+    }
+
+    false
+}
+
+#[cfg(feature = "postgres_db")]
+fn skip_sql_quoted(chars: &[char], start: usize, quote: char) -> usize {
+    let mut i = start + 1;
+    while i < chars.len() {
+        if chars[i] == quote {
+            if chars.get(i + 1) == Some(&quote) {
+                i += 2;
+                continue;
+            }
+            return i + 1;
+        }
+        i += 1;
+    }
+    chars.len()
+}
+
+#[cfg(feature = "postgres_db")]
+fn skip_postgres_dollar_quote(chars: &[char], start: usize) -> Option<usize> {
+    let mut tag_end = start + 1;
+    while tag_end < chars.len() && (chars[tag_end].is_ascii_alphanumeric() || chars[tag_end] == '_') {
+        tag_end += 1;
+    }
+    if chars.get(tag_end) != Some(&'$') {
+        return None;
+    }
+
+    let delimiter: Vec<char> = chars[start..=tag_end].to_vec();
+    let mut i = tag_end + 1;
+    while i + delimiter.len() <= chars.len() {
+        if chars[i..i + delimiter.len()] == delimiter[..] {
+            return Some(i + delimiter.len());
+        }
+        i += 1;
+    }
+    Some(chars.len())
+}
+
 /// Dynamic-driver-only `queryExecute` for builds that don't enable any
 /// of the per-engine DB features (e.g. the Cloudflare Workers host,
 /// which uses the dynamic-driver registry to plug in D1). Looks up
@@ -7917,10 +8046,10 @@ fn run_postgres_statements(
     params_arg: &CfmlValue,
     return_type: &str,
 ) -> CfmlResult {
-    let select = is_select_query(sql);
-    let statements = crate::pg_sql::prepare_pg_statements(sql, params_arg, !select)?;
+    let returns_rows = postgres_returns_rows(sql);
+    let statements = crate::pg_sql::prepare_pg_statements(sql, params_arg, !returns_rows)?;
 
-    if select {
+    if returns_rows {
         // split=false guarantees exactly one statement.
         let stmt = &statements[0];
         let pg_params: Vec<PgParam> = stmt.params.iter().map(cfml_to_pg_param).collect();
@@ -7943,11 +8072,7 @@ fn run_postgres_statements(
             Err(e) => return Err(CfmlError::runtime(format_pg_error("queryExecute: PostgreSQL query error", &e))),
         };
 
-        let columns: Vec<String> = if let Some(first_row) = rows.first() {
-            first_row.columns().iter().map(|c| c.name().to_string()).collect()
-        } else {
-            vec![]
-        };
+        let columns: Vec<String> = prepared.columns().iter().map(|c| c.name().to_string()).collect();
 
         let mut result_rows: Vec<ValueMap> = Vec::with_capacity(rows.len());
         for row in &rows {

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -293,6 +293,9 @@ include "harness.cfm";
 <cf_runtest file="tags/test_pg_jsonb_param_binds.cfm">
 <cf_runtest file="tags/test_pg_vector_param_binds.cfm">
 <cf_runtest file="tags/test_pg_error_cause_chain.cfm">
+<!--- PostgreSQL DML with RETURNING returns rows and must use the query path, --->
+<!--- not the execute path. Lucee supports atomic UPDATE ... RETURNING patterns. --->
+<cf_runtest file="tags/test_pg_dml_returning.cfm">
 <cf_runtest file="tags/test_pg_extended_param_binds.cfm">
 <cf_runtest file="tags/test_pg_pool_checkout_validation.cfm">
 <cf_runtest file="tags/test_cfquery_quoted_identifier.cfm">

--- a/tests/tags/test_pg_dml_returning.cfm
+++ b/tests/tags/test_pg_dml_returning.cfm
@@ -1,0 +1,115 @@
+<cfscript>
+// PostgreSQL DML with RETURNING must be handled as row-returning SQL.
+//
+// The postgres crate rejects `execute()` for statements that return rows:
+// "Execute returned results - did you mean to call query?". Lucee returns the
+// rows from INSERT/UPDATE/DELETE ... RETURNING, and CFML applications commonly
+// depend on that for atomic "claim and return" updates.
+//
+// Live test, gated on RUSTCFML_TEST_PG_URL (same pattern as the other PG tests).
+// To run locally:
+//   docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
+//   RUSTCFML_TEST_PG_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres \
+//     cargo run --features all-databases -- tests/runner.cfm
+
+suiteBegin("PostgreSQL DML RETURNING rows (skipped without RUSTCFML_TEST_PG_URL)");
+
+pgdsn = "";
+try {
+    pgdsn = server.system.environment.RUSTCFML_TEST_PG_URL ?: "";
+} catch (any e) {
+    pgdsn = "";
+}
+
+pgskip = false;
+tbl = "zz_rcfml_returning_" & lCase(left(replace(createUUID(), "-", "", "all"), 8));
+
+if (pgdsn == "") {
+    pgskip = true;
+    writeOutput("  (skipped - set RUSTCFML_TEST_PG_URL to enable)" & chr(10));
+} else {
+    try {
+        queryExecute("CREATE TABLE #tbl# (id int PRIMARY KEY, label text, touched boolean default false)",
+            [], { datasource: pgdsn });
+        queryExecute("INSERT INTO #tbl# (id, label) VALUES (1, 'alpha'), (2, 'beta')",
+            [], { datasource: pgdsn });
+    } catch (any e) {
+        pgskip = true;
+        writeOutput("  (skipped - PostgreSQL not reachable: " & e.message & ")" & chr(10));
+    }
+}
+
+if (NOT pgskip) {
+    try {
+        rows = queryExecute(
+            "UPDATE #tbl# SET touched = true WHERE id = ? RETURNING id, label, touched",
+            [1],
+            { datasource: pgdsn, returntype: "array" }
+        );
+        assertTrue("queryExecute UPDATE RETURNING returns an array", isArray(rows));
+        assert("queryExecute UPDATE RETURNING row count", arrayLen(rows), 1);
+        assert("queryExecute UPDATE RETURNING id", rows[1].id ?: 0, 1);
+        assert("queryExecute UPDATE RETURNING label", rows[1].label ?: "", "alpha");
+        assertTrue("queryExecute UPDATE RETURNING boolean", rows[1].touched ?: false);
+
+        none = queryExecute(
+            "UPDATE #tbl# SET touched = true WHERE id = ? RETURNING id",
+            [999],
+            { datasource: pgdsn, returntype: "array" }
+        );
+        assertTrue("queryExecute UPDATE RETURNING no-match still returns array", isArray(none));
+        assert("queryExecute UPDATE RETURNING no-match row count", arrayLen(none), 0);
+
+        inserted = queryExecute(
+            "INSERT INTO #tbl# (id, label) VALUES (?, ?) RETURNING id, label",
+            [3, "gamma"],
+            { datasource: pgdsn, returntype: "struct" }
+        );
+        assert("queryExecute INSERT RETURNING id", inserted.id ?: 0, 3);
+        assert("queryExecute INSERT RETURNING label", inserted.label ?: "", "gamma");
+    } catch (any e) {
+        assertTrue("PostgreSQL queryExecute DML RETURNING failed: " & e.message, false);
+    }
+}
+</cfscript>
+
+<cfif NOT pgskip>
+    <cftry>
+        <cfquery name="tagRows" datasource="#pgdsn#" returntype="array">
+            UPDATE #tbl#
+            SET touched = false
+            WHERE id = <cfqueryparam value="2" cfsqltype="cf_sql_integer">
+            RETURNING id, label, touched
+        </cfquery>
+        <cfscript>
+        assertTrue("cfquery UPDATE RETURNING returns an array", isArray(tagRows));
+        assert("cfquery UPDATE RETURNING row count", arrayLen(tagRows), 1);
+        assert("cfquery UPDATE RETURNING id", tagRows[1].id ?: 0, 2);
+        assert("cfquery UPDATE RETURNING label", tagRows[1].label ?: "", "beta");
+        assertFalse("cfquery UPDATE RETURNING boolean", tagRows[1].touched ?: true);
+
+        deleted = queryExecute(
+            "DELETE FROM #tbl# WHERE id = ? RETURNING label",
+            [2],
+            { datasource: pgdsn, returntype: "array" }
+        );
+        assert("queryExecute DELETE RETURNING row count", arrayLen(deleted), 1);
+        assert("queryExecute DELETE RETURNING label", deleted[1].label ?: "", "beta");
+        </cfscript>
+        <cfcatch type="any">
+            <cfscript>
+            assertTrue("PostgreSQL cfquery DML RETURNING failed: " & cfcatch.message, false);
+            </cfscript>
+        </cfcatch>
+    </cftry>
+</cfif>
+
+<cfscript>
+if (NOT pgskip) {
+    try {
+        queryExecute("DROP TABLE #tbl#", [], { datasource: pgdsn });
+    } catch (any e) {}
+}
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary
- Route PostgreSQL DML statements with a top-level `RETURNING` clause through the row-returning query path.
- Preserve ordinary PostgreSQL mutation splitting for non-returning statements.
- Add a live PostgreSQL regression registered through the `cf_runtest`/`cfmodule` isolation wrapper, covering both `queryExecute(..., { returntype = "array" })` and `<cfquery returntype="array">`.

## Root Cause
RustCFML classified PostgreSQL statements as row-returning only from the first SQL keyword. `UPDATE ... RETURNING`, `INSERT ... RETURNING`, and `DELETE ... RETURNING` therefore went through `postgres::Client::execute`, which rejects statements that produce rows with `Execute returned results - did you mean to call query?`. Lucee returns those rows, and applications use this shape for atomic consume/claim operations.

## Validation
- `cargo check --features all-databases`
- Focused live regression against disposable Postgres 16 via `cfmodule template="tests/runtest.cfm" file="tags/test_pg_dml_returning.cfm"`: `16/16 passed`

## Notes
The app database user I first tried could connect but did not have `CREATE TABLE` permission in `public`, so the live validation used a disposable local Postgres container instead.