### PR TITLE
RED test: PostgreSQL queryExecute failures must be catchable as type=database

### DIFF
--- a/tests/database/test_query_error_catch_type_database.cfm
+++ b/tests/database/test_query_error_catch_type_database.cfm
@@ -1,0 +1,64 @@
+<cfscript>
+// A queryExecute failure must raise a DATABASE-typed exception so
+// `catch (database e)` / `<cfcatch type="database">` matches — Lucee/ACF parity.
+//
+// The SQLite and MySQL adapters already raise CfmlError::database, but the
+// PostgreSQL adapter funnels every query failure through
+// PgRunError::from_postgres (crates/cfml-stdlib/src/builtins.rs), which wraps
+// them as CfmlError::runtime — so a database-typed catch never matches and the
+// error falls through to `catch (any)`. (pg_sql.rs's two param-rewrite errors
+// have the same blind spot.)
+//
+// Repro class: framework first-run fallbacks wrap "table may not exist yet"
+// probes in <cfcatch type="database">. On RustCFML + Postgres the catch never
+// matches, so booting against an empty database throws instead of falling back
+// (moopa route_registry_store.cfc / core.cfc had to widen to type="any").
+//
+// The PostgreSQL leg is live-gated (same convention as
+// test_db_null_column_empty_string.cfm) and skips when the env var is unset:
+//   docker run -d -p 55432:5432 -e POSTGRES_PASSWORD=test -e POSTGRES_DB=testdb postgres:16
+//   RUSTCFML_TEST_PG_DS=postgres://postgres:test@127.0.0.1:55432/testdb \
+//     cargo run --features all-databases -- tests/runner.cfm
+
+suiteBegin("queryExecute failures are catchable as type=database");
+
+function envDs(required string varName) {
+	try { return getEnvironmentVariable(arguments.varName, ""); }
+	catch (any e) { return ""; }
+}
+
+// Which catch clause does a missing-table query error land in?
+function catchClauseFor(required any ds) {
+	try {
+		queryExecute("SELECT 1 FROM rcfml_missing_table_f362", [], {datasource: arguments.ds});
+		return "no-error-raised";
+	} catch (database e) {
+		return "database";
+	} catch (any e) {
+		return "any (cfcatch.type=" & (e.type ?: "") & ")";
+	}
+}
+
+// ---- SQLite (control: already lands in the database-typed catch) ----
+memDs = { class: "org.sqlite.JDBC", connectionString: "jdbc:sqlite::memory:" };
+assert("SQLite: missing-table error lands in catch (database e)", catchClauseFor(memDs), "database");
+
+// ---- PostgreSQL (currently lands in catch (any) as a generic runtime error) ----
+pgDs = envDs("RUSTCFML_TEST_PG_DS");
+if ( len(pgDs) == 0 ) {
+	assertTrue("PostgreSQL database-typed catch skipped (RUSTCFML_TEST_PG_DS not set)", true);
+} else {
+	assert("PostgreSQL: missing-table error lands in catch (database e)", catchClauseFor(pgDs), "database");
+
+	// Lucee parity detail: the caught exception reports its type as "database".
+	caughtType = "";
+	try {
+		queryExecute("SELECT 1 FROM rcfml_missing_table_f362", [], {datasource: pgDs});
+	} catch (any e) {
+		caughtType = lCase(e.type ?: "");
+	}
+	assert("PostgreSQL: cfcatch.type is database", caughtType, "database");
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -267,6 +267,7 @@ include "harness.cfm";
 <cf_runtest file="database/test_sqlite_datasource_paths.cfm">
 <cf_runtest file="database/test_duplicate_result_columns.cfm">
 <cf_runtest file="database/test_update_affected_rows_matched.cfm">
+<cf_runtest file="database/test_query_error_catch_type_database.cfm">
 <cf_runtest file="stdlib/test_date_functions_extra.cfm">
 <cf_runtest file="stdlib/test_locale_functions.cfm">
 <cf_runtest file="stdlib/test_java_i18n_shims.cfm">


### PR DESCRIPTION
## What

Adds a database test proving a failed `queryExecute` raises a **database-typed** exception, so `catch (database e)` / `<cfcatch type="database">` matches (Lucee/ACF behavior). SQLite leg runs always as the control; the PostgreSQL leg is live-gated on `RUSTCFML_TEST_PG_DS` (same convention as `test_db_null_column_empty_string.cfm`) and skips green when unset.

## Why

The SQLite and MySQL adapters already raise `CfmlError::database` (~30 call sites, e.g. builtins.rs:9139, 9398, 9514). The PostgreSQL adapter is the odd one out: every query failure funnels through `PgRunError::from_postgres` (crates/cfml-stdlib/src/builtins.rs:11607), which wraps it as `CfmlError::runtime` — so a database-typed catch never matches and the error falls through to `catch (any)` with `cfcatch.type = Runtime`. The two param-rewrite errors in pg_sql.rs:88/103 share the blind spot. The VM machinery is already in place: `catch_type_matches` (cfml-vm/src/lib.rs:4109) and the `"database"` mapping used by cfthrow (lib.rs:4612).

Real-world repro: moopa's first-run fallbacks wrap "table may not exist yet" probes in `<cfcatch type="database">`. On Lucee this boots an empty database cleanly; on RustCFML + Postgres (Neon) the catch never matches, so first boot 500s intermittently — we had to widen the catches to `type="any"` as a workaround (moopa `route_registry_store.cfc`, `lib/core.cfc`).

Stretch goal while you're in there: populating `cfcatch.sqlstate` from `e.code()` would complete Lucee parity for database catches.

## Validation

RustCFML **v0.541.0** stock release binary, live Postgres 16 (`RUSTCFML_TEST_PG_DS` set):

```text
FAIL | queryExecute failures are catchable as type=database | 1/3 passed (2 failed)
FAIL: PostgreSQL: missing-table error lands in catch (database e) | expected: [database] | got: [any (cfcatch.type=Runtime)]
FAIL: PostgreSQL: cfcatch.type is database | expected: [database] | got: [runtime]
```

Without `RUSTCFML_TEST_PG_DS` (skip path):

```text
PASS | queryExecute failures are catchable as type=database | 2/2 passed
```

The SQLite control passes today, pinning the existing correct behavior. Test-only PR so the Lucee-compatible exception typing is pinned before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)