### PR TITLE
RED test: cfquery tag must forward columnkey and maxrows like queryExecute

### DIFF
--- a/tests/database/test_cfquery_tag_forwards_columnkey_maxrows.cfm
+++ b/tests/database/test_cfquery_tag_forwards_columnkey_maxrows.cfm
@@ -1,0 +1,53 @@
+<cfscript>
+// The <cfquery> TAG must behave identically to queryExecute() for the same
+// attributes. queryExecute honours returntype="struct" + columnKey (row-keyed
+// struct, Lucee behavior — supported since v0.13.0) and maxrows — but the tag
+// lowering forwards only a whitelist of attributes into the options struct
+// (tag_parser.rs "cfquery" arm: datasource/name/result/returntype/dbtype/
+// attributeCollection), so columnkey and maxrows are silently dropped.
+//
+// With columnkey dropped, returntype="struct" falls into the "single-row map"
+// branch and returns a struct keyed by COLUMN NAMES instead of row key values.
+//
+// Real-world repro: moopa's hub schema-sync reads index/FK metadata with
+// <cfquery returntype="struct" columnkey="name"> (schemaSync.cfc
+// getTableIndexes/getTableForeignKeys). On RustCFML the "existing indexes"
+// struct comes back keyed by the query's column names, so the schema diff
+// offers to DROP CONSTRAINT name/table_name/onupdate/... on every table and
+// re-CREATE every index and FK that already exists.
+//
+// Verified identical on v0.125.0, v0.126.0, v0.531.0 and v0.541.0 release
+// binaries — the tag path has never forwarded these attributes.
+
+suiteBegin("cfquery tag forwards columnkey and maxrows like queryExecute");
+
+memDs = { class: "org.sqlite.JDBC", connectionString: "jdbc:sqlite::memory:" };
+twoRowSql = "SELECT 'alpha' AS name, '1' AS v UNION ALL SELECT 'beta', '2'";
+
+// ---- Control: queryExecute already honours both options ----
+stQe = queryExecute(twoRowSql, [], { datasource: memDs, returntype: "struct", columnKey: "name" });
+assert("queryExecute: struct is keyed by the columnKey column's row values", listSort(structKeyList(stQe), "text"), "alpha,beta");
+assert("queryExecute: row struct carries the other columns", stQe["alpha"].v, "1");
+
+qQe = queryExecute(twoRowSql, [], { datasource: memDs, maxrows: 1 });
+assert("queryExecute: maxrows caps the resultset", qQe.recordCount, 1);
+</cfscript>
+
+<!--- ---- The same attributes through the <cfquery> TAG ---- --->
+<cfquery name="stTag" datasource="#memDs#" returntype="struct" columnkey="name">
+    SELECT 'alpha' AS name, '1' AS v UNION ALL SELECT 'beta', '2'
+</cfquery>
+<cfscript>
+assert("cfquery tag: struct is keyed by the columnkey column's row values", listSort(structKeyList(stTag), "text"), "alpha,beta");
+hasAlpha = structKeyExists(stTag, "alpha");
+assertTrue("cfquery tag: row key resolves to its row struct", hasAlpha AND (stTag["alpha"].v ?: "") EQ "1");
+</cfscript>
+
+<cfquery name="qTag" datasource="#memDs#" maxrows="1">
+    SELECT 'alpha' AS name UNION ALL SELECT 'beta'
+</cfquery>
+<cfscript>
+assert("cfquery tag: maxrows caps the resultset", qTag.recordCount, 1);
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -265,6 +265,7 @@ include "harness.cfm";
 <cf_runtest file="database/test_lucee_query_builder.cfm">
 <cf_runtest file="database/test_datasource_list_maxrows.cfm">
 <cf_runtest file="database/test_sqlite_datasource_paths.cfm">
+<cf_runtest file="database/test_cfquery_tag_forwards_columnkey_maxrows.cfm">
 <cf_runtest file="database/test_duplicate_result_columns.cfm">
 <cf_runtest file="database/test_update_affected_rows_matched.cfm">
 <cf_runtest file="stdlib/test_date_functions_extra.cfm">


### PR DESCRIPTION
## What

Adds a database test proving the `<cfquery>` **tag** honours `returntype="struct" columnkey="..."` (row-keyed struct, Lucee behavior) and `maxrows` the same way `queryExecute()` already does. Runs entirely on the in-memory SQLite datasource — no live DB or env gating needed. The three `queryExecute` assertions pass today and pin the working path; the three tag assertions fail.

## Why

Both options are implemented and work through `queryExecute` (columnkey since v0.13.0 / 64be57ee, including the `keyColumn` alias from 72fb6c38; maxrows capping in builtins.rs `apply_query_maxrows`). But the tag lowering forwards only a whitelist of attributes into the options struct — `tag_parser.rs` "cfquery" arm: `datasource / name / result / returntype / dbtype / attributeCollection` — so `columnkey` and `maxrows` are silently dropped. With `returntype="struct"` and no columnkey, the builtin falls into its single-row-map branch and returns a struct keyed by **column names** instead of row key values.

Bisected against release binaries **v0.125.0, v0.126.0, v0.531.0 and v0.541.0** — identical on all four, so this isn't a regression; the tag path has never forwarded these attributes. (64be57ee's end-to-end verification presumably exercised the builtin path.)

Real-world repro: moopa's hub schema-sync reads existing index/FK metadata with `<cfquery returntype="struct" columnkey="name">` (`schemaSync.cfc` `getTableIndexes` / `getTableForeignKeys` / `getTablePrimaryKey`). On RustCFML the "existing objects" struct comes back keyed by the query's column names, so against a perfectly healthy schema the diff page proposes `ALTER TABLE ... DROP CONSTRAINT name / table_name / foreign_key_table / onupdate / ondelete` on every table, `DROP INDEX name / fields / unique / type / indexdef / where`, and re-`CREATE` of every index and FK that already exists.

## Validation

RustCFML **v0.541.0** stock release binary:

```text
FAIL | cfquery tag forwards columnkey and maxrows like queryExecute | 3/6 passed (3 failed)
FAIL: cfquery tag: struct is keyed by the columnkey column's row values | expected: [alpha,beta] | got: [name,v]
FAIL: cfquery tag: row key resolves to its row struct | expected truthy | got: [false]
FAIL: cfquery tag: maxrows caps the resultset | expected: [1] | got: [2]
```

Test-only PR so tag/queryExecute parity is pinned before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)