### PR TITLE
test(core): closure must capture enclosing var-scoped function expressions

### DIFF
--- a/tests/core/test_closure_captures_local_function.cfm
+++ b/tests/core/test_closure_captures_local_function.cfm
@@ -1,0 +1,50 @@
+<cfscript>
+suiteBegin("Closure captures enclosing var-scoped function");
+
+// ============================================================
+// Gap surfaced laddering the Wheels framework test suite on RustCFML 0.273.0
+// ============================================================
+// A closure captures the var-scoped variables of its enclosing function. On
+// Lucee/ACF/BoxLang that includes var-scoped FUNCTION EXPRESSIONS: a helper
+// declared `var fn = function(){...}` in the outer function can be called by
+// bare name from inside a nested closure. RustCFML captures plain var VALUES
+// (strings, numbers, structs) correctly, but a var-scoped function expression
+// is NOT visible inside the closure — a bare call throws
+// "Variable 'fn' is undefined", and even isClosure(fn) / a bare read throws.
+//
+// This is the standard test-helper pattern: define a helper at the top of a
+// spec's run() and call it from inside the it()/describe() closures. The Wheels
+// core suite uses it widely (e.g. MigratorInfoSpec `var insertOrphan = ...`
+// called from nested it() closures; packages specs `var $withEnv`, `$freshCache`).
+// On RustCFML every such call errors.
+//
+// catch-body locals don't persist on every engine, so outcomes are recorded in
+// a struct FIELD.
+// ============================================================
+
+function buildScope() {
+	// var-scoped values AND a var-scoped function expression in the enclosing fn
+	var strVal = "captured-string";
+	var fnVal  = function (required string x) {
+		return "fn:" & arguments.x;
+	};
+	var out = {};
+	// a nested closure that reads both
+	var inner = () => {
+		try { out.str = strVal; }       catch (any e) { out.str = "ERR:" & e.message; }
+		try { out.fn  = fnVal("ok"); }   catch (any e) { out.fn  = "ERR:" & e.message; }
+	};
+	inner();
+	return out;
+}
+
+result = buildScope();
+
+// CONTROL: plain var VALUE is captured by the nested closure (already works on RustCFML)
+assert("nested closure captures an enclosing var-scoped string", result.str, "captured-string");
+
+// THE GAP: nested closure must also see the enclosing var-scoped FUNCTION expression
+assert("nested closure can call an enclosing var-scoped function", result.fn, "fn:ok");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -22,6 +22,14 @@ include "harness.cfm";
 <cf_runtest file="core/test_null_return_no_key.cfm">
 <cf_runtest file="core/test_bare_call_shadowing_semantics.cfm">
 <cf_runtest file="core/test_closure_env_leak.cfm">
+<!--- - closure_captures_local_function: a closure captures its enclosing fn's --->
+<!--- var-scoped values AND var-scoped FUNCTION expressions. RustCFML captures --->
+<!--- plain values but not a `var fn = function(){}` helper — a bare call from --->
+<!--- inside a nested closure throws "Variable 'fn' is undefined". Surfaced in --->
+<!--- the Wheels suite where specs define a helper at the top of run() and call --->
+<!--- it from nested it()/describe() closures (MigratorInfoSpec insertOrphan, --->
+<!--- packages $withEnv/$freshCache). Runtime-level, registration is safe. --->
+<cf_runtest file="core/test_closure_captures_local_function.cfm">
 <cf_runtest file="core/test_struct_stored_closure_dotcall.cfm">
 <cf_runtest file="core/test_compound_assignment.cfm">
 <cf_runtest file="core/test_undeclared_named_args.cfm">


### PR DESCRIPTION
Adds a cross-engine test (red on RustCFML, green on Lucee/ACF/BoxLang) for closure capture of an enclosing `var`-scoped **function expression**.

## Gap

A closure captures the `var`-scoped variables of its enclosing function. On Lucee/ACF/BoxLang that includes function expressions — a helper declared `var fn = function(){...}` can be called by bare name from inside a nested closure. RustCFML captures plain `var` values (string/number/struct) but **not** a `var`-scoped function expression: a bare call from inside the closure throws `Variable fn is undefined` (and even `isClosure(fn)` / a bare read throws).

## Repro (verified on v0.273.0)

```cfml
function buildScope() {
    var strVal = "captured-string";
    var fnVal  = function (x) { return "fn:" & arguments.x; };
    var out = {};
    var inner = () => {
        out.str = strVal;      // OK on RustCFML — value captured
        out.fn  = fnVal("ok"); // RustCFML: "Variable fnVal is undefined"
    };
    inner();
    return out;
}
```

Same nested closure, same enclosing `var` scope:

| Captured var | RustCFML 0.273.0 | Lucee 5.4 / ACF / BoxLang |
|---|---|---|
| `strVal` (string) | `"captured-string"` ✅ | ✅ |
| `fnVal` (function expr) | **`Variable fnVal is undefined`** 🔴 | `"fn:ok"` ✅ |

So plain-value capture already works; only function-expression capture is missing.

## Why it matters

This is the standard test-helper pattern — define a helper at the top of a specs `run()`, call it from inside `it()`/`describe()` closures. The Wheels core suite uses it widely and every such call errors on RustCFML (~21 spec failures across `migrator` and `packages`):

- `vendor/wheels/tests/specs/migrator/MigratorInfoSpec.cfc` — `var insertOrphan = function(version){...}` called from nested `it()` closures (12 failures)
- `vendor/wheels/tests/specs/packages/*` — `var $withEnv`, `var $freshCache` (9 failures)

## Test

`tests/core/test_closure_captures_local_function.cfm` — control assertion (a `var`-scoped string IS captured) passes on RustCFML, isolating function-expression capture specifically. Registered in `tests/runner.cfm` beside the other closure tests.