### PR TITLE
test(oop): getMetadata self-name in ctor + ancestor functions/path on the extends chain

### DIFF
--- a/tests/oop/GmaBaseFixture.cfc
+++ b/tests/oop/GmaBaseFixture.cfc
@@ -1,0 +1,3 @@
+component {
+	public function baseFn() {}
+}

--- a/tests/oop/GmaCtorFixture.cfc
+++ b/tests/oop/GmaCtorFixture.cfc
@@ -1,0 +1,7 @@
+component {
+	// Read the component's own metadata name DURING the pseudo-constructor.
+	variables.nameAtCtor = getMetadata(this).name;
+	public function getNameAtCtor() {
+		return variables.nameAtCtor;
+	}
+}

--- a/tests/oop/GmaSubFixture.cfc
+++ b/tests/oop/GmaSubFixture.cfc
@@ -1,0 +1,3 @@
+component extends="GmaBaseFixture" {
+	public function subFn() {}
+}

--- a/tests/oop/test_getmetadata_fidelity.cfm
+++ b/tests/oop/test_getmetadata_fidelity.cfm
@@ -1,0 +1,31 @@
+<cfscript>
+suiteBegin("getMetadata fidelity (ctor-time self name + ancestor functions/path)");
+
+// ============================================================
+// Gaps surfaced laddering the Wheels framework test suite on RustCFML 0.309.0.
+// ============================================================
+// (A) GetMetadata(this).name read DURING the pseudo-constructor returns the
+//     literal "Anonymous" on RustCFML (it resolves correctly only AFTER
+//     construction). Wheels keys its promote-includes memo on this ctor-time
+//     name (Global.cfc), so the cache lands under "Anonymous" —
+//     promoteIncludedGlobalsMemoSpec fails with "got [Anonymous]".
+// (B) GetMetadata().extends ANCESTOR nodes must carry the same functions[] and
+//     path keys the leaf component does (Lucee/ACF/BoxLang populate every level
+//     of the chain). RustCFML leaves them off the ancestor node, so the Wheels
+//     inheritance-chain config()-shadow scan (Controller.cfc
+//     $configOverrideSkipsSuper) cannot see ancestor functions and
+//     configSuperWarningSpec fails.
+// ============================================================
+
+// (A) ctor-time self name
+ctorObj = createObject("component", "GmaCtorFixture");
+assert("GetMetadata(this).name in the pseudo-constructor is the class name, not Anonymous", ctorObj.getNameAtCtor(), "GmaCtorFixture");
+
+// (B) ancestor node carries functions[] and path
+md = getMetadata(createObject("component", "GmaSubFixture"));
+ext = md.keyExists("extends") ? md.extends : {};
+assertTrue("GetMetadata().extends ancestor node carries a functions array", structKeyExists(ext, "functions"));
+assertTrue("GetMetadata().extends ancestor node carries a path", structKeyExists(ext, "path"));
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -714,6 +714,7 @@ include "harness.cfm";
 <cf_runtest file="oop/test_cfinvoke_sibling_scope.cfm">
 <cf_runtest file="oop/test_cfinvoke_overlay_writeback.cfm">
 <cf_runtest file="oop/test_mixin_private_scope_dispatch.cfm">
+<cf_runtest file="oop/test_getmetadata_fidelity.cfm">
 
 <!--- --- Lucee-compat regression tests (PRs #153/#154/#155/#156) --- --->
 <cf_runtest file="comments/test_cfset_expression_comments.cfm">


### PR DESCRIPTION
## getMetadata fidelity: ctor-time self name + ancestor `functions`/`path` on the `extends` chain

Two related `getMetadata` gaps surfaced laddering the Wheels framework test suite on **v0.309.0**. Both are pure-CFML reflection semantics, fail on RustCFML, and pass on Lucee 7.0.4.34.

### (A) `GetMetadata(this).name` is `"Anonymous"` during the pseudo-constructor
Read from inside a component's pseudo-constructor body, `GetMetadata(this).name` returns the literal `"Anonymous"` instead of the class name. It resolves correctly *after* construction — so the engine knows the name, it just isn't populated yet when the constructor runs.

Wheels keys its promote-includes memo on this ctor-time name (`Global.cfc`), so the cache lands under `"Anonymous"` — `promoteIncludedGlobalsMemoSpec` fails with `got [Anonymous]` and an extra spurious cache entry.

### (B) `GetMetadata().extends` ancestor nodes miss `functions` and `path`
The leaf component's metadata has `functions` and `path`; its `.extends` ancestor node does not (Lucee/ACF/BoxLang populate every level of the chain). Wheels' inheritance-chain `config()`-shadow scan (`Controller.cfc::$configOverrideSkipsSuper`) walks the ancestors looking for shadowed functions, finds none, and the dev-mode "called config() without super.config()" warning never fires — `configSuperWarningSpec` fails (4 specs).

### Cross-engine results

| | RustCFML v0.309.0 | Lucee 7.0.4.34 |
|---|---|---|
| `GetMetadata(this).name` in ctor | `Anonymous` ❌ | `GmaCtorFixture` ✅ |
| ancestor `.extends.functions` present | `false` ❌ | `true` ✅ |
| ancestor `.extends.path` present | `false` ❌ | `true` ✅ |

### This PR
Adds `tests/oop/test_getmetadata_fidelity.cfm` (+ fixtures `GmaCtorFixture`, `GmaBaseFixture`, `GmaSubFixture`) and registers it. Validated **red on the v0.309.0 binary** (0/3) and **green on Lucee 7.0.4.34** (3/3).
