### PR TITLE
[codex] Add regression for custom tag caller scope from CFC method

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -291,6 +291,7 @@ include "harness.cfm";
 <cf_runtest file="tags/test_tags_cfhtmlhead_body.cfm">
 <cf_runtest file="tags/test_tags_cfexit.cfm">
 <cf_runtest file="tags/test_tags_customtag.cfm">
+<cf_runtest file="tags/test_custom_tag_caller_cfc_method.cfm">
 <cf_runtest file="tags/test_custom_tag_attribute_collection.cfm">
 <cf_runtest file="tags/test_tags_customtag_lifecycle.cfm">
 <cf_runtest file="tags/test_tags_buffer_recovery.cfm">

--- a/tests/tags/CustomTagCallerCfcFixture.cfc
+++ b/tests/tags/CustomTagCallerCfcFixture.cfc
@@ -1,0 +1,7 @@
+<cfcomponent output="false">
+    <cffunction name="render" returntype="string" output="false">
+        <cfset payload = { label: "method-scope" } />
+        <cfsavecontent variable="local.out"><cfmodule template="customtags/cfc_caller_probe.cfm">BODY</cfmodule></cfsavecontent>
+        <cfreturn trim(local.out) />
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/customtags/cfc_caller_probe.cfm
+++ b/tests/tags/customtags/cfc_caller_probe.cfm
@@ -1,0 +1,8 @@
+<cfif thisTag.executionMode EQ "end">
+    <cfif structKeyExists(caller, "payload")>
+        <cfoutput>caller:#caller.payload.label#|body:#trim(thisTag.generatedContent)#</cfoutput>
+    <cfelse>
+        <cfoutput>caller:missing|body:#trim(thisTag.generatedContent)#</cfoutput>
+    </cfif>
+    <cfset thisTag.generatedContent = "" />
+</cfif>

--- a/tests/tags/test_custom_tag_caller_cfc_method.cfm
+++ b/tests/tags/test_custom_tag_caller_cfc_method.cfm
@@ -1,0 +1,16 @@
+<cfscript>
+suiteBegin("Tags: custom tag caller scope from CFC methods");
+
+try {
+    fixture = createObject("component", "tags.CustomTagCallerCfcFixture");
+} catch (any e) {
+    fixture = createObject("component", "tests.tags.CustomTagCallerCfcFixture");
+}
+assert(
+    "body custom tag sees CFC method-scope variables through caller scope",
+    fixture.render(),
+    "caller:method-scope|body:BODY"
+);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## Summary

This draft PR adds a generic Lucee compatibility regression test for custom tag `caller` scope when a body-mode custom tag is invoked from inside a CFC method.

It intentionally contains only tests and does not propose an implementation change.

## Minimal Shape

```cfml
<cfcomponent>
    <cffunction name="render">
        <cfset payload = { label: "method-scope" } />
        <cfmodule template="customtags/cfc_caller_probe.cfm">BODY</cfmodule>
    </cffunction>
</cfcomponent>
```

The custom tag's end phase reads `caller.payload.label` and `thisTag.generatedContent`.

## Expected vs Actual

On Lucee, the custom tag sees the CFC method-scope variable through `caller` and renders:

```text
caller:method-scope|body:BODY
```

On RustCFML v0.266.0 / current `main`, the body content is delivered correctly, but `caller.payload` is missing:

```text
caller:missing|body:BODY
```

## Covered Scenario

- Body-mode `cfmodule` invoked from a CFC method.
- End-phase custom tag code reading a caller-scope variable.
- Body generated content still delivered through `thisTag.generatedContent`.

## Validation

- `cargo build` passed.
- `./target/debug/rustcfml tests/runner.cfm` fails as expected for the new regression:
  - `Tags: custom tag caller scope from CFC methods | 0/1 passed`
  - expected `caller:method-scope|body:BODY`, got `caller:missing|body:BODY`
  - overall `SUMMARY: 4542/4543 passed across 554 suites`
- `/Users/mat/dev/hello/.agents/skills/rustcfml-upstream/scripts/targeted-lucee-test.sh tests/tags/test_custom_tag_caller_cfc_method.cfm` passed:
  - `SUMMARY: 1/1 passed across 1 suites`
