### PR TITLE
Match Lucee cfcookie Path and SameSite attributes

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -253,6 +253,20 @@ fn format_cookie_expires(raw: &str) -> String {
     dt.format(FMT).to_string()
 }
 
+fn format_cookie_samesite(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(match trimmed.to_ascii_lowercase().as_str() {
+        "lax" => "Lax".to_string(),
+        "strict" => "Strict".to_string(),
+        "none" => "None".to_string(),
+        _ => trimmed.to_string(),
+    })
+}
+
 /// A cached compiled bytecode program with its source file modification time.
 pub struct CachedProgram {
     pub program: BytecodeProgram,
@@ -10288,10 +10302,18 @@ impl CfmlVirtualMachine {
                         {
                             cookie.push_str(&format!("; Domain={}", domain.as_string()));
                         }
-                        if let Some((_, path)) =
-                            opts.iter().find(|(k, _)| k.to_lowercase() == "path")
+                        let path = opts
+                            .iter()
+                            .find(|(k, _)| k.to_lowercase() == "path")
+                            .map(|(_, v)| v.as_string())
+                            .unwrap_or_else(|| "/".to_string());
+                        cookie.push_str(&format!("; Path={}", path));
+                        if let Some((_, samesite)) =
+                            opts.iter().find(|(k, _)| k.to_lowercase() == "samesite")
                         {
-                            cookie.push_str(&format!("; Path={}", path.as_string()));
+                            if let Some(value) = format_cookie_samesite(&samesite.as_string()) {
+                                cookie.push_str(&format!("; SameSite={}", value));
+                            }
                         }
                         if let Some((_, secure)) =
                             opts.iter().find(|(k, _)| k.to_lowercase() == "secure")

--- a/crates/cfml-vm/tests/cfcookie_path_samesite.rs
+++ b/crates/cfml-vm/tests/cfcookie_path_samesite.rs
@@ -1,0 +1,186 @@
+//! Regression: `<cfcookie>` must emit Lucee-compatible `Path` and `SameSite`
+//! cookie attributes.
+//!
+//! Lucee defaults omitted `path` to `/`, so a cookie set from `/easy/check.cfm`
+//! is site-wide. RustCFML previously omitted `Path` entirely, leaving browsers
+//! to scope the cookie to the request directory (`/easy`).
+//!
+//! Lucee also emits the `samesite` attribute supplied to `<cfcookie>`. RustCFML
+//! previously ignored it in the VM-level `__cfcookie` handler.
+
+use cfml_codegen::compiler::CfmlCompiler;
+use cfml_common::dynamic::{CfmlValue, ValueMap};
+use cfml_common::vfs::{EmbeddedFs, Vfs};
+use cfml_compiler::{parser::Parser, tag_parser};
+use cfml_stdlib::builtins::{get_builtin_functions, get_builtins};
+use cfml_vm::{CfmlVirtualMachine, MemoryStore, ServerState, SessionStore};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+const VROOT: &str = "/app";
+
+const APP: &str = r##"
+component {
+    this.name = "cfcookie-path-samesite-test";
+    function onRequest(targetPage) { include "#targetPage#"; }
+}
+"##;
+
+/// Execute a CFML page from a non-root path and return `Set-Cookie` headers.
+fn set_cookies(page: &str) -> Vec<String> {
+    let mut files: HashMap<String, Vec<u8>> = HashMap::new();
+    files.insert("Application.cfc".to_string(), APP.as_bytes().to_vec());
+    files.insert("easy/check.cfm".to_string(), page.as_bytes().to_vec());
+    let vfs: Arc<dyn Vfs> = Arc::new(EmbeddedFs::new(files, VROOT.to_string()));
+
+    let page_path = format!("{}/easy/check.cfm", VROOT);
+    let source = vfs.read_to_string(&page_path).unwrap();
+    let processed = if tag_parser::has_cfml_tags(&source) {
+        tag_parser::tags_to_script(&source)
+    } else {
+        source
+    };
+    let ast = Parser::new(processed).parse().unwrap();
+    let program = CfmlCompiler::new().compile(ast);
+
+    let mut server_state = ServerState::with_production(false);
+    server_state.sessions = Arc::new(MemoryStore::new()) as Arc<dyn SessionStore>;
+
+    let mut vm = CfmlVirtualMachine::new(program);
+    vm.vfs = vfs;
+    vm.source_file = Some(page_path.clone());
+    vm.base_template_path = Some(page_path);
+    for (name, value) in get_builtins() {
+        vm.globals.insert(name, value);
+    }
+    for (name, func) in get_builtin_functions() {
+        vm.builtins.insert(name, func);
+    }
+    for scope in ["url", "cgi", "form"] {
+        vm.globals
+            .entry(scope.to_string())
+            .or_insert_with(|| CfmlValue::strukt(ValueMap::default()));
+    }
+    vm.server_state = Some(server_state);
+    vm.session_id = Some("sid-cookie".to_string());
+
+    let _ = vm.execute_with_lifecycle();
+
+    vm.response_headers
+        .iter()
+        .filter(|(k, _)| k.eq_ignore_ascii_case("set-cookie"))
+        .map(|(_, v)| v.clone())
+        .collect()
+}
+
+fn cookie(cookies: &[String], name: &str) -> String {
+    let prefix = format!("{}=", name);
+    cookies
+        .iter()
+        .find(|c| c.starts_with(&prefix))
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn attr_value(cookie_line: &str, attr_name: &str) -> Option<String> {
+    let prefix = format!("{}=", attr_name).to_ascii_lowercase();
+    cookie_line.split(';').find_map(|segment| {
+        let trimmed = segment.trim();
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.starts_with(&prefix) {
+            Some(trimmed[prefix.len()..].to_string())
+        } else {
+            None
+        }
+    })
+}
+
+#[test]
+fn cfcookie_default_path_is_root() {
+    let cookies = set_cookies(r#"<cfcookie name="root_path" value="v">"#);
+    let c = cookie(&cookies, "root_path");
+    assert_eq!(
+        attr_value(&c, "Path").as_deref(),
+        Some("/"),
+        "omitted path must default to Path=/, got: {}",
+        c
+    );
+}
+
+#[test]
+fn cfcookie_explicit_path_wins() {
+    let cookies = set_cookies(r#"<cfcookie name="custom_path" value="v" path="/custom">"#);
+    let c = cookie(&cookies, "custom_path");
+    assert_eq!(
+        attr_value(&c, "Path").as_deref(),
+        Some("/custom"),
+        "explicit path must be preserved, got: {}",
+        c
+    );
+}
+
+#[test]
+fn cfcookie_samesite_lax_is_emitted() {
+    let cookies = set_cookies(r#"<cfcookie name="same_lax" value="v" samesite="Lax">"#);
+    let c = cookie(&cookies, "same_lax");
+    assert_eq!(
+        attr_value(&c, "SameSite").as_deref(),
+        Some("Lax"),
+        "samesite=\"Lax\" must emit SameSite=Lax, got: {}",
+        c
+    );
+}
+
+#[test]
+fn cfcookie_samesite_strict_and_none_are_emitted() {
+    let cookies = set_cookies(
+        r#"
+        <cfcookie name="same_strict" value="v" samesite="Strict">
+        <cfcookie name="same_none" value="v" samesite="None" secure="true">
+        "#,
+    );
+
+    let strict = cookie(&cookies, "same_strict");
+    assert_eq!(
+        attr_value(&strict, "SameSite").as_deref(),
+        Some("Strict"),
+        "samesite=\"Strict\" must emit SameSite=Strict, got: {}",
+        strict
+    );
+
+    let none = cookie(&cookies, "same_none");
+    assert_eq!(
+        attr_value(&none, "SameSite").as_deref(),
+        Some("None"),
+        "samesite=\"None\" must emit SameSite=None, got: {}",
+        none
+    );
+}
+
+#[test]
+fn cfcookie_samesite_expression_is_evaluated() {
+    let cookies = set_cookies(
+        r##"
+        <cfset sameSitePolicy = "Lax">
+        <cfcookie name="same_expr" value="v" samesite="#sameSitePolicy#">
+        "##,
+    );
+    let c = cookie(&cookies, "same_expr");
+    assert_eq!(
+        attr_value(&c, "SameSite").as_deref(),
+        Some("Lax"),
+        "samesite=\"#sameSitePolicy#\" must evaluate and emit SameSite=Lax, got: {}",
+        c
+    );
+}
+
+#[test]
+fn cfcookie_omitted_samesite_does_not_emit_attribute() {
+    let cookies = set_cookies(r#"<cfcookie name="same_omitted" value="v">"#);
+    let c = cookie(&cookies, "same_omitted");
+    assert!(
+        attr_value(&c, "SameSite").is_none(),
+        "omitted samesite must not invent a SameSite attribute, got: {}",
+        c
+    );
+}

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -339,6 +339,7 @@ include "harness.cfm";
 <cf_runtest file="tags/test_tags_cfthread.cfm">
 <cf_runtest file="tags/test_tags_cfthread_concurrency.cfm">
 <cf_runtest file="tags/test_tags_cfscript_statements.cfm">
+<cf_runtest file="tags/test_cfcookie_path_samesite.cfm">
 <cf_runtest file="tags/test_tags_cfhttp_interpolation.cfm">
 <cf_runtest file="tags/test_cfhttp_attribute_collection.cfm">
 <cf_runtest file="tags/test_throw_object_rootcause.cfm">

--- a/tests/tags/cfcookie_path_samesite_target.cfm
+++ b/tests/tags/cfcookie_path_samesite_target.cfm
@@ -1,0 +1,14 @@
+<cfparam name="url.test" default="">
+
+<cfif url.test EQ "default">
+    <cfcookie name="ck_default" value="v" samesite="Lax">
+    <cfoutput>default-ok</cfoutput>
+<cfelseif url.test EQ "explicit">
+    <cfcookie name="ck_explicit" value="v" path="/custom" samesite="Strict" httponly="true" secure="true">
+    <cfoutput>explicit-ok</cfoutput>
+<cfelseif url.test EQ "omitted">
+    <cfcookie name="ck_omitted" value="v">
+    <cfoutput>omitted-ok</cfoutput>
+<cfelse>
+    <cfoutput>unknown-test</cfoutput>
+</cfif>

--- a/tests/tags/test_cfcookie_path_samesite.cfm
+++ b/tests/tags/test_cfcookie_path_samesite.cfm
@@ -1,0 +1,74 @@
+<cfscript>
+suiteBegin("Tags: cfcookie Path and SameSite attributes");
+
+function responseHeaderBlob(required struct result) {
+    return serializeJSON(arguments.result.responseheader);
+}
+
+function statusCodeIs200(required string statusCode) {
+    return left(trim(arguments.statusCode), 3) == "200";
+}
+
+function getTarget(required string testName) {
+    var candidate = "";
+    var lastResult = {};
+
+    for (candidate in request.cookieBaseUrls) {
+        http url=candidate & request.cookieTargetPath & "?test=" & arguments.testName method="GET" result="httpResult";
+        lastResult = httpResult;
+        if (statusCodeIs200(httpResult.statuscode)) {
+            return httpResult;
+        }
+    }
+
+    return lastResult;
+}
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+if (serverPort == "" || serverPort == "0") {
+    writeOutput(chr(10) & "  skipped cfcookie HTTP header subtests (no cgi.server_port - run via rustcfml --serve)" & chr(10));
+} else {
+    request.cookieBaseUrls = [
+        "http://127.0.0.1:" & serverPort,
+        "http://127.0.0.1",
+        "http://localhost:" & serverPort,
+        "http://localhost"
+    ];
+    request.cookieTargetPath = "/tests/tags/cfcookie_path_samesite_target.cfm";
+
+    defaultResult = getTarget("default");
+    assertTrue("default target responds", statusCodeIs200(defaultResult.statuscode));
+    assert("default body", trim(defaultResult.filecontent), "default-ok");
+    defaultHeaders = responseHeaderBlob(defaultResult);
+    assertTrue("default cfcookie emits Path=/",
+        findNoCase("ck_default=v", defaultHeaders) > 0
+        && findNoCase("Path=/", defaultHeaders) > 0);
+    assertTrue("default cfcookie emits SameSite=Lax",
+        findNoCase("ck_default=v", defaultHeaders) > 0
+        && findNoCase("SameSite=Lax", defaultHeaders) > 0);
+
+    explicitResult = getTarget("explicit");
+    assertTrue("explicit target responds", statusCodeIs200(explicitResult.statuscode));
+    assert("explicit body", trim(explicitResult.filecontent), "explicit-ok");
+    explicitHeaders = responseHeaderBlob(explicitResult);
+    assertTrue("explicit cfcookie preserves path",
+        findNoCase("ck_explicit=v", explicitHeaders) > 0
+        && findNoCase("Path=/custom", explicitHeaders) > 0);
+    assertTrue("explicit cfcookie emits SameSite=Strict",
+        findNoCase("ck_explicit=v", explicitHeaders) > 0
+        && findNoCase("SameSite=Strict", explicitHeaders) > 0);
+    assertTrue("explicit cfcookie still emits Secure and HttpOnly",
+        findNoCase("Secure", explicitHeaders) > 0
+        && findNoCase("HttpOnly", explicitHeaders) > 0);
+
+    omittedResult = getTarget("omitted");
+    assertTrue("omitted target responds", statusCodeIs200(omittedResult.statuscode));
+    assert("omitted body", trim(omittedResult.filecontent), "omitted-ok");
+    omittedHeaders = responseHeaderBlob(omittedResult);
+    assertTrue("omitted samesite does not invent SameSite",
+        findNoCase("ck_omitted=v", omittedHeaders) > 0
+        && findNoCase("SameSite", omittedHeaders) == 0);
+}
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

- Default omitted `<cfcookie path>` to `Path=/`, matching Lucee browser scope behavior.
- Emit `SameSite=<value>` from the `<cfcookie samesite>` attribute.
- Preserve explicit `path`, existing `Secure`, and existing `HttpOnly` handling.

## Minimal CFML shape

```cfml
<cfcookie name="x" value="1" samesite="Lax">
```

When emitted from a non-root request path, Lucee sends the cookie with `Path=/; SameSite=Lax`. RustCFML previously omitted both attributes, leaving browsers to scope the cookie to the request directory and silently dropping the SameSite policy.

## Root cause

The VM `__cfcookie` handler only emitted `Path` when the `path` attribute was explicitly supplied, and it had no `samesite` branch. The tag parser already passes arbitrary attributes through to `__cfcookie`, so this is fixed at the VM cookie-header emission point.

## Covered scenarios

- Omitted `path` emits `Path=/`.
- Explicit `path` still wins.
- `samesite="Lax"`, `Strict`, and `None` are emitted.
- `samesite="#expression#"` is evaluated before emission.
- Omitted `samesite` does not invent a SameSite attribute.
- Served CFML regression checks real `Set-Cookie` headers and confirms `Secure`/`HttpOnly` still emit.

## Validation

- `cargo test -p cfml-vm --test cfcookie_path_samesite` — 6/6 passed.
- Served RustCFML targeted CFML probe for `tests/tags/test_cfcookie_path_samesite.cfm` — 12/12 passed.
- `cargo run -q -p rustcfml-cli --bin rustcfml -- tests/runner.cfm` — 4308/4308 passed across 539 suites.
- Targeted Lucee validation via `targeted-lucee-test.sh tests/tags/test_cfcookie_path_samesite.cfm` — 12/12 passed.
- `git diff --cached --check` — passed.
- `rustfmt --check --edition 2021 crates/cfml-vm/tests/cfcookie_path_samesite.rs` — passed.
