### PR TITLE
[codex] Handle same-quote strings inside interpolation

### DIFF
--- a/crates/cfml-compiler/src/lexer.rs
+++ b/crates/cfml-compiler/src/lexer.rs
@@ -304,13 +304,40 @@ impl Lexer {
                     let mut expr_str = String::new();
                     let mut depth = 0;
                     // Scan to the matching (depth-0) '#'. A lone, unbalanced '#'
-                    // must NOT run past the end of the string literal: if we reach
-                    // the closing quote (at depth <= 0, i.e. not inside a nested
-                    // call) the interpolation was never terminated. Report it at
-                    // the opening '#', not at some far-off EOF (GitHub #181).
+                    // must NOT run past the end of the string literal. Quoted
+                    // literals inside the interpolation expression are still part
+                    // of that expression, even when they use the same quote as the
+                    // outer string (for example: "#flag ? "YES" : ""#").
                     while !self.is_at_end() && !(self.current() == '#' && depth == 0) {
-                        if self.current() == '(' { depth += 1; }
-                        if self.current() == ')' { depth -= 1; }
+                        if (self.current() == '"' || self.current() == '\'')
+                            && self.can_start_interpolation_string_literal(&expr_str)
+                        {
+                            let nested_quote = self.current();
+                            expr_str.push(nested_quote);
+                            self.advance();
+
+                            while !self.is_at_end() {
+                                let c = self.current();
+                                expr_str.push(c);
+                                self.advance();
+
+                                if c == nested_quote {
+                                    if !self.is_at_end() && self.current() == nested_quote {
+                                        expr_str.push(self.current());
+                                        self.advance();
+                                        continue;
+                                    }
+                                    break;
+                                }
+                            }
+                            continue;
+                        }
+                        if self.current() == '(' {
+                            depth += 1;
+                        }
+                        if self.current() == ')' {
+                            depth -= 1;
+                        }
                         if self.current() == quote && depth <= 0 {
                             self.tokens.push(TokenWithLoc {
                                 token: Token::Error(format!(
@@ -403,6 +430,65 @@ impl Lexer {
                 });
             }
         }
+    }
+
+    fn can_start_interpolation_string_literal(&self, expr_str: &str) -> bool {
+        let trimmed = expr_str.trim_end();
+        let Some(previous) = trimmed.chars().last() else {
+            return true;
+        };
+
+        if matches!(
+            previous,
+            '(' | '['
+                | '{'
+                | ','
+                | ':'
+                | '?'
+                | '='
+                | '!'
+                | '<'
+                | '>'
+                | '+'
+                | '-'
+                | '*'
+                | '/'
+                | '%'
+                | '&'
+                | '|'
+                | '^'
+        ) {
+            return true;
+        }
+
+        if previous.is_ascii_alphanumeric() || previous == '_' || previous == '$' {
+            let word = trimmed
+                .rsplit(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$'))
+                .next()
+                .unwrap_or("")
+                .to_ascii_lowercase();
+
+            return matches!(
+                word.as_str(),
+                "and"
+                    | "or"
+                    | "xor"
+                    | "eq"
+                    | "neq"
+                    | "ne"
+                    | "gt"
+                    | "gte"
+                    | "lt"
+                    | "lte"
+                    | "contains"
+                    | "is"
+                    | "mod"
+                    | "eqv"
+                    | "imp"
+            );
+        }
+
+        false
     }
 
     fn number(&mut self, first: char) {
@@ -520,7 +606,8 @@ mod tests {
         assert_eq!(err.location.start.column, 22);
         // It must not have devoured the trailing bar(...) call.
         assert!(
-            toks.iter().any(|t| matches!(&t.token, Token::Identifier(s) if s == "bar")),
+            toks.iter()
+                .any(|t| matches!(&t.token, Token::Identifier(s) if s == "bar")),
             "interpolation ran past the string and swallowed later tokens"
         );
     }
@@ -543,6 +630,24 @@ mod tests {
             assert!(
                 lone_hash_error(&toks).is_none(),
                 "valid string wrongly flagged: {src}"
+            );
+        }
+    }
+
+    #[test]
+    fn same_quote_string_literals_inside_interpolation_do_not_error() {
+        for src in [
+            r###""value=#flag ? "YES" : ""#""###,
+            r###""statement=#flag ? "UNIQUE" : ""# INDEX #name#""###,
+            r###""enabled=#status EQ "active" ? "yes" : "no"#""###,
+            r###""quoted=#flag ? "A ""quoted"" value" : "fallback"#""###,
+            r###""hash=#replace("a##b", "##", "-")#""###,
+            r###"'value=#flag ? 'YES' : ''#'"###,
+        ] {
+            let toks = tokenize(src.to_string());
+            assert!(
+                lone_hash_error(&toks).is_none(),
+                "valid same-quote interpolation wrongly flagged: {src}"
             );
         }
     }

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -126,6 +126,7 @@ include "harness.cfm";
 <cf_runtest file="types/test_query_reference.cfm">
 <cf_runtest file="types/test_binary.cfm">
 <cf_runtest file="types/test_hash_in_strings.cfm">
+<cf_runtest file="types/test_string_interpolation_nested_strings.cfm">
 <cf_runtest file="comments/test_hash_in_comments.cfm">
 <cf_runtest file="comments/test_tags_in_block_comments.cfm">
 

--- a/tests/types/test_string_interpolation_nested_strings.cfm
+++ b/tests/types/test_string_interpolation_nested_strings.cfm
@@ -1,0 +1,34 @@
+<cfscript>
+suiteBegin("Type: string interpolation nested string literals");
+
+flag = true;
+sameQuoteTernary = "value=#flag ? "YES" : ""#";
+assert("double-quoted outer string allows double-quoted ternary branches", sameQuoteTernary, "value=YES");
+
+flag = false;
+sameQuoteEmptyBranch = "value=#flag ? "YES" : ""#";
+assert("same-quote ternary empty-string branch", sameQuoteEmptyBranch, "value=");
+
+indexName = "idx_demo";
+statementStruct = {
+    statement: "CREATE #flag ? "UNIQUE" : ""# INDEX #indexName#"
+};
+assert("same-quote interpolation inside struct literal value", statementStruct.statement, "CREATE  INDEX idx_demo");
+
+flag = true;
+statementStruct.statement = "CREATE #flag ? "UNIQUE" : ""# INDEX #indexName#";
+assert("same-quote interpolation preserves following interpolation segments", statementStruct.statement, "CREATE UNIQUE INDEX idx_demo");
+
+quotedValue = "value=#flag ? "A ""quoted"" value" : "fallback"#";
+assert("same-quote nested string keeps doubled quote escapes", quotedValue, "value=A ""quoted"" value");
+
+status = "active";
+keywordOperator = "enabled=#status EQ "active" ? "yes" : "no"#";
+assert("keyword operator followed by same-quote string literal", keywordOperator, "enabled=yes");
+
+singleOuterFlag = true;
+singleQuotedOuter = 'value=#singleOuterFlag ? 'YES' : ''#';
+assert("single-quoted outer string allows single-quoted ternary branches", singleQuotedOuter, "value=YES");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

Fixes a lexer regression where a quoted string literal inside a `#...#` interpolation expression could be mistaken for the end of the outer string when both strings use the same quote character.

This keeps the bounded-interpolation behavior from Issue #181 for genuinely lone hashes, but allows valid CFML such as:

```cfml
"value=#flag ? "YES" : ""#"
"statement=#flag ? "UNIQUE" : ""# INDEX #name#"
'enabled=#flag ? 'YES' : ''#'
```

## Root cause

The interpolation scanner currently treats the outer string's quote character as the end of the string whenever it appears at interpolation paren-depth `<= 0`. That correctly catches a lone hash such as `"GitHub #181"`, but it also rejects valid expression syntax where the interpolation expression itself contains a string literal.

The scanner now recognizes quoted string literals inside interpolation expressions before applying the outer-string boundary check. This prevents nested string content from changing interpolation depth or prematurely ending the outer string.

## Covered scenarios

- double-quoted outer string with double-quoted ternary branches
- empty-string ternary branch
- interpolated string inside a struct literal value
- a following `#name#` interpolation segment after the same-quote expression
- doubled quote escapes inside nested strings
- keyword operators followed by same-quote string literals (`EQ "active"`)
- single-quoted outer string with single-quoted ternary branches
- nested string literals containing escaped `##`

## Validation

- `cargo test -p cfml-compiler`
- `cargo run -- --code 'include "tests/harness.cfm"; include "tests/types/test_string_interpolation_nested_strings.cfm";'`
  - `PASS | Type: string interpolation nested string literals | 7/7 passed`
- `cargo run -- tests/runner.cfm | rg 'SUMMARY|FAIL \\||ERROR'`
  - `SUMMARY: 4271/4271 passed across 529 suites`
- Targeted Lucee 7 check using disposable `lucee/lucee:7.0.3.43-light-nginx` container
  - `SUMMARY: 7/7 passed across 1 suites`
