### PR TITLE
test(qoq): queryExecute maxrows option + list:true IN-clause expansion

### DIFF
--- a/tests/qoq/test_queryexecute_maxrows_list.cfm
+++ b/tests/qoq/test_queryexecute_maxrows_list.cfm
@@ -1,0 +1,30 @@
+<cfscript>
+suiteBegin("queryExecute maxrows option + list:true IN-clause expansion");
+
+// ============================================================
+// Gaps surfaced laddering the Wheels framework test suite on RustCFML 0.309.0.
+// ============================================================
+// Both reproduce in pure Query-of-Queries (dbtype="query"), so they are
+// engine-wide query-binding gaps, NOT database-specific. Surfaced by
+// DatabaseAdapterSpec's cleanup() (a SELECT bounded by the `maxrows` option,
+// then a DELETE ... WHERE id IN (:ids) using a list=true param). The cluster's
+// "DELETE ... LIMIT" hypothesis was a red herring — these two query primitives
+// are the actual gaps.
+//   (A) the `maxrows` queryExecute option must cap the result set.
+//   (B) a list=true query param must expand into a parenthesized value list.
+// Lucee/ACF honor both; RustCFML ignores maxrows (returns all rows) and does not
+// expand list=true (matches 0 rows).
+// ============================================================
+
+q = queryNew("id", "integer", [[1],[2],[3],[4],[5]]);
+
+// (A) maxrows
+capped = queryExecute("SELECT id FROM q ORDER BY id", {}, {dbtype = "query", maxrows = 2});
+assert("the maxrows option caps the result set to 2 rows", capped.recordCount, 2);
+
+// (B) list:true expansion into IN()
+inList = queryExecute("SELECT id FROM q WHERE id IN (:ids)", {ids = {value = "1,2,3", list = true}}, {dbtype = "query"});
+assert("a list=true param expands into an IN() value list (3 matches)", inList.recordCount, 3);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -728,6 +728,7 @@ include "harness.cfm";
 <cf_runtest file="qoq/test_qoq_subqueries_union.cfm">
 <cf_runtest file="qoq/test_qoq_custom_functions.cfm">
 <cf_runtest file="qoq/test_qoq_rustcfml_ext.cfm">
+<cf_runtest file="qoq/test_queryexecute_maxrows_list.cfm">
 
 <!--- WebSocket / realtime: connection-free harness coverage (live-socket --->
 <!--- behaviour is covered by crates/cli/tests/websocket_raw.rs). --->


### PR DESCRIPTION
## queryExecute `maxrows` option + `list:true` IN-clause expansion

Two `queryExecute` query-binding gaps surfaced laddering the Wheels framework test suite on **v0.309.0** (`DatabaseAdapterSpec` cleanup). Both reproduce in **pure Query-of-Queries** (`dbtype="query"`), so they are engine-wide query-binding gaps — not database-specific.

> Note: the original hypothesis ("DELETE … LIMIT / `SQLITE_ENABLE_UPDATE_DELETE_LIMIT`") was a red herring. `DatabaseAdapter.cfc::cleanup()` does not emit `DELETE … LIMIT`; it bounds a `SELECT` with the `maxrows` option, then `DELETE`s `WHERE id IN (:ids)` using a `list=true` param. Those two primitives are the actual gaps.

### (A) the `maxrows` option is ignored
`queryExecute(sql, {}, {dbtype="query", maxrows=2})` returns all rows instead of capping at 2.

### (B) a `list=true` param does not expand into an IN() value list
`queryExecute("… WHERE id IN (:ids)", {ids={value="1,2,3", list=true}}, …)` matches 0 rows instead of expanding to `IN (1,2,3)`.

### Cross-engine results

| | RustCFML v0.309.0 | Lucee 7.0.4.34 |
|---|---|---|
| `maxrows=2` → recordCount | `5` ❌ | `2` ✅ |
| `list=true` IN() → recordCount | `0` ❌ | `3` ✅ |

### This PR
Adds `tests/qoq/test_queryexecute_maxrows_list.cfm` and registers it. Validated **red on the v0.309.0 binary** (0/2) and **green on Lucee 7.0.4.34** (2/2).
