### PR TITLE
Fixes #280

### DIFF
--- a/crates/cfml-vm/src/web.rs
+++ b/crates/cfml-vm/src/web.rs
@@ -259,11 +259,38 @@ pub fn parse_query_string(qs: &str) -> ValueMap {
             let key = url_decode(key);
             let value = url_decode(value);
             if !key.is_empty() {
-                map.insert(key.to_lowercase(), CfmlValue::string(value));
+                insert_query_value(&mut map, key.to_lowercase(), value);
             }
         }
     }
     map
+}
+
+fn insert_query_value(map: &mut ValueMap, key: String, value: String) {
+    if value.is_empty() {
+        // An empty value never contributes to a merge, but the key must still
+        // exist (a lone `dup=` yields an empty string).
+        map.entry(key)
+            .or_insert_with(|| CfmlValue::string(String::new()));
+        return;
+    }
+    if let Some(existing) = map.get_mut(&key) {
+        if let CfmlValue::String(existing_value) = existing {
+            if existing_value.is_empty() {
+                *existing = CfmlValue::string(value);
+            } else {
+                let mut merged =
+                    String::with_capacity(existing_value.len() + 1 + value.len());
+                merged.push_str(existing_value);
+                merged.push(',');
+                merged.push_str(&value);
+                *existing = CfmlValue::string(merged);
+            }
+            return;
+        }
+    }
+
+    map.insert(key, CfmlValue::string(value));
 }
 
 /// HTTP "singleton" response headers: ones that must carry exactly one value
@@ -532,6 +559,25 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect()
+    }
+
+    #[test]
+    fn duplicate_query_keys_join_with_commas() {
+        // CFML semantics (verified live on Lucee 5.3.10 AND 7.0.4): duplicate
+        // FORM/URL keys merge into a comma-separated list in document order,
+        // with EMPTY values dropped from the merge. Last-one-wins loses data.
+        let m = parse_query_string("dup=first&dup=&dup=third");
+        assert_eq!(m["dup"].as_string(), "first,third");
+        // all-empty: key exists, value is ""
+        let m = parse_query_string("dup=&dup=");
+        assert_eq!(m["dup"].as_string(), "");
+        // trailing/leading empty never leaves a placeholder
+        assert_eq!(parse_query_string("dup=x&dup=")["dup"].as_string(), "x");
+        assert_eq!(parse_query_string("dup=&dup=x")["dup"].as_string(), "x");
+        // duplicates are NOT deduped
+        assert_eq!(parse_query_string("dup=a&dup=a")["dup"].as_string(), "a,a");
+        // single key unaffected
+        assert_eq!(parse_query_string("solo=1")["solo"].as_string(), "1");
     }
 
     #[test]

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -531,6 +531,7 @@ include "harness.cfm";
 <cf_runtest file="lifecycle/test_appscope_receiver_no_resurrect.cfm">
 <cf_runtest file="server/test_front_controller_fallback.cfm">
 <cf_runtest file="server/test_location_redirect.cfm">
+<cf_runtest file="server/test_form_duplicate_fields.cfm">
 
 <!--- --- Java Shims --- --->
 <cf_runtest file="java_shims/test_all.cfm">

--- a/tests/server/form_duplicate_fields_target.cfm
+++ b/tests/server/form_duplicate_fields_target.cfm
@@ -1,0 +1,8 @@
+<cfsetting enablecfoutputonly="true" />
+<!---
+    Target for test_form_duplicate_fields.cfm. Echoes the received `dup` value
+    from whichever scope the caller exercised, so the caller can assert how
+    duplicate keys were merged (comma-join, Lucee semantics) rather than
+    last-one-wins.
+--->
+<cfoutput>form=[#form.dup ?: "(missing)"#];url=[#url.dup ?: "(missing)"#]</cfoutput>

--- a/tests/server/test_form_duplicate_fields.cfm
+++ b/tests/server/test_form_duplicate_fields.cfm
@@ -1,0 +1,71 @@
+<cfscript>
+suiteBegin("Server: duplicate form/url keys merge");
+
+// ============================================================
+// Background
+// ============================================================
+// Duplicate field names in a request must merge into a comma-separated list
+// in document order (Lucee/ACF semantics), with EMPTY values dropped from the
+// merge: `dup=first&dup=&dup=third` -> "first,third". Last-one-wins silently
+// loses every earlier value -- real browsers post duplicate fields routinely
+// (hidden fallback inputs, multi-select checkboxes), so the loss is invisible
+// until production. Verified live against Lucee 7.0.4.
+//
+// Both the form and url scopes share the same parse path, so both are
+// asserted. The POST body is sent raw (type="body") so the test exercises the
+// server's request parsing, not cfhttp's own duplicate-formfield encoding.
+//
+// Like the other HTTP round-trip tests this needs a live server: it discovers
+// the port from cgi.server_port and skips when run from the CLI.
+// ============================================================
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+if (skip) {
+    assertTrue("duplicate form/url keys skipped (no cgi.server_port)", true);
+} else {
+    baseUrl = "http://127.0.0.1:" & serverPort;
+    target = "/tests/server/form_duplicate_fields_target.cfm";
+    postError = "";
+    getError = "";
+}
+</cfscript>
+
+<cfif NOT skip>
+    <!--- form scope: raw urlencoded body with duplicate keys + an empty middle value --->
+    <cftry>
+        <cfhttp url="#baseUrl##target#" method="POST" result="postResult">
+            <cfhttpparam type="header" name="Content-Type" value="application/x-www-form-urlencoded" />
+            <cfhttpparam type="body" value="dup=first&dup=&dup=third" />
+        </cfhttp>
+        <cfcatch type="any"><cfset postError = cfcatch.message></cfcatch>
+    </cftry>
+
+    <!--- url scope: same duplicate keys on the query string --->
+    <cftry>
+        <cfhttp url="#baseUrl##target#?dup=first&dup=&dup=third" method="GET" result="getResult">
+        </cfhttp>
+        <cfcatch type="any"><cfset getError = cfcatch.message></cfcatch>
+    </cftry>
+
+    <cfscript>
+        assertTrue("duplicate-key POST round-trip completed", postError == "");
+        if (postError == "") {
+            assert("form scope: duplicate keys comma-join, empties dropped",
+                listFirst(trim(postResult.fileContent), ";"),
+                "form=[first,third]");
+        }
+
+        assertTrue("duplicate-key GET round-trip completed", getError == "");
+        if (getError == "") {
+            assert("url scope: duplicate keys comma-join, empties dropped",
+                listLast(trim(getResult.fileContent), ";"),
+                "url=[first,third]");
+        }
+    </cfscript>
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Duplicate field names in a request were resolved last-one-wins in both the`form` and `url` scopes. Lucee merge them into a comma-separated list in document order, with empty values dropped: `dup=first&dup=&dup=third` → `first,third`. Both scopes route through `parse_query_string()`, so one change in `insert_query_value()` covers both.

Semantics verified live against Lucee 7.0.4.34:
- comma-join in document order, empty values dropped (`first,third`, not `first,,third`)
- all-empty → key exists with `""`
- duplicates are NOT deduped (`a,a`)
- values containing literal commas join naively, no escaping (matches Lucee)

## Tests

- CFML: `tests/server/test_form_duplicate_fields.cfm` + echo target — POST sends a raw urlencoded body (`type="body"`) so it exercises the server's request parsing rather than cfhttp's own duplicate-formfield encoding; asserts both scopes; skips from the CLI like the other HTTP round-trip tests.   **Passes 4/4 on Lucee 7.0.4** (served from the project root) and on RustCFML serve mode (suite: 6684/6684).
- Rust: unit test in `web.rs` covering the merge + empty-value edge cases (`cargo test -p cfml-vm --lib`: 145 passed).
