### PR TITLE
Fixes #310

### DIFF
--- a/crates/cfml-vm/src/lib.rs
+++ b/crates/cfml-vm/src/lib.rs
@@ -1828,8 +1828,15 @@ pub struct CfmlVirtualMachine {
     pending_exit: Option<String>,
     /// The `cfexit` method carried out of the most recently unwound template
     /// frame. Consumed by the custom-tag handlers to decide exittag (skip body +
-    /// end) vs exittemplate (run body + end normally).
+    /// end) vs exittemplate (run body + end normally) vs loop (re-run the body).
+    /// Taken with a single `.take()` per phase boundary: a method fired in an end
+    /// phase must not leak into an unrelated later tag.
     last_exit_method: Option<String>,
+    /// Set by `__cfcustomtag_start`: the execution loop (which owns `ip`) records
+    /// the body's instruction index into the tag state just pushed.
+    pending_tag_body_start: bool,
+    /// Set by `__cfcustomtag_end` on `cfexit method="loop"`: rewind target.
+    pending_tag_loop: Option<usize>,
     /// Buffered `<cfhtmlhead>` / `<cfhtmlbody>` content, injected into the
     /// response `<head>` / `<body>` (or appended) at output finalization.
     html_head_buffer: String,
@@ -2331,6 +2338,10 @@ struct CustomTagState {
     /// end phase must be skipped, but partial start-phase caller writes still
     /// propagate.
     exit_tag: bool,
+    /// Instruction index of the tag BODY in the *calling* frame — the rewind
+    /// target for `cfexit method="loop"`. The body stays inline bytecode (a jump
+    /// re-runs it) so `cfbreak`/`cfcontinue` in a body keep binding as before.
+    body_start_ip: Option<usize>,
 }
 
 impl CfmlVirtualMachine {
@@ -2424,6 +2435,8 @@ impl CfmlVirtualMachine {
             custom_tag_stack: Vec::new(),
             pending_exit: None,
             last_exit_method: None,
+            pending_tag_body_start: false,
+            pending_tag_loop: None,
             html_head_buffer: String::new(),
             html_body_buffer: String::new(),
             app_function_table: Vec::new(),
@@ -4741,6 +4754,9 @@ impl CfmlVirtualMachine {
         if self.custom_tag_stack.len() > handler.custom_tag_depth {
             self.custom_tag_stack.truncate(handler.custom_tag_depth);
         }
+        // A throw in a tag body must not leave a rewind target for an abandoned tag.
+        self.pending_tag_loop = None;
+        self.pending_tag_body_start = false;
     }
 
     /// Lucee/ACF parity for the `arguments` scope: reading a declared-but-unpassed
@@ -7745,6 +7761,44 @@ impl CfmlVirtualMachine {
                                 // CallMethod arm / reconcile_closure_env_into_locals).
                                 Self::reconcile_closure_env_into_locals(&closure_env, &mut locals);
                                 stack.push(result);
+
+                                // Record where the tag BODY begins. An expression
+                                // statement compiles to `… Call; Pop` and `ip` was
+                                // advanced before this match, so `ip` is that Pop and
+                                // `ip + 1` is the body's first instruction.
+                                if self.pending_tag_body_start {
+                                    self.pending_tag_body_start = false;
+                                    let pop_ok = ip < func.instructions.len()
+                                        && matches!(func.instructions[ip], BytecodeOp::Pop);
+                                    if !pop_ok {
+                                        // Fail loudly rather than degrade into silent
+                                        // wrong output. Unwind the start handler's
+                                        // pushes first — `output_buffer` is the body
+                                        // capture, the page output is on the stack.
+                                        let _discarded_body =
+                                            std::mem::take(&mut self.output_buffer);
+                                        self.output_buffer =
+                                            self.saved_output_buffers.pop().unwrap_or_default();
+                                        self.custom_tag_stack.pop();
+                                        self.pending_tag_loop = None;
+                                        return Err(self.wrap_error(CfmlError::runtime(
+                                            "internal error: custom-tag start call is not followed by Pop"
+                                                .to_string(),
+                                        )));
+                                    }
+                                    if let Some(state) = self.custom_tag_stack.last_mut() {
+                                        state.body_start_ip = Some(ip + 1);
+                                    }
+                                }
+
+                                // Another iteration: discard this call's result
+                                // explicitly (we jump over the Pop that would have
+                                // consumed it), then rewind to the body.
+                                if let Some(target) = self.pending_tag_loop.take() {
+                                    stack.pop();
+                                    ip = target;
+                                    continue;
+                                }
                             }
                             Err(e) => {
                                 if Self::is_control_flow_error(&e) {
@@ -19065,47 +19119,84 @@ impl CfmlVirtualMachine {
 
                     self.execute_custom_tag_template(&resolved, &frame)?;
 
-                    // `cfexit method="exittag"` in the start phase skips the end
-                    // phase entirely (partial start-phase caller writes still
-                    // propagate below).
-                    let exit_tag = matches!(
-                        self.last_exit_method.take().as_deref(),
-                        Some("exittag")
-                    );
+                    // Consume the start phase's `cfexit` signal exactly once.
+                    let exit_tag = match self.last_exit_method.take().as_deref() {
+                        // exittag: skip the end phase (caller writes still propagate).
+                        Some("exittag") => true,
+                        // Lucee rejects a loop request outside the end phase.
+                        Some("loop") => {
+                            return Err(self.wrap_error(CfmlError::runtime(
+                                "invalid context for the tag exit, method loop can only be used in the end tag of a custom tag"
+                                    .to_string(),
+                            )));
+                        }
+                        Some("exittemplate") | None => false,
+                        Some(_other) => false,
+                    };
 
                     if run_end_phase && !exit_tag {
                         // The end phase runs in the SAME tag variables scope
                         // (Lucee semantics: state set during start is visible at
                         // end) — just flip thistag over to the end phase. No
                         // start-locals clone, no caller re-snapshot.
-                        let mut this_tag = ValueMap::default();
-                        this_tag.insert(
-                            "executionmode".to_string(),
-                            CfmlValue::string("end".to_string()),
-                        );
-                        this_tag.insert("hasendtag".to_string(), CfmlValue::Bool(true));
-                        this_tag.insert(
-                            "generatedcontent".to_string(),
-                            CfmlValue::string(String::new()),
-                        );
+                        // No body to re-run here, so a loop request just repeats the
+                        // end phase (Lucee-measured).
                         if !tag_vars.contains_key_ci("attributes") {
                             tag_vars.insert("attributes".to_string(), attrs_val);
                         }
-                        tag_vars.insert("thistag".to_string(), CfmlValue::strukt(this_tag));
+                        loop {
+                            // Refresh thisTag IN PLACE: replacing the struct would
+                            // drop members the tag set and stale out any alias it kept.
+                            match tag_vars.get("thistag") {
+                                Some(CfmlValue::Struct(existing)) => {
+                                    existing.insert(
+                                        "executionmode".to_string(),
+                                        CfmlValue::string("end".to_string()),
+                                    );
+                                    existing
+                                        .insert("hasendtag".to_string(), CfmlValue::Bool(true));
+                                    existing.insert(
+                                        "generatedcontent".to_string(),
+                                        CfmlValue::string(String::new()),
+                                    );
+                                }
+                                // Missing or wrong type: create it once.
+                                _ => {
+                                    let mut m = ValueMap::default();
+                                    m.insert(
+                                        "executionmode".to_string(),
+                                        CfmlValue::string("end".to_string()),
+                                    );
+                                    m.insert("hasendtag".to_string(), CfmlValue::Bool(true));
+                                    m.insert(
+                                        "generatedcontent".to_string(),
+                                        CfmlValue::string(String::new()),
+                                    );
+                                    tag_vars
+                                        .insert("thistag".to_string(), CfmlValue::strukt(m));
+                                }
+                            }
 
-                        let outer_output = std::mem::take(&mut self.output_buffer);
-                        self.execute_custom_tag_template(&resolved, &frame)?;
-                        let end_output = std::mem::take(&mut self.output_buffer);
-                        self.output_buffer = outer_output;
+                            let outer_output = std::mem::take(&mut self.output_buffer);
+                            self.execute_custom_tag_template(&resolved, &frame)?;
+                            let end_output = std::mem::take(&mut self.output_buffer);
+                            self.output_buffer = outer_output;
 
-                        if let Some(CfmlValue::Struct(tag_info)) = tag_vars.get("thistag") {
-                            if let Some(CfmlValue::String(content)) =
-                                tag_info.get("generatedcontent")
-                            {
-                                self.output_buffer.push_str(&content);
+                            if let Some(CfmlValue::Struct(tag_info)) = tag_vars.get("thistag") {
+                                if let Some(CfmlValue::String(content)) =
+                                    tag_info.get("generatedcontent")
+                                {
+                                    self.output_buffer.push_str(&content);
+                                }
+                            }
+                            self.output_buffer.push_str(&end_output);
+
+                            // Consume this end phase's signal exactly once.
+                            match self.last_exit_method.take().as_deref() {
+                                Some("loop") => continue,
+                                _ => break,
                             }
                         }
-                        self.output_buffer.push_str(&end_output);
                     }
 
                     self.apply_tag_caller_writeback(
@@ -19155,13 +19246,21 @@ impl CfmlVirtualMachine {
 
                     self.execute_custom_tag_template(&resolved, &frame)?;
 
-                    // `cfexit method="exittag"` in the start phase: the body and
-                    // the end phase are skipped, but partial start-phase caller
-                    // writes still propagate (below).
-                    let exit_tag = matches!(
-                        self.last_exit_method.take().as_deref(),
-                        Some("exittag")
-                    );
+                    // Consume the start phase's `cfexit` signal exactly once.
+                    let exit_tag = match self.last_exit_method.take().as_deref() {
+                        // exittag: skip body + end phase (caller writes still propagate).
+                        Some("exittag") => true,
+                        // Lucee rejects a loop request outside the end phase.
+                        Some("loop") => {
+                            return Err(self.wrap_error(CfmlError::runtime(
+                                "invalid context for the tag exit, method loop can only be used in the end tag of a custom tag"
+                                    .to_string(),
+                            )));
+                        }
+                        // exittemplate / none / unrecognised: proceed as before.
+                        Some("exittemplate") | None => false,
+                        Some(_other) => false,
+                    };
 
                     // Caller write-back from start execution
                     self.apply_tag_caller_writeback(
@@ -19177,7 +19276,11 @@ impl CfmlVirtualMachine {
                         attributes: attrs_val,
                         tag_vars,
                         exit_tag,
+                        body_start_ip: None,
                     });
+
+                    // Ask the execution loop to record where the body starts.
+                    self.pending_tag_body_start = true;
 
                     // Push output buffer to capture body content (like savecontent)
                     self.saved_output_buffers
@@ -19207,23 +19310,44 @@ impl CfmlVirtualMachine {
                         return Ok(CfmlValue::Null);
                     }
 
-                    let mut this_tag = ValueMap::default();
-                    this_tag.insert(
-                        "executionmode".to_string(),
-                        CfmlValue::string("end".to_string()),
-                    );
-                    this_tag.insert("hasendtag".to_string(), CfmlValue::Bool(true));
-                    this_tag.insert(
-                        "generatedcontent".to_string(),
-                        CfmlValue::string(body_content),
-                    );
-
                     let CustomTagState {
                         template_path,
                         attributes,
                         tag_vars,
                         exit_tag: _,
+                        body_start_ip,
                     } = state;
+
+                    // Refresh `thisTag` IN PLACE: replacing the struct would drop
+                    // members the tag set and stale out any alias it kept. Only the
+                    // engine-owned keys change; `generatedContent` is per-iteration.
+                    match tag_vars.get("thistag") {
+                        Some(CfmlValue::Struct(existing)) => {
+                            existing.insert(
+                                "executionmode".to_string(),
+                                CfmlValue::string("end".to_string()),
+                            );
+                            existing.insert("hasendtag".to_string(), CfmlValue::Bool(true));
+                            existing.insert(
+                                "generatedcontent".to_string(),
+                                CfmlValue::string(body_content),
+                            );
+                        }
+                        // Missing or wrong type: create it once.
+                        _ => {
+                            let mut m = ValueMap::default();
+                            m.insert(
+                                "executionmode".to_string(),
+                                CfmlValue::string("end".to_string()),
+                            );
+                            m.insert("hasendtag".to_string(), CfmlValue::Bool(true));
+                            m.insert(
+                                "generatedcontent".to_string(),
+                                CfmlValue::string(body_content),
+                            );
+                            tag_vars.insert("thistag".to_string(), CfmlValue::strukt(m));
+                        }
+                    }
 
                     // The end phase runs in the start phase's tag variables
                     // scope (Lucee semantics). Re-derive the caller context —
@@ -19231,6 +19355,8 @@ impl CfmlVirtualMachine {
                     // parent frame, so the snapshot path needs a fresh baseline.
                     let (live_caller, shadow_prevals, caller_snapshot) =
                         Self::tag_caller_ctx(parent_locals);
+                    // Kept for the loop re-push below (the original is moved into tag_vars).
+                    let attributes_for_loop = attributes.clone();
                     if !tag_vars.contains_key_ci("attributes") {
                         tag_vars.insert("attributes".to_string(), attributes);
                     }
@@ -19241,7 +19367,6 @@ impl CfmlVirtualMachine {
                             None => CfmlValue::strukt(caller_snapshot.clone()),
                         },
                     );
-                    tag_vars.insert("thistag".to_string(), CfmlValue::strukt(this_tag));
                     let frame = Self::custom_tag_frame(parent_locals, &tag_vars);
 
                     let outer_output = std::mem::take(&mut self.output_buffer);
@@ -19265,6 +19390,40 @@ impl CfmlVirtualMachine {
                         &caller_snapshot,
                         &tag_vars,
                     );
+
+                    // Consume this phase's signal exactly once — leaving it set is how
+                    // an end-phase exit used to leak into the next tag.
+                    match self.last_exit_method.take().as_deref() {
+                        // Re-execute the BODY: keep the tag state alive (so `thisTag`
+                        // persists) and push a fresh capture buffer (so each
+                        // iteration's `generatedContent` is its own), then rewind.
+                        Some("loop") => {
+                            // Always recorded right after the matching start call, so
+                            // a missing target is a broken invariant — fail loudly
+                            // rather than silently dropping the loop.
+                            let body_ip = match body_start_ip {
+                                Some(ip) => ip,
+                                None => {
+                                    return Err(self.wrap_error(CfmlError::runtime(
+                                        "internal error: custom-tag loop requested but no body start was recorded"
+                                            .to_string(),
+                                    )));
+                                }
+                            };
+                            self.custom_tag_stack.push(CustomTagState {
+                                template_path,
+                                attributes: attributes_for_loop,
+                                tag_vars,
+                                exit_tag: false,
+                                body_start_ip: Some(body_ip),
+                            });
+                            self.saved_output_buffers
+                                .push(std::mem::take(&mut self.output_buffer));
+                            self.pending_tag_loop = Some(body_ip);
+                        }
+                        // Anything else: the end phase has already run.
+                        _ => {}
+                    }
 
                     return Ok(CfmlValue::Null);
                 }

--- a/tests/tags/ltcfexitendexit.cfm
+++ b/tests/tags/ltcfexitendexit.cfm
@@ -1,0 +1,4 @@
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.outVar] = caller[attributes.outVar] & "[first-end]">
+    <cfexit method="exittag">
+</cfif>

--- a/tests/tags/ltcfexitloop.cfm
+++ b/tests/tags/ltcfexitloop.cfm
@@ -1,0 +1,19 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfset caller[attributes.outVar] = caller[attributes.outVar] & "[start:" & attributes.label & "]">
+    <cfset thisTag.carried = "S0">
+</cfif>
+
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.countVar] = caller[attributes.countVar] + 1>
+    <cfset caller[attributes.outVar] = caller[attributes.outVar]
+        & "[end" & caller[attributes.countVar]
+        & " gc=" & trim(thisTag.generatedContent)
+        & " carried=" & (structKeyExists(thisTag, "carried") ? thisTag.carried : "GONE")
+        & " mode=" & thisTag.executionMode
+        & " attr=" & attributes.label & "]">
+    <cfset thisTag.carried = "S" & caller[attributes.countVar]>
+    <cfset thisTag.generatedContent = "">
+    <cfif caller[attributes.countVar] LT 3>
+        <cfexit method="loop">
+    </cfif>
+</cfif>

--- a/tests/tags/ltcfexitloopout.cfm
+++ b/tests/tags/ltcfexitloopout.cfm
@@ -1,0 +1,18 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfset thisTag.carried = "S0">
+    <!--- keep an alias: after the phase flip it must observe the CURRENT
+          executionMode / generatedContent, not a stale snapshot --->
+    <cfset caller[attributes.aliasVar] = thisTag>
+</cfif>
+
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.countVar] = caller[attributes.countVar] + 1>
+    <!--- deliberately does NOT clear generatedContent: the caller's page must
+          receive every iteration's body output, in order, each followed by
+          this tag's own end-phase output. --->
+    <cfoutput>(e#caller[attributes.countVar]#)</cfoutput>
+    <cfset thisTag.carried = "S" & caller[attributes.countVar]>
+    <cfif caller[attributes.countVar] LT 3>
+        <cfexit method="loop">
+    </cfif>
+</cfif>

--- a/tests/tags/ltcfexitloopself.cfm
+++ b/tests/tags/ltcfexitloopself.cfm
@@ -1,0 +1,15 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfset caller[attributes.outVar] = caller[attributes.outVar] & "[start]">
+    <cfset thisTag.carried = "S0">
+</cfif>
+
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.countVar] = caller[attributes.countVar] + 1>
+    <cfset caller[attributes.outVar] = caller[attributes.outVar]
+        & "[end" & caller[attributes.countVar]
+        & " carried=" & (structKeyExists(thisTag, "carried") ? thisTag.carried : "GONE") & "]">
+    <cfset thisTag.carried = "S" & caller[attributes.countVar]>
+    <cfif caller[attributes.countVar] LT 3>
+        <cfexit method="loop">
+    </cfif>
+</cfif>

--- a/tests/tags/ltcfexitloopstart.cfm
+++ b/tests/tags/ltcfexitloopstart.cfm
@@ -1,0 +1,3 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfexit method="loop">
+</cfif>

--- a/tests/tags/ltcfexitplain.cfm
+++ b/tests/tags/ltcfexitplain.cfm
@@ -1,0 +1,8 @@
+<cfif thisTag.executionMode EQ "start">
+    <cfset caller[attributes.outVar] = caller[attributes.outVar] & "[second-start]">
+</cfif>
+
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.outVar] = caller[attributes.outVar] & "[second-end:" & trim(thisTag.generatedContent) & "]">
+    <cfset thisTag.generatedContent = "">
+</cfif>

--- a/tests/tags/ltinnerloop.cfm
+++ b/tests/tags/ltinnerloop.cfm
@@ -1,0 +1,7 @@
+<cfif thisTag.executionMode EQ "end">
+    <cfset caller[attributes.countVar] = caller[attributes.countVar] + 1>
+    <cfset caller[attributes.outVar] = caller[attributes.outVar] & "(in" & caller[attributes.countVar] & ")">
+    <cfif caller[attributes.countVar] MOD 2 EQ 1>
+        <cfexit method="loop">
+    </cfif>
+</cfif>

--- a/tests/tags/test_tags_cfexit.cfm
+++ b/tests/tags/test_tags_cfexit.cfm
@@ -17,4 +17,159 @@
     assert('start-phase cfexit method="exittag" skips remaining tag code and end phase', ltExitLog, "[start]");
 </cfscript>
 
+<!--- ---------------------------------------------------------------
+      cfexit method="loop": the tag re-executes its own BODY.
+      Reference behaviour measured on Lucee 7.0.4: the start phase runs
+      once, the body is re-executed per iteration, thisTag state carries
+      across iterations, and generatedContent holds only the CURRENT
+      iteration's body output.
+      --------------------------------------------------------------- --->
+<cfset loopLog = "">
+<cfset loopCount = 0>
+<cfset loopBodyRuns = 0>
+<cfset loopError = "">
+<cfset loopOut = "">
+
+<cftry>
+    <cfsavecontent variable="loopOut"><cf_ltcfexitloop outVar="loopLog" countVar="loopCount" label="L1"><cfset loopBodyRuns = loopBodyRuns + 1><cfoutput>body#loopBodyRuns#</cfoutput></cf_ltcfexitloop></cfsavecontent>
+    <cfcatch type="any">
+        <cfset loopError = cfcatch.message>
+    </cfcatch>
+</cftry>
+
+<cfscript>
+    assert('cfexit method="loop" does not throw', loopError, "");
+    assert('cfexit method="loop" re-executes the tag body', loopBodyRuns, 3);
+    assert('cfexit method="loop" runs the end phase once per iteration', loopCount, 3);
+    // generatedContent is per-iteration (never accumulated), thisTag members
+    // carry across iterations, attributes and executionMode stay stable, and
+    // the start phase appears exactly once.
+    assert('cfexit method="loop" iteration detail',
+        loopLog,
+        "[start:L1]"
+        & "[end1 gc=body1 carried=S0 mode=end attr=L1]"
+        & "[end2 gc=body2 carried=S1 mode=end attr=L1]"
+        & "[end3 gc=body3 carried=S2 mode=end attr=L1]");
+</cfscript>
+
+<!--- The point of the feature: the CALLER's page must receive every
+      iteration's body output, in order, each followed by that iteration's
+      end-phase output. This tag does not clear generatedContent, so the
+      rendered result is asserted directly rather than via a side channel.
+      An alias kept from the start phase must also observe the current phase
+      (thisTag is refreshed in place, not replaced). --->
+<cfset outCount = 0>
+<cfset outRuns = 0>
+<cfset aliasTag = "">
+<cfset outRendered = "">
+<cfsavecontent variable="outRendered"><cf_ltcfexitloopout countVar="outCount" aliasVar="aliasTag"><cfset outRuns = outRuns + 1><cfoutput>body#outRuns#</cfoutput></cf_ltcfexitloopout></cfsavecontent>
+
+<cfscript>
+    // Whitespace-stripped: the tag template's own newlines are irrelevant, the
+    // point is that every iteration's body reached the page, in order, each
+    // followed by that iteration's end-phase output.
+    assert('cfexit method="loop" renders every iteration to the page',
+        reReplace(outRendered, "[[:space:]]+", "", "all"),
+        "body1(e1)body2(e2)body3(e3)");
+    assert('cfexit method="loop" body ran once per iteration', outRuns, 3);
+    // thisTag was refreshed in place, so an alias taken during the start
+    // phase sees the end phase and the latest member value.
+    assert("thisTag alias observes the current executionMode",
+        aliasTag.executionMode, "end");
+    assert("thisTag alias observes later member updates", aliasTag.carried, "S3");
+</cfscript>
+
+<!--- Self-closing tags take a different engine path (no start/end pair):
+      a loop request there simply re-runs the end phase. --->
+<cfset selfLog = "">
+<cfset selfCount = 0>
+<cfset selfError = "">
+<cfset selfOut = "">
+
+<cftry>
+    <cfsavecontent variable="selfOut"><cf_ltcfexitloopself outVar="selfLog" countVar="selfCount" /><cf_ltcfexitplain outVar="selfLog">AFTER</cf_ltcfexitplain></cfsavecontent>
+    <cfcatch type="any">
+        <cfset selfError = cfcatch.message>
+    </cfcatch>
+</cftry>
+
+<cfscript>
+    assert('self-closing cfexit method="loop" does not throw', selfError, "");
+    assert('self-closing cfexit method="loop" repeats the end phase', selfCount, 3);
+    assert('self-closing loop keeps thisTag state and lets the next tag run',
+        selfLog,
+        "[start][end1 carried=S0][end2 carried=S1][end3 carried=S2]"
+        & "[second-start][second-end:AFTER]");
+</cfscript>
+
+<!--- Nested body-mode tags, BOTH looping: the rewind target is per-tag
+      state, so an inner loop must not disturb the outer one. --->
+<cfset nestLog = "">
+<cfset nestOuter = 0>
+<cfset nestInner = 0>
+<cfset nestError = "">
+<cfset nestOut = "">
+
+<cftry>
+    <cfsavecontent variable="nestOut"><cf_ltcfexitloop outVar="nestLog" countVar="nestOuter" label="OUT"><cf_ltinnerloop outVar="nestLog" countVar="nestInner"></cf_ltinnerloop></cf_ltcfexitloop></cfsavecontent>
+    <cfcatch type="any">
+        <cfset nestError = cfcatch.message>
+    </cfcatch>
+</cftry>
+
+<cfscript>
+    assert('nested cfexit method="loop" does not throw', nestError, "");
+    assert('nested loop: outer tag iterates 3 times', nestOuter, 3);
+    // The inner tag loops while its own count is odd: 1->loop->2 stop,
+    // 3->loop->4 stop, 5->loop->6 stop. Three outer iterations, two inner
+    // runs each.
+    assert('nested loop: inner tag iterates independently', nestInner, 6);
+</cfscript>
+
+<!--- The operand stack must stay balanced across a rewind: ordinary
+      expressions after a looping tag still evaluate correctly. --->
+<cfset stackLog = "">
+<cfset stackCount = 0>
+<cfset stackOut = "">
+<cfsavecontent variable="stackOut"><cf_ltcfexitloop outVar="stackLog" countVar="stackCount" label="ST">x</cf_ltcfexitloop></cfsavecontent>
+<cfset stackMath = (1 + 2) * 3>
+<cfset stackList = listLen("a,b,c")>
+
+<cfscript>
+    assert("operand stack stays balanced after a looping tag (arithmetic)", stackMath, 9);
+    assert("operand stack stays balanced after a looping tag (function call)", stackList, 3);
+</cfscript>
+
+<!--- A loop request from the START phase is invalid (Lucee throws). --->
+<cfset startLoopError = "">
+<cfset startLoopOut = "">
+<cftry>
+    <cfsavecontent variable="startLoopOut"><cf_ltcfexitloopstart>BODY</cf_ltcfexitloopstart></cfsavecontent>
+    <cfcatch type="any">
+        <cfset startLoopError = cfcatch.message>
+    </cfcatch>
+</cftry>
+
+<cfscript>
+    assertTrue('start-phase cfexit method="loop" is rejected', len(startLoopError) GT 0);
+</cfscript>
+
+<!--- An exit fired in an END phase must not leak into the next, unrelated
+      tag: that tag's body and end phase still run. --->
+<cfset leakLog = "">
+<cfset leakError = "">
+<cfset leakOut = "">
+<cftry>
+    <cfsavecontent variable="leakOut"><cf_ltcfexitendexit outVar="leakLog">FIRST</cf_ltcfexitendexit><cf_ltcfexitplain outVar="leakLog">SECOND</cf_ltcfexitplain></cfsavecontent>
+    <cfcatch type="any">
+        <cfset leakError = cfcatch.message>
+    </cfcatch>
+</cftry>
+
+<cfscript>
+    assert("end-phase cfexit does not throw", leakError, "");
+    assert("end-phase cfexit does not leak into the next tag",
+        leakLog, "[first-end][second-start][second-end:SECOND]");
+</cfscript>
+
 <cfscript>suiteEnd();</cfscript>


### PR DESCRIPTION
Fixes #310

## What

`<cfexit method="loop">` was accepted but silently inert: it parsed, ran, and
landed in `last_exit_method`, which nothing ever consumed (before this change:
`exittag` 5 consumption sites, `exittemplate` 1, **`loop` 0**). Any custom tag
that iterates its own body therefore rendered only its first row.

The execution loop now records the tag body's instruction index right after
`__cfcustomtag_start` returns, and rewinds to it when the end phase requests
another iteration.

### Why rewind instead of a synthetic loop

The tag preprocessor already expands a pair into flat script
(`__cfcustomtag_start(...); <body> __cfcustomtag_end();`), so the tempting fix is
to emit `while (true) { <body> if (!__cfcustomtag_end()) break; }`. That would
**rebind a `<cfbreak>` written in the body and intended for the caller's own
`<cfloop>`** to the synthetic loop — a silent behaviour change. Keeping the body
as inline bytecode avoids it, and needs **no codegen and no preprocessor change**.

`break`/`continue` behaviour in tag bodies is unchanged by this patch. 

Stack invariant worth flagging for review: an expression statement compiles to
`… Call; Pop`, and `ip` is advanced before the op match, so at the record site
`ip` is that trailing `Pop` and `ip + 1` is the body. The code asserts the `Pop`
is really there (bounds-checked) and **fails fast** if it isn't, after unwinding
the tag state and restoring the outer output buffer — a broken VM/codegen
invariant should not degrade into silently wrong output. On the rewind path the
end call's result is popped explicitly, since we jump over the `Pop` that would
otherwise have consumed it.

## Two pre-existing divergences fixed along the way

Both were required for iterations to work at all, and each ships with its own
assertion:

1. **`thisTag` was rebuilt wholesale at the end phase**, discarding members the
   tag set itself. Lucee keeps them — probe: `state=S0` on Lucee vs **`GONE`** on
   `main`. It is now refreshed **in place** (mutating the existing struct, not
   replacing it), so members survive *and* an alias the tag kept
   (`variables.saved = thisTag`) still observes the current phase rather than a
   stale snapshot. Only `executionMode` / `hasEndTag` / `generatedContent` change.
2. **`last_exit_method` was taken only in start phases**, so a `cfexit` fired in
   an *end* phase stayed set until some unrelated later tag consumed it — and if
   it was `exittag`, that tag's body and end phase were silently skipped. It is
   now taken exactly once per phase boundary with an exhaustive match
   (`loop` / `exittag` / `exittemplate` | none / other). An unrecognised method
   keeps `main`'s current behaviour; it is only consumed so it cannot leak.

## Semantics — measured on Lucee 7.0.4.34, not assumed

| Behaviour | Lucee |
|---|---|
| start phase of a looped tag | runs **once** — loop re-runs body + end phase only |
| body | re-executed per iteration |
| `thisTag` members | persist across iterations (`S0 → S1 → S2`) |
| `thisTag.generatedContent` | per-iteration, never accumulated |
| `attributes`, `executionMode` | stable (`end` every round) |
| page output per iteration | generatedContent, then the end phase's own output |
| loop requested in the **start** phase | throws — this patch raises Lucee's message |
| loop from a **self-closing** tag | allowed; re-runs the (empty) body + end phase |

The self-closing case is a separate engine path (no start/end pair, no rewind)
and is handled in its own arm, with its own tests.

## Tests

Extends the existing `tests/tags/test_tags_cfexit.cfm` suite (already registered
in `runner.cfm`, so no runner change): **3 → 22 assertions**, plus 7 tag
templates in `tests/tags/`.

## Verification

- `Tags: cfexit` **22/22 on RustCFML and 22/22 on Lucee 7.0.4.34** — including
  the page-output assertion, so the expected ordering is Lucee's real behaviour.
- Full CFML suite: **7090/7091 CLI**, **7122/7123 served — dev *and*
  `--production`, cold and warm**. The single failure is a pre-existing
  datasource assertion (`cftransaction: an unopenable datasource is
  database-typed`) that fails identically on an unpatched build of this base.
- `cargo test -p cfml-vm --lib` 147/147, **JIT suite `jit_numeric` 76/76**,
  `wasm32-unknown-unknown` build of `cfml-worker` + `rustcfml-wasm` OK.
