### PR TITLE
Preserve cfquery SQL line comments

### DIFF
--- a/crates/cfml-compiler/src/tag_parser.rs
+++ b/crates/cfml-compiler/src/tag_parser.rs
@@ -3180,13 +3180,15 @@ fn scan_cfqueryparam_tags(sql_body: &str) -> (String, Vec<CfQueryParam>) {
 /// Converts #var# to string concatenation: `"..." & var & "..."`
 /// Returns a script expression that builds the final SQL string.
 fn process_sql_hashes(sql: &str) -> String {
-    let sql = sql.trim().replace('\n', " ").replace('\r', "");
+    let sql = sql.trim().replace("\r\n", "\n").replace('\r', "\n");
 
     if !sql.contains('#') {
         // No hash expressions — simple string literal. CFML escapes an embedded
         // double-quote by DOUBLING it (""), not with a backslash; SQL bodies use
         // double-quoted identifiers (AS "where"), so a backslash escape would
-        // terminate the string early and fail to parse.
+        // terminate the string early and fail to parse. Preserve line breaks:
+        // SQL `--` comments are line-scoped, and flattening newlines changes
+        // the statement semantics.
         return format!("\"{}\"", sql.replace('"', "\"\""));
     }
 
@@ -3556,6 +3558,20 @@ mod tests {
         let result = tags_to_script(input);
         assert!(result.contains(r#""tok-" & (mailVar)"#), "got: {result}");
         assert!(!result.contains("value: tok-mailVar"), "got: {result}");
+    }
+
+    #[test]
+    fn test_cfquery_preserves_sql_line_comment_newlines() {
+        let input = "<cfquery name=\"q\" dbtype=\"query\">\nSELECT name\n-- comment\nFROM src\nWHERE id = #targetId#\n</cfquery>";
+        let result = tags_to_script(input);
+        assert!(
+            result.contains("SELECT name\n-- comment\nFROM src\nWHERE id = "),
+            "got: {result}"
+        );
+        assert!(
+            !result.contains("SELECT name -- comment FROM src"),
+            "got: {result}"
+        );
     }
 
     #[test]

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -322,6 +322,7 @@ include "harness.cfm";
 <cf_runtest file="tags/test_pg_pool_stale_connection_retry.cfm">
 <cf_runtest file="tags/test_mssql_pool_stale_connection_retry.cfm">
 <cf_runtest file="tags/test_cfquery_quoted_identifier.cfm">
+<cf_runtest file="tags/test_cfquery_sql_line_comments.cfm">
 <cf_runtest file="tags/test_cte_with_query.cfm">
 <cf_runtest file="tags/test_tags_cfquery_control_tags.cfm">
 <cf_runtest file="tags/test_cfquery_result_delivery.cfm">

--- a/tests/tags/test_cfquery_sql_line_comments.cfm
+++ b/tests/tags/test_cfquery_sql_line_comments.cfm
@@ -1,0 +1,36 @@
+<cfscript>
+suiteBegin("cfquery SQL line comments");
+
+src = queryNew("id,name", "integer,varchar", [[1, "alpha"], [2, "beta"]]);
+targetId = 2;
+</cfscript>
+
+<cfquery name="controlRows" dbtype="query">
+    SELECT name
+    FROM src
+    WHERE id = 2
+</cfquery>
+
+<cfquery name="lineCommentRows" dbtype="query">
+    SELECT name
+    -- this SQL comment must end at the newline, not consume FROM/WHERE
+    FROM src
+    WHERE id = 2
+</cfquery>
+
+<cfquery name="interpolatedLineCommentRows" dbtype="query">
+    SELECT name
+    -- this SQL comment must also end before interpolated SQL text
+    FROM src
+    WHERE id = #targetId#
+</cfquery>
+
+<cfscript>
+assert("control cfquery body without SQL comment", controlRows.recordCount, 1);
+assert("cfquery body preserves newline after SQL line comment", lineCommentRows.recordCount, 1);
+assert("cfquery body returns row after SQL line comment", lineCommentRows.name, "beta");
+assert("interpolated cfquery body preserves newline after SQL line comment", interpolatedLineCommentRows.recordCount, 1);
+assert("interpolated cfquery body returns row after SQL line comment", interpolatedLineCommentRows.name, "beta");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

`<cfquery>` currently flattens SQL body newlines while lowering tag syntax to `queryExecute(...)`. That changes the semantics of SQL line comments: a PostgreSQL/QoQ `--` comment that should end at the next newline instead consumes the rest of the statement after newline flattening.

## Minimal CFML shape

```cfml
<cfquery name="q" dbtype="query">
    SELECT name
    -- comment
    FROM src
    WHERE id = #targetId#
</cfquery>
```

Lucee preserves the newline after `--`, so the `FROM` and `WHERE` clauses remain part of the SQL statement.

## Root cause

`process_sql_hashes()` trimmed the `<cfquery>` body and replaced every LF with a space before emitting the generated CFScript string. That made the generated SQL effectively one line:

```sql
SELECT name -- comment FROM src WHERE id = ...
```

This PR keeps line breaks intact, normalizing CRLF and bare CR to LF instead of flattening them.

## Covered scenarios

- Static `<cfquery>` SQL with `--` line comments.
- Interpolated `<cfquery>` SQL with `#...#` expressions after a `--` line comment.
- Query-of-Queries coverage keeps the regression self-contained and cross-engine.
- A focused compiler unit pins the tag-lowering output so the generated script keeps the line break.

## Validation

- `cargo test -p cfml-compiler test_cfquery_preserves_sql_line_comment_newlines -- --nocapture`: passed.
- Focused RustCFML CFML test: `PASS | cfquery SQL line comments | 5/5 passed`; `SUMMARY: 5/5 passed across 1 suites`.
- Full RustCFML runner: new test passed; final summary `4380/4380 passed across 544 suites`. The run also emitted an unrelated `ERROR | stdlib/test_cfhttp.cfm | Invalid JSON: EOF while parsing a value at line 1 column 0` while still reporting the all-passed summary.
- Targeted Lucee validation: `PASS | cfquery SQL line comments | 5/5 passed`; `SUMMARY: 5/5 passed across 1 suites`.
- `cargo check -p rustcfml-cli`: passed with the existing `compile_expression_static` dead-code warning in `cfml-codegen`.

## Formatting note

`cargo fmt -p cfml-compiler -- --check` was attempted, but it reports broad pre-existing formatting drift across the package. I did not run formatter to avoid unrelated churn; the changed hunks pass `git diff --check`.
