### PR TITLE
test(tags): nested cftransaction blocks must run (savepoint semantics)

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -512,6 +512,12 @@ include "harness.cfm";
 <!--- above (which has a body). A bare transaction{} block is the in-suite --->
 <!--- control. --->
 <cf_runtest file="tags/test_transaction_action_statement.cfm">
+<!--- - nested_transaction: a transaction{} block nested inside another --->
+<!--- transaction{} block. Lucee/ACF/BoxLang run the inner as a savepoint and --->
+<!--- complete; RustCFML throws "nested transactions are not supported". Wheels --->
+<!--- model save()/create() inside an outer app transaction hits this (84 specs --->
+<!--- in the core suite). --->
+<cf_runtest file="tags/test_nested_transaction.cfm">
 <!--- - component_declaration_attributes: follow-on to component_soft_keyword. --->
 <!--- Component-header metadata attributes are order-independent and may be --->
 <!--- written quoted or unquoted on Lucee/ACF/BoxLang. Two shapes the Wheels --->

--- a/tests/tags/test_nested_transaction.cfm
+++ b/tests/tags/test_nested_transaction.cfm
@@ -1,0 +1,55 @@
+<cfscript>
+suiteBegin("Tags: nested cftransaction blocks (savepoint semantics)");
+
+// ============================================================
+// Background  (gap surfaced laddering the Wheels framework test suite on RustCFML 0.220.0–0.228.0)
+// ============================================================
+// A `transaction { ... }` block may be NESTED inside another `transaction { ... }`
+// block. Lucee/ACF/BoxLang implement the inner block as a SAVEPOINT on the
+// already-open outer transaction, so the code runs to completion. RustCFML
+// instead throws at the inner block:
+//   "cftransaction: nested transactions are not supported"
+//
+// Wheels relies on this heavily: model save()/create() and the migrator wrap
+// work in a transaction, and application code frequently opens its own
+// transaction around several saves — producing a transaction inside a
+// transaction. The Wheels core test suite hits this in 84 specs; the suite is
+// green on Lucee. On RustCFML every model create() performed inside an outer
+// transaction aborts here.
+//
+// No datasource is required: with no query inside, the outer begin and the
+// inner savepoint are no-ops on Lucee/ACF/BoxLang, so the surrounding code
+// simply runs (same rationale as test_transaction_action_statement.cfm).
+//
+// catch-body locals don't persist on every engine (BoxLang discards a nested
+// `local` on exit), so each probe records its outcome in a struct FIELD.
+// ============================================================
+
+// ---- a transaction block nested inside another transaction block ----
+nestedState = {inner = false, outer = false, err = ""};
+try {
+	transaction {
+		transaction {
+			nestedState.inner = true;
+		}
+		nestedState.outer = true;
+	}
+} catch (any e) {
+	nestedState.err = e.message;
+}
+assertTrue("inner nested transaction{} block runs to completion", nestedState.inner);
+assertTrue("outer transaction{} block continues after the nested block", nestedState.outer);
+
+// ---- CONTROL: a single (non-nested) transaction block still works ----
+bareState = {flag = false};
+try {
+	transaction {
+		bareState.flag = true;
+	}
+} catch (any e) {
+	bareState.flag = false;
+}
+assertTrue("CONTROL: single transaction{} block runs to completion", bareState.flag);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
Adds a cross-engine test (red on RustCFML, green on Lucee/ACF/BoxLang) for nested `transaction { ... }` blocks.

## Gap

A `transaction { ... }` block nested inside another `transaction { ... }` block runs to completion on Lucee/ACF/BoxLang — the inner block becomes a **savepoint** on the already-open outer transaction. RustCFML throws at the inner block:

```
cftransaction: nested transactions are not supported
```

## Why it matters

Wheels relies on nested transactions heavily: model `save()`/`create()` and the migrator wrap their work in a transaction, and application code routinely opens its own transaction around several saves — producing a transaction inside a transaction. The Wheels core test suite hits this in **84 specs** (green on Lucee); on RustCFML every model `create()` performed inside an outer application transaction aborts here.

## Repro (verified on v0.228.0)

```cfml
transaction {
    transaction {
        // inner block — savepoint on Lucee/ACF/BoxLang
    }
}
```

- **RustCFML 0.228.0:** throws `cftransaction: nested transactions are not supported`
- **Lucee 5.4 / ACF / BoxLang:** runs to completion (empty blocks need no datasource)

## Test

`tests/tags/test_nested_transaction.cfm` — asserts the inner and outer blocks both run to completion, with a bare single-`transaction{}` block as the in-suite control. Registered in `tests/runner.cfm` beside the other transaction tags tests.