### PR TITLE
test(core): closure must capture grandparent var-fn across a deferred nested closure

### DIFF
--- a/tests/core/test_closure_captures_local_function.cfm
+++ b/tests/core/test_closure_captures_local_function.cfm
@@ -42,4 +42,57 @@ assert("nested closure captures an enclosing var-scoped string", result.str, "ca
 assert("nested closure can call an enclosing var-scoped function", result.fn, "fn:ok");
 
 suiteEnd();
+
+
+suiteBegin("Closure captures enclosing var-scoped function (deferred / nested-closure)");
+
+// ============================================================
+// Second gap, surfaced laddering the Wheels suite on RustCFML 0.309.0. The
+// single-level case above is now fixed, but the shape the Wheels core specs
+// actually use is still broken: the capturing closure is DEFINED INSIDE an
+// intermediate closure's body and INVOKED AFTER that intermediate has returned
+// — i.e. describe(() => { it(() => { helper(); }); }), where TestBox stores the
+// it() body and runs it later. RustCFML loses the grandparent var-scoped
+// function expression across that intermediate boundary and throws
+// "Variable 'fnVal' is undefined". Lucee/ACF/BoxLang keep the capture.
+//
+// This is the exact shape of MigratorInfoSpec / OrphanDetectionSpec /
+// MigratorReconciliationSpec — `var insertOrphan = function(){...}` declared in
+// run(), called from inside it() closures nested under describe() — which error
+// "Variable 'insertOrphan' is undefined" on 0.309 (12 specs).
+// ============================================================
+
+function buildDeferredScope() {
+	// var-scoped function expression in the ENCLOSING (grandparent) fn
+	var fnVal = function (required string x) {
+		return "fn:" & arguments.x;
+	};
+	var stored = [];
+	// an intermediate closure that runs its argument synchronously (like describe())
+	var intermediate = function (required any body) {
+		arguments.body();
+	};
+	intermediate(() => {
+		// inner closure DEFINED HERE (inside the intermediate's body), capturing the
+		// grandparent fnVal, and STORED for later invocation (like it()'s body)
+		arrayAppend(stored, () => {
+			return fnVal("ok");
+		});
+	});
+	var out = {};
+	// pull the stored closure out before calling — arr[idx]() call syntax is rejected
+	// by the Lucee/ACF parsers, so keep this cross-engine safe
+	var deferred = stored[1];
+	try { out.fn = deferred(); }          // invoke AFTER the intermediate returned
+	catch (any e) { out.fn = "ERR:" & e.message; }
+	return out;
+}
+
+deferredResult = buildDeferredScope();
+
+// THE GAP: a closure defined inside an intermediate closure and invoked later must
+// still see the enclosing var-scoped FUNCTION expression.
+assert("deferred nested closure can call an enclosing var-scoped function", deferredResult.fn, "fn:ok");
+
+suiteEnd();
 </cfscript>


### PR DESCRIPTION
## Closure must capture an enclosing var-scoped function expression across a *deferred* nested closure

Follow-up to #198. That PR fixed the single-level case — a nested closure invoked **immediately** inside its enclosing function can now call a `var`-scoped function expression by bare name (verified: scenario 1 of the test passes on v0.309). But the shape the Wheels core suite actually uses is still broken on **v0.309.0**:

> a closure is **defined inside an intermediate closure's body** and **invoked after that intermediate has returned** — i.e. `describe(() => { it(() => { helper(); }); })`, where TestBox stores the `it()` body and runs it later.

Across that intermediate boundary RustCFML loses the grandparent's `var`-scoped function expression and throws `Variable '<name>' is undefined`. Lucee / ACF / BoxLang keep the capture.

### Impact in the Wheels suite (v0.309.0, core BDD suite)
12 specs error with `Variable 'insertOrphan' is undefined`, all using the helper-in-`run()` / call-from-`it()` pattern:
- `OrphanDetectionSpec` (7), `MigratorReconciliationSpec` (3), `MigratorInfoSpec` (2)

```cfm
function run() {
    var insertOrphan = function(version) { queryExecute(...); };   // grandparent var-fn
    describe("...", () => {                                         // intermediate closure
        it("...", () => { insertOrphan("999"); });                 // inner: deferred, foreign-invoked
    });
}
```

### Minimal repro (cross-engine)
Bisected: it is **not** about a foreign caller or nesting depth per se — it is the combination of *defining the inner closure inside an intermediate closure's body* and *invoking it after that body returned*. A closure created directly in the enclosing function and stored/invoked later works fine.

```cfm
function buildDeferredScope() {
    var fnVal = function (x) { return "fn:" & x; };
    var stored = [];
    var intermediate = function (body) { body(); };   // like describe()
    intermediate(() => {
        arrayAppend(stored, () => { return fnVal("ok"); });  // inner captures grandparent fnVal
    });
    var deferred = stored[1];                          // (arr[idx]() call form rejected by Lucee/ACF)
    return deferred();                                 // invoked AFTER intermediate returned
}
```

| Engine | Result |
|---|---|
| Lucee 7.0.4.34 | `fn:ok` ✅ |
| RustCFML v0.309.0 | `ERR:Variable 'fnVal' is undefined` ❌ |

### This PR
Adds a second suite to `tests/core/test_closure_captures_local_function.cfm` (the #198 test) covering the deferred shape. Validated **red on the v0.309.0 binary** (scenario 2: 0/1) and **green on Lucee 7.0.4.34** (1/1); scenario 1 (the #198 fix) stays green on both.
