### PR TITLE
RED test: cfloop list with both item and index must populate both (Lucee parity)

### DIFF
--- a/tests/core/test_cfloop_list_item_with_index.cfm
+++ b/tests/core/test_cfloop_list_item_with_index.cfm
@@ -1,0 +1,47 @@
+<!--- <cfloop list> with BOTH item and index must populate both, Lucee-style:
+      item = the list element, index = the 1-based position. RustCFML currently
+      treats the combination like the legacy index-only form — the element
+      lands in `index` and `item` is never set, so any read of the item
+      variable throws "Variable '...' is undefined".
+
+      The two single-attribute forms already match Lucee (item-only → element;
+      legacy index-only → element) and are pinned here as controls.
+
+      Real-world repro: moopa's hub schema-sync FK comparison —
+        <cfloop list="#structKeyList(code_fk)#" item="code_fk_param" index="i">
+      (schemaSync.cfc compareDatabaseSchema). On RustCFML the sysadmin schema
+      page 500s with "Variable 'code_fk_param' is undefined" as soon as an
+      existing foreign key is compared. (Unreachable before v0.543.0 — the
+      cfquery tag columnkey fix (GH #294) made the FK metadata readable, which
+      let this loop execute for the first time.)
+
+      Lucee 6.2 direct check (lucee/lucee:6.2 Docker):
+        item-only=a,b,c  index-only=a,b,c  both: item=a,b,c index=1,2,3 --->
+
+<cfset itemsOnly = "">
+<cfloop list="a,b,c" item="el1">
+    <cfset itemsOnly = listAppend(itemsOnly, isNull(el1) ? "UNDEF" : el1)>
+</cfloop>
+
+<cfset legacyIndex = "">
+<cfloop list="a,b,c" index="ix1">
+    <cfset legacyIndex = listAppend(legacyIndex, isNull(ix1) ? "UNDEF" : ix1)>
+</cfloop>
+
+<cfset bothItems = "">
+<cfset bothIndexes = "">
+<cfloop list="a,b,c" item="el2" index="ix2">
+    <cfset bothItems = listAppend(bothItems, isNull(el2) ? "UNDEF" : el2)>
+    <cfset bothIndexes = listAppend(bothIndexes, isNull(ix2) ? "UNDEF" : ix2)>
+</cfloop>
+
+<cfscript>
+suiteBegin("cfloop list with both item and index");
+
+assert("item-only: item receives each element", itemsOnly, "a,b,c");
+assert("index-only (legacy): index receives each element", legacyIndex, "a,b,c");
+assert("item+index: item receives each element", bothItems, "a,b,c");
+assert("item+index: index receives the 1-based position", bothIndexes, "1,2,3");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -794,6 +794,7 @@ include "harness.cfm";
 <!--- the next body and a case without `break` falls through. Surfaced porting --->
 <!--- WireBox (Builder.cfc's `case "model": case "id":` DSL dispatch). --->
 <cf_runtest file="core/test_switch_fallthrough.cfm">
+<cf_runtest file="core/test_cfloop_list_item_with_index.cfm">
 <cf_runtest file="core/test_switch_continue_in_loop.cfm">
 <cf_runtest file="core/test_application_scope_persist.cfm">
 <cf_runtest file="core/test_application_name_implicit.cfm">


### PR DESCRIPTION
## What

Adds a core test pinning Lucee's `<cfloop list>` semantics when **both** `item` and `index` are present: `item` = the list element, `index` = the 1-based position. The two single-attribute forms (item-only → element; legacy index-only → element) already match Lucee and are pinned as controls.

## Why

RustCFML currently treats `item` + `index` like the legacy index-only form — the element lands in `index` and `item` is never set, so any read of the item variable throws `Variable '...' is undefined`.

Real-world repro: moopa's hub schema-sync FK comparison —

```cfml
<cfloop list="#structKeyList(code_fk)#" item="code_fk_param" index="i">
    <cfif code_fk[code_fk_param] NEQ (db_foreign_keys[code_fk_name][code_fk_param]?:'')>
```

(`schemaSync.cfc` `compareDatabaseSchema`). The sysadmin schema page 500s with `Variable 'code_fk_param' is undefined` as soon as an existing foreign key is compared. Fun detail: this line was unreachable until **v0.543.0** — your GH #294 fix made the FK metadata struct readable, which let this loop execute on RustCFML for the first time. One layer down the onion.

## Validation

RustCFML **v0.543.0** stock release binary:

```text
FAIL | cfloop list with both item and index | 2/4 passed (2 failed)
FAIL: item+index: item receives each element | expected: [a,b,c] | got: [UNDEF,UNDEF,UNDEF]
FAIL: item+index: index receives the 1-based position | expected: [1,2,3] | got: [a,b,c]
```

Lucee **6.2** direct check (lucee/lucee:6.2 Docker, same probe): `item-only=a,b,c`, `index-only=a,b,c`, both: `item=a,b,c` `index=1,2,3`.

Test-only PR so the Lucee-compatible loop-variable population is pinned before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)