### PR TITLE
Preserve cfhttp binary responses

### DIFF
--- a/crates/cfml-compiler/src/tag_parser.rs
+++ b/crates/cfml-compiler/src/tag_parser.rs
@@ -888,7 +888,18 @@ fn parse_cf_tag(chars: &[char], start: usize, len: usize, imports: &mut std::col
             // format_attr_value emits literal segments quoted and only evaluates
             // the #...# parts; strip_hashes would collapse the whole value into a
             // bare (mis-parsed) expression like `baseUrlpath`.
-            for key in ["url", "method", "timeout", "charset", "username", "password", "useragent", "proxyserver", "multipart"] {
+            for key in [
+                "url",
+                "method",
+                "timeout",
+                "charset",
+                "username",
+                "password",
+                "useragent",
+                "proxyserver",
+                "multipart",
+                "getasbinary",
+            ] {
                 if let Some(v) = attrs.get(key) {
                     opts.push(format!("{}: {}", key, format_attr_value(v, quoted.contains(key))));
                 }

--- a/crates/cfml-stdlib/src/builtins.rs
+++ b/crates/cfml-stdlib/src/builtins.rs
@@ -6063,14 +6063,42 @@ fn merge_cfhttp_attribute_collection(arg: CfmlValue) -> CfmlValue {
 }
 
 #[cfg(feature = "http")]
+fn cfhttp_get_as_binary_enabled(value: &CfmlValue) -> bool {
+    match value {
+        CfmlValue::Bool(enabled) => *enabled,
+        CfmlValue::Int(i) => *i != 0,
+        CfmlValue::Double(d) => *d != 0.0,
+        CfmlValue::String(s) => matches!(
+            s.to_ascii_lowercase().as_str(),
+            "true" | "yes" | "1" | "binary" | "always"
+        ),
+        _ => false,
+    }
+}
+
+#[cfg(feature = "http")]
+fn cfhttp_file_content(resp: ureq::Response, get_as_binary: bool) -> CfmlValue {
+    if !get_as_binary {
+        return CfmlValue::string(resp.into_string().unwrap_or_default());
+    }
+
+    let mut reader = resp.into_reader();
+    let mut body = Vec::new();
+    if std::io::Read::read_to_end(&mut reader, &mut body).is_err() {
+        body.clear();
+    }
+    CfmlValue::Binary(body)
+}
+
+#[cfg(feature = "http")]
 fn fn_cfhttp(args: Vec<CfmlValue>) -> CfmlResult {
     use std::collections::HashMap;
 
     let arg = merge_cfhttp_attribute_collection(args.into_iter().next().unwrap_or(CfmlValue::Null));
 
     // Parse arguments: either a URL string or an options struct
-    let (mut url, method, headers, body, timeout_secs, throw_on_error, follow_redirects, encode_url, port, proxy_server, proxy_port) = match &arg {
-        CfmlValue::String(url) => ((**url).clone(), "GET".to_string(), HashMap::<String, String>::new(), None::<Vec<u8>>, 30u64, false, true, true, None::<u16>, None::<String>, None::<u16>),
+    let (mut url, method, headers, body, timeout_secs, throw_on_error, follow_redirects, encode_url, port, proxy_server, proxy_port, get_as_binary) = match &arg {
+        CfmlValue::String(url) => ((**url).clone(), "GET".to_string(), HashMap::<String, String>::new(), None::<Vec<u8>>, 30u64, false, true, true, None::<u16>, None::<String>, None::<u16>, false),
         CfmlValue::Struct(opts) => {
             let mut url = opts.iter()
                 .find(|(k, _)| k.eq_ignore_ascii_case("url"))
@@ -6322,7 +6350,12 @@ fn fn_cfhttp(args: Vec<CfmlValue>) -> CfmlResult {
                     _ => None,
                 });
 
-            (url, method, hdrs, body, timeout, throw_on_error, follow_redirects, encode_url, port, proxy_server, proxy_port)
+            let get_as_binary = opts.iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case("getasbinary"))
+                .map(|(_, v)| cfhttp_get_as_binary_enabled(&v))
+                .unwrap_or(false);
+
+            (url, method, hdrs, body, timeout, throw_on_error, follow_redirects, encode_url, port, proxy_server, proxy_port, get_as_binary)
         }
         _ => return Err(CfmlError::runtime("cfhttp requires a URL string or options struct".to_string())),
     };
@@ -6428,7 +6461,7 @@ fn fn_cfhttp(args: Vec<CfmlValue>) -> CfmlResult {
                 }
             }
 
-            let body_text = resp.into_string().unwrap_or_default();
+            let file_content = cfhttp_file_content(resp, get_as_binary);
 
             let (mime, charset) = parse_content_type(&content_type);
 
@@ -6440,7 +6473,7 @@ fn fn_cfhttp(args: Vec<CfmlValue>) -> CfmlResult {
             result_struct.insert("status_code".to_string(), CfmlValue::Int(status as i64));
             result_struct.insert("statusText".to_string(), CfmlValue::string(status_text.clone()));
             result_struct.insert("status_text".to_string(), CfmlValue::string(status_text));
-            result_struct.insert("fileContent".to_string(), CfmlValue::string(body_text));
+            result_struct.insert("fileContent".to_string(), file_content);
             result_struct.insert("mimeType".to_string(), CfmlValue::string(mime));
             result_struct.insert("charset".to_string(), CfmlValue::string(charset));
             result_struct.insert("responseHeader".to_string(), CfmlValue::strukt(resp_headers));
@@ -6464,14 +6497,14 @@ fn fn_cfhttp(args: Vec<CfmlValue>) -> CfmlResult {
                 }
             }
 
-            let body_text = resp.into_string().unwrap_or_default();
+            let file_content = cfhttp_file_content(resp, get_as_binary);
             let (mime, charset) = parse_content_type(&content_type);
 
             result_struct.insert("statusCode".to_string(), CfmlValue::string(format!("{} {}", code, status_text)));
             result_struct.insert("status_code".to_string(), CfmlValue::Int(code as i64));
             result_struct.insert("statusText".to_string(), CfmlValue::string(status_text.clone()));
             result_struct.insert("status_text".to_string(), CfmlValue::string(status_text));
-            result_struct.insert("fileContent".to_string(), CfmlValue::string(body_text));
+            result_struct.insert("fileContent".to_string(), file_content);
             result_struct.insert("mimeType".to_string(), CfmlValue::string(mime));
             result_struct.insert("charset".to_string(), CfmlValue::string(charset));
             result_struct.insert("responseHeader".to_string(), CfmlValue::strukt(resp_headers));

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1762,11 +1762,15 @@ fn build_success_response(
         &response.response_headers,
     );
 
-    // Determine body
+    // Determine body. Binary cfcontent payloads must stay raw bytes; stringifying
+    // a CfmlValue::Binary would emit the diagnostic placeholder instead.
     let body = if let Some(ref body_override) = response.response_body {
-        body_override.as_string()
+        match body_override {
+            CfmlValue::Binary(bytes) => axum::body::Body::from(bytes.clone()),
+            other => axum::body::Body::from(other.as_string()),
+        }
     } else {
-        response.output
+        axum::body::Body::from(response.output)
     };
 
     // Determine status code
@@ -1795,7 +1799,7 @@ fn build_success_response(
         }
     }
 
-    builder.body(axum::body::Body::from(body)).unwrap()
+    builder.body(body).unwrap()
 }
 
 use cfml_vm::web::{ResolvedFile, resolve_file};
@@ -3036,4 +3040,3 @@ fn embedded_status(pid_file: &str) {
     }
     exit(0);
 }
-

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -185,6 +185,7 @@ include "harness.cfm";
 <cf_runtest file="stdlib/test_writedump.cfm">
 <cf_runtest file="stdlib/test_cfdirectory_type_filter.cfm">
 <cf_runtest file="stdlib/test_cfhttp.cfm">
+<cf_runtest file="stdlib/test_cfhttp_binary_response.cfm">
 
 <!--- --- Function References --- --->
 <cf_runtest file="functions/test_function_references.cfm">

--- a/tests/stdlib/cfhttp_binary_target.cfm
+++ b/tests/stdlib/cfhttp_binary_target.cfm
@@ -1,0 +1,4 @@
+<cfscript>
+payload = binaryDecode("00FF10414280", "hex");
+cfcontent(type = "application/octet-stream", variable = payload, reset = true);
+</cfscript>

--- a/tests/stdlib/test_cfhttp_binary_response.cfm
+++ b/tests/stdlib/test_cfhttp_binary_response.cfm
@@ -1,0 +1,33 @@
+<cfscript>
+suiteBegin("cfhttp binary response");
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+if (skip) {
+    assertTrue("cfhttp binary response skipped (no cgi.server_port)", true);
+} else {
+    targetPath = "/tests/stdlib/cfhttp_binary_target.cfm";
+    targetUrl = "http://127.0.0.1:" & serverPort & targetPath;
+    fallbackTargetUrl = "http://127.0.0.1" & targetPath;
+}
+</cfscript>
+
+<cfif NOT skip>
+    <cfhttp url="#targetUrl#" method="GET" result="binaryResult" getAsBinary="yes">
+
+    <cfif binaryResult.status_code NEQ 200>
+        <cfhttp url="#fallbackTargetUrl#" method="GET" result="binaryResult" getAsBinary="yes">
+    </cfif>
+
+    <cfscript>
+    assertTrue("getAsBinary returns binary fileContent", isBinary(binaryResult.fileContent));
+    assert("getAsBinary preserves exact bytes", binaryEncode(binaryResult.fileContent, "hex"), "00FF10414280");
+    assert("binary response status", binaryResult.status_code, 200);
+    assert("binary response mime type", binaryResult.mimeType, "application/octet-stream");
+    </cfscript>
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

RustCFML currently decodes `cfhttp` response bodies as text even when `getAsBinary` is requested, and serve mode stringifies binary `cfcontent` payloads instead of writing raw bytes. That breaks CFML proxy patterns where a binary resource is fetched with `cfhttp getAsBinary="yes"` and returned with `cfcontent`.

## Minimal CFML shape

```cfml
<cfhttp url="#url#" method="GET" result="r" getAsBinary="yes">
<cfcontent type="application/octet-stream" variable="#r.fileContent#" reset="true">
```

## Root cause

- The `<cfhttp>` tag parser did not include `getAsBinary` in the generated options struct.
- `fn_cfhttp` always consumed response bodies through `into_string()`, so arbitrary bytes were decoded as text.
- Serve-mode `cfcontent` responses converted `CfmlValue::Binary` through `as_string()`, producing the diagnostic placeholder instead of the original bytes.

## Covered scenarios

- `cfhttp getAsBinary` returns binary `fileContent` for byte payloads.
- Both success and non-2xx `cfhttp` responses preserve binary `fileContent` when requested.
- Served `cfcontent variable=<binary>` responses emit raw bytes.
- Lucee-compatible truthy values for `getAsBinary` include `true`, `yes`, `1`, `binary`, and `always`.

## Validation

- `cargo check -p rustcfml-cli`: passed with the existing `compile_expression_static` dead-code warning in `cfml-codegen`.
- Served RustCFML full runner: `PASS | cfhttp binary response | 4/4 passed`; `SUMMARY: 4387/4387 passed across 540 suites`.
- Targeted Lucee validation: `PASS | cfhttp binary response | 4/4 passed`; `SUMMARY: 4/4 passed across 1 suites`.

No known validation gaps.
