### PR TITLE
Retry stale Postgres pooled connections

### DIFF
--- a/crates/cfml-stdlib/src/builtins.rs
+++ b/crates/cfml-stdlib/src/builtins.rs
@@ -6711,6 +6711,7 @@ type PgStmtCache = HashMap<String, postgres::Statement>;
 struct PgConn {
     client: postgres::Client,
     stmt_cache: PgStmtCache,
+    broken: bool,
 }
 
 /// Prepare `sql` once per connection, then hand back the cached `Statement`.
@@ -6768,7 +6769,7 @@ impl r2d2::ManageConnection for PostgresConnectionManager {
 
     fn connect(&self) -> Result<Self::Connection, Self::Error> {
         let client = connect_postgres(&self.url)?;
-        Ok(PgConn { client, stmt_cache: HashMap::new() })
+        Ok(PgConn { client, stmt_cache: HashMap::new(), broken: false })
     }
 
     fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
@@ -6782,7 +6783,7 @@ impl r2d2::ManageConnection for PostgresConnectionManager {
         // true. `is_closed()` flips once the background connection task has
         // terminated (e.g. the server closed an idle socket), so a closed
         // connection is evicted rather than handed back out.
-        conn.client.is_closed()
+        conn.broken || conn.client.is_closed()
     }
 }
 
@@ -7878,12 +7879,37 @@ fn execute_postgres(url: &str, sql: &str, params_arg: &CfmlValue, return_type: &
     let pool = get_postgres_pool(url)?;
     let mut conn = pool.get()
         .map_err(|e| CfmlError::runtime(format!("queryExecute: PostgreSQL connection error: {}", e)))?;
-    let pg = &mut *conn;
-    run_postgres_statements(&mut pg.client, &mut pg.stmt_cache, sql, params_arg, return_type)
+    match run_postgres_on_conn(&mut conn, sql, params_arg, return_type) {
+        Ok(value) => Ok(value),
+        Err(err) if err.retry_safe => {
+            drop(conn);
+            let mut retry_conn = pool.get()
+                .map_err(|e| CfmlError::runtime(format!("queryExecute: PostgreSQL connection error: {}", e)))?;
+            run_postgres_on_conn(&mut retry_conn, sql, params_arg, return_type)
+                .map_err(|retry_err| retry_err.error)
+        }
+        Err(err) => Err(err.error),
+    }
+}
+
+#[cfg(feature = "postgres_db")]
+fn run_postgres_on_conn(
+    conn: &mut PgConn,
+    sql: &str,
+    params_arg: &CfmlValue,
+    return_type: &str,
+) -> Result<CfmlValue, PgRunError> {
+    let result = run_postgres_statements(&mut conn.client, &mut conn.stmt_cache, sql, params_arg, return_type);
+    if let Err(err) = &result {
+        if err.connection_broken {
+            conn.broken = true;
+        }
+    }
+    result
 }
 
 /// Shared PostgreSQL execution for both the pooled (`execute_postgres`) and
-/// persistent-connection (`execute_postgres_with_conn`) paths.
+/// transaction (`execute_postgres_with_conn`) paths.
 ///
 /// SELECTs run as a single `query`. Non-SELECT mutations are split into one
 /// parameterized statement each (see `pg_sql::prepare_pg_statements`) and run
@@ -7910,15 +7936,43 @@ fn format_pg_error(context: &str, e: &postgres::Error) -> String {
 }
 
 #[cfg(feature = "postgres_db")]
+struct PgRunError {
+    error: CfmlError,
+    connection_broken: bool,
+    retry_safe: bool,
+}
+
+#[cfg(feature = "postgres_db")]
+impl PgRunError {
+    fn from_cfml(error: CfmlError) -> Self {
+        Self {
+            error,
+            connection_broken: false,
+            retry_safe: false,
+        }
+    }
+
+    fn from_postgres(context: &str, e: postgres::Error, retry_safe: bool) -> Self {
+        let connection_broken = e.is_closed();
+        Self {
+            error: CfmlError::runtime(format_pg_error(context, &e)),
+            connection_broken,
+            retry_safe: connection_broken && retry_safe,
+        }
+    }
+}
+
+#[cfg(feature = "postgres_db")]
 fn run_postgres_statements(
     client: &mut postgres::Client,
     cache: &mut PgStmtCache,
     sql: &str,
     params_arg: &CfmlValue,
     return_type: &str,
-) -> CfmlResult {
+) -> Result<CfmlValue, PgRunError> {
     let select = is_select_query(sql);
-    let statements = crate::pg_sql::prepare_pg_statements(sql, params_arg, !select)?;
+    let statements = crate::pg_sql::prepare_pg_statements(sql, params_arg, !select)
+        .map_err(PgRunError::from_cfml)?;
 
     if select {
         // split=false guarantees exactly one statement.
@@ -7930,17 +7984,17 @@ fn run_postgres_statements(
         // Cached prepared statement → one round-trip in steady state. On a stale
         // cached plan (DDL changed the table), evict and re-prepare once.
         let prepared = pg_prepare_cached(client, cache, stmt.sql.as_str())
-            .map_err(|e| CfmlError::runtime(format_pg_error("queryExecute: PostgreSQL prepare error", &e)))?;
+            .map_err(|e| PgRunError::from_postgres("queryExecute: PostgreSQL prepare error", e, true))?;
         let rows = match client.query(&prepared, &param_refs) {
             Ok(r) => r,
             Err(e) if is_stale_cached_plan(&e) => {
                 cache.remove(stmt.sql.as_str());
                 let prepared = pg_prepare_cached(client, cache, stmt.sql.as_str())
-                    .map_err(|e| CfmlError::runtime(format_pg_error("queryExecute: PostgreSQL prepare error", &e)))?;
+                    .map_err(|e| PgRunError::from_postgres("queryExecute: PostgreSQL prepare error", e, true))?;
                 client.query(&prepared, &param_refs)
-                    .map_err(|e| CfmlError::runtime(format_pg_error("queryExecute: PostgreSQL query error", &e)))?
+                    .map_err(|e| PgRunError::from_postgres("queryExecute: PostgreSQL query error", e, true))?
             }
-            Err(e) => return Err(CfmlError::runtime(format_pg_error("queryExecute: PostgreSQL query error", &e))),
+            Err(e) => return Err(PgRunError::from_postgres("queryExecute: PostgreSQL query error", e, true)),
         };
 
         let columns: Vec<String> = if let Some(first_row) = rows.first() {
@@ -7957,30 +8011,32 @@ fn run_postgres_statements(
             }
             result_rows.push(row_map);
         }
-        build_query_result(columns, result_rows, sql, return_type)
+        build_query_result(columns, result_rows, sql, return_type).map_err(PgRunError::from_cfml)
     } else {
         let mut total: i64 = 0;
+        let mut executed_any = false;
         for stmt in &statements {
             let pg_params: Vec<PgParam> = stmt.params.iter().map(cfml_to_pg_param).collect();
             let param_refs: Vec<&(dyn postgres::types::ToSql + Sync)> = pg_params.iter()
                 .map(|v| v as &(dyn postgres::types::ToSql + Sync))
                 .collect();
             let prepared = pg_prepare_cached(client, cache, stmt.sql.as_str())
-                .map_err(|e| CfmlError::runtime(format_pg_error("queryExecute: PostgreSQL prepare error", &e)))?;
+                .map_err(|e| PgRunError::from_postgres("queryExecute: PostgreSQL prepare error", e, !executed_any))?;
             let affected = match client.execute(&prepared, &param_refs) {
                 Ok(n) => n,
                 Err(e) if is_stale_cached_plan(&e) => {
                     cache.remove(stmt.sql.as_str());
                     let prepared = pg_prepare_cached(client, cache, stmt.sql.as_str())
-                        .map_err(|e| CfmlError::runtime(format_pg_error("queryExecute: PostgreSQL prepare error", &e)))?;
+                        .map_err(|e| PgRunError::from_postgres("queryExecute: PostgreSQL prepare error", e, !executed_any))?;
                     client.execute(&prepared, &param_refs)
-                        .map_err(|e| CfmlError::runtime(format_pg_error("queryExecute: PostgreSQL error", &e)))?
+                        .map_err(|e| PgRunError::from_postgres("queryExecute: PostgreSQL error", e, false))?
                 }
-                Err(e) => return Err(CfmlError::runtime(format_pg_error("queryExecute: PostgreSQL error", &e))),
+                Err(e) => return Err(PgRunError::from_postgres("queryExecute: PostgreSQL error", e, false)),
             };
+            executed_any = true;
             total += affected as i64;
         }
-        build_mutation_result(total, 0, sql) // PG uses RETURNING, not last_insert_id
+        build_mutation_result(total, 0, sql).map_err(PgRunError::from_cfml) // PG uses RETURNING, not last_insert_id
     }
 }
 
@@ -8890,8 +8946,13 @@ fn transaction_begin(datasource: &str) -> Result<TransactionConn, CfmlError> {
             let pool = get_postgres_pool(&url)?;
             let mut conn = pool.get()
                 .map_err(|e| CfmlError::runtime(format!("cftransaction: PostgreSQL pool error: {}", e)))?;
-            conn.client.simple_query("BEGIN")
-                .map_err(|e| CfmlError::runtime(format!("cftransaction: BEGIN error: {}", e)))?;
+            let pg = &mut *conn;
+            if let Err(e) = pg.client.simple_query("BEGIN") {
+                if e.is_closed() {
+                    pg.broken = true;
+                }
+                return Err(CfmlError::runtime(format!("cftransaction: BEGIN error: {}", e)));
+            }
             Ok(TransactionConn::Postgres(conn))
         }
         #[cfg(feature = "mssql_db")]
@@ -8927,8 +8988,16 @@ fn transaction_commit(conn: &mut TransactionConn) -> Result<(), CfmlError> {
         }
         #[cfg(feature = "postgres_db")]
         TransactionConn::Postgres(c) => {
-            c.client.simple_query("COMMIT").map(|_| ())
-                .map_err(|e| CfmlError::runtime(format!("cftransaction: COMMIT error: {}", e)))
+            let pg = &mut **c;
+            match pg.client.simple_query("COMMIT") {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    if e.is_closed() {
+                        pg.broken = true;
+                    }
+                    Err(CfmlError::runtime(format!("cftransaction: COMMIT error: {}", e)))
+                }
+            }
         }
         #[cfg(feature = "mssql_db")]
         TransactionConn::Mssql(c) => {
@@ -8957,8 +9026,16 @@ fn transaction_rollback(conn: &mut TransactionConn) -> Result<(), CfmlError> {
         }
         #[cfg(feature = "postgres_db")]
         TransactionConn::Postgres(c) => {
-            c.client.simple_query("ROLLBACK").map(|_| ())
-                .map_err(|e| CfmlError::runtime(format!("cftransaction: ROLLBACK error: {}", e)))
+            let pg = &mut **c;
+            match pg.client.simple_query("ROLLBACK") {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    if e.is_closed() {
+                        pg.broken = true;
+                    }
+                    Err(CfmlError::runtime(format!("cftransaction: ROLLBACK error: {}", e)))
+                }
+            }
         }
         #[cfg(feature = "mssql_db")]
         TransactionConn::Mssql(c) => {
@@ -8991,7 +9068,7 @@ fn execute_with_transaction(conn: &mut TransactionConn, sql: &str, params_arg: &
         }
         #[cfg(feature = "postgres_db")]
         TransactionConn::Postgres(c) => {
-            execute_postgres_with_conn(&mut c.client, sql, params_arg, return_type)
+            execute_postgres_with_conn(&mut **c, sql, params_arg, return_type)
         }
         #[cfg(feature = "mssql_db")]
         TransactionConn::Mssql(c) => {
@@ -9091,11 +9168,11 @@ fn execute_mysql_with_conn(conn: &mut mysql::PooledConn, sql: &str, params_arg: 
 }
 
 #[cfg(feature = "postgres_db")]
-fn execute_postgres_with_conn(client: &mut postgres::Client, sql: &str, params_arg: &CfmlValue, return_type: &str) -> CfmlResult {
-    // Transaction path: a transaction is short-lived, so use a local statement
-    // cache (still de-dupes repeated SQL within the transaction).
-    let mut cache = PgStmtCache::new();
-    run_postgres_statements(client, &mut cache, sql, params_arg, return_type)
+fn execute_postgres_with_conn(conn: &mut PgConn, sql: &str, params_arg: &CfmlValue, return_type: &str) -> CfmlResult {
+    // Transaction path: do not retry inside a transaction, but still mark a
+    // closed connection as broken so the pool discards it on return.
+    run_postgres_on_conn(conn, sql, params_arg, return_type)
+        .map_err(|err| err.error)
 }
 
 // -----------------------------------------------

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -295,6 +295,7 @@ include "harness.cfm";
 <cf_runtest file="tags/test_pg_error_cause_chain.cfm">
 <cf_runtest file="tags/test_pg_extended_param_binds.cfm">
 <cf_runtest file="tags/test_pg_pool_checkout_validation.cfm">
+<cf_runtest file="tags/test_pg_pool_stale_connection_retry.cfm">
 <cf_runtest file="tags/test_cfquery_quoted_identifier.cfm">
 <cf_runtest file="tags/test_cte_with_query.cfm">
 <cf_runtest file="tags/test_tags_cfquery_control_tags.cfm">

--- a/tests/tags/test_pg_pool_stale_connection_retry.cfm
+++ b/tests/tags/test_pg_pool_stale_connection_retry.cfm
@@ -1,0 +1,65 @@
+<cfscript>
+// PostgreSQL pooled connections must recover when the server closes an idle
+// session behind the pool (Neon scale-to-zero / suspend-resume parity).
+//
+// RustCFML deliberately does not ping SELECT 1 on every checkout, matching
+// Lucee's default datasource behaviour and avoiding an extra remote round-trip.
+// Without a one-shot retry, though, a pooled connection whose backend was
+// closed while idle is handed out and the first real query fails at prepare
+// time with "connection closed".
+//
+// Live test, gated on RUSTCFML_TEST_PG_URL. To run locally:
+//   docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16
+//   RUSTCFML_TEST_PG_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres \
+//     cargo run -- tests/runner.cfm
+
+suiteBegin("PostgreSQL stale pooled connection retry (skipped without RUSTCFML_TEST_PG_URL)");
+
+function pgStaleRetryAppendDsnParam(required string dsn, required string key, required string value) {
+    return arguments.dsn & (find("?", arguments.dsn) ? "&" : "?") & arguments.key & "=" & arguments.value;
+}
+
+pgdsn = "";
+try {
+    pgdsn = server.system.environment.RUSTCFML_TEST_PG_URL ?: "";
+} catch (any e) {
+    pgdsn = "";
+}
+
+pgskip = false;
+
+if (pgdsn == "") {
+    pgskip = true;
+    writeOutput("  (skipped - set RUSTCFML_TEST_PG_URL to enable)" & chr(10));
+} else {
+    try {
+        queryExecute("SELECT 1", [], { datasource: pgdsn });
+    } catch (any e) {
+        pgskip = true;
+        writeOutput("  (skipped - PostgreSQL not reachable: " & e.message & ")" & chr(10));
+    }
+}
+
+if (NOT pgskip) {
+    try {
+        // First checkout creates and returns an idle pooled connection.
+        original = queryExecute("SELECT pg_backend_pid() AS pid", [], { datasource: pgdsn });
+        originalPid = original.pid[1];
+
+        // A distinct datasource string forces a separate pool/connection, so it
+        // can terminate the idle backend sitting in the original pool.
+        killerDsn = pgStaleRetryAppendDsnParam(pgdsn, "application_name", "rustcfml_stale_retry_killer");
+        killed = queryExecute("SELECT pg_terminate_backend(?::int) AS killed", [originalPid], { datasource: killerDsn });
+        assertTrue("test should terminate the original pooled backend", killed.killed[1]);
+
+        // The first attempt receives the stale pooled connection. The runtime
+        // must mark it broken, discard it, and retry on a fresh connection.
+        retried = queryExecute("SELECT 42 AS n", [], { datasource: pgdsn });
+        assert("stale pooled connection is retried transparently", retried.n[1], 42);
+    } catch (any e) {
+        assertTrue("stale pooled connection retry failed: " & e.message, false);
+    }
+}
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary
- mark pooled Postgres connections broken when query execution sees a closed driver connection
- retry once for retry-safe statements after returning the broken connection, preserving the no-SELECT-1-on-checkout behavior
- add a `cf_runtest` regression that terminates an idle PostgreSQL backend and verifies transparent retry

## Root cause
RustCFML intentionally disables r2d2 checkout validation for Lucee parity and remote database performance. That keeps each `cfquery` to one database round trip, but a server-closed idle session can still be handed back out by the pool. Neon scale-to-zero / suspend-resume closes those old sessions, so the first real `prepare` can fail with `connection closed` instead of evicting the connection and retrying.

The retry only applies when the driver reports a closed connection and the statement is retry-safe. SELECTs can retry. Mutation prepare failures can retry only before any mutation has executed. Mutation execute failures and transaction queries are not retried.

## Tests
- `cargo check -p rustcfml-cli`
- `RUSTCFML_TEST_PG_URL=postgresql://postgres:postgres@127.0.0.1:55432/postgres cargo run -- tests/runner.cfm | rg "FAIL \||FAILED:|All failures|PostgreSQL stale pooled|PostgreSQL pool checkout|SUMMARY|ALL TESTS PASSED"`
  - `PASS | PostgreSQL pool checkout validation ... | 1/1 passed`
  - `PASS | PostgreSQL stale pooled connection retry ... | 2/2 passed`
  - `SUMMARY: 4222/4222 passed across 517 suites`
  - `ALL TESTS PASSED`

## Lucee compatibility
The regression is env-gated on `RUSTCFML_TEST_PG_URL`; without a live PostgreSQL URL it skips cleanly. The runtime behavior matches Lucee-style recovery from dead idle pooled connections without adding a validation query to every checkout.