### PR TITLE
Add CFML test for bare column references inside cfloop query

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -922,6 +922,14 @@ include "harness.cfm";
 <cf_runtest file="tags/test_script_loop.cfm">
 <cf_runtest file="tags/test_cfloop_query_currentrow.cfm">
 <cf_runtest file="tags/test_tags_cfloop_query_window_group.cfm">
+<!--- - cfloop_query_bare_column: inside <cfloop query>, a BARE column --->
+<!--- reference (expression read or interpolated output) must resolve to the --->
+<!--- current row like the scoped q.col form -- the same row-into-scope merge --->
+<!--- <cfoutput query> already does (§13). RustCFML throws "Variable 'grp' is --->
+<!--- undefined" for both bare forms; the scoped spelling is the in-suite --->
+<!--- control. Runtime-level (catchable), runner-safe. Reduced from the titan --->
+<!--- (Moopa) codebase port. --->
+<cf_runtest file="tags/test_cfloop_query_bare_column.cfm">
 <cf_runtest file="tags/test_tags_cfexit_loop.cfm">
 <cf_runtest file="tags/test_cfcookie_attributecollection.cfm">
 <cf_runtest file="tags/test_tag_attribute_escaped_hash.cfm">

--- a/tests/tags/test_cfloop_query_bare_column.cfm
+++ b/tests/tags/test_cfloop_query_bare_column.cfm
@@ -1,0 +1,63 @@
+<cfscript>
+suiteBegin("Tags: cfloop query bare column references");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    Inside <cfloop query="q">, a BARE column reference -- `grp` in an
+    expression, or ##grp## interpolated in the body -- must resolve to the
+    CURRENT ROW's column value: Lucee puts the query at the head of the scope
+    cascade for the loop body, exactly as it does for <cfoutput query> (which
+    RustCFML already supports -- known-issues §13: bare column refs "resolved
+    by merging each row into the variables scope"). Verified on Lucee 7: the
+    bare and scoped forms agree.
+
+    RustCFML resolves bare columns in <cfoutput query> but NOT in
+    <cfloop query>: the bare read throws "Variable 'grp' is undefined" while
+    the scoped q.grp spelling works (control below). Runtime-level gap (a
+    catchable throw, no parse error), so it is pinned inline under cftry and
+    registration is runner-safe.
+
+    Reduced from the titan (Moopa) codebase port: legacy report templates
+    iterate line items with <cfloop query> bodies written with bare column
+    names throughout.
+    ============================================================
+--->
+
+<cfset q = queryNew("grp,val", "varchar,integer",
+    [["A",1],["A",2],["B",3],["B",4],["B",5],["C",6]])>
+
+<!--- Control: the scoped q.grp spelling resolves per row today. --->
+<cfset scopedSeq = "">
+<cfloop query="q"><cfset scopedSeq = scopedSeq & q.grp></cfloop>
+<cfscript>
+assert("control: scoped q.grp resolves per row", scopedSeq, "AABBBC");
+</cfscript>
+
+<!--- Gap 1: a bare column read in an expression inside the loop body. --->
+<cfset bareSeq = "">
+<cfset bareErr = "">
+<cftry>
+    <cfloop query="q"><cfset bareSeq = bareSeq & grp></cfloop>
+    <cfcatch type="any"><cfset bareErr = cfcatch.message></cfcatch>
+</cftry>
+<cfscript>
+assert("bare column read in a loop-body expression does not throw", bareErr, "");
+assert("bare column read agrees with the scoped form", bareSeq, "AABBBC");
+</cfscript>
+
+<!--- Gap 2: the same bare column interpolated in output inside the loop. --->
+<cfset bareOut = "">
+<cfset bareOutErr = "">
+<cftry>
+    <cfsavecontent variable="bareOut"><cfloop query="q"><cfoutput>#grp#-#val# </cfoutput></cfloop></cfsavecontent>
+    <cfcatch type="any"><cfset bareOutErr = cfcatch.message></cfcatch>
+</cftry>
+<cfscript>
+assert("bare column interpolation in the loop body does not throw", bareOutErr, "");
+assert("bare column interpolation renders per row", trim(bareOut), "A-1 A-2 B-3 B-4 B-5 C-6");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a cross-engine CFML test pinning that inside `<cfloop query="q">` a **bare** column reference — `grp` in an expression, or `#grp#` interpolated in the body — resolves to the current row's column value, exactly like the scoped `q.grp` spelling.

## Why

Lucee puts the query at the head of the scope cascade for the loop body — the same row-into-scope merge RustCFML already performs for `<cfoutput query>` (known-issues §13: bare column refs "resolved by merging each row into the `variables` scope"). On RustCFML the `<cfloop query>` body has no such merge, so both bare forms throw `Variable 'grp' is undefined` while the scoped spelling works. Verified green on Lucee 7.0 and red on the v0.552.0 **and current-main** release binaries.

## Shape

Runtime-class gap (catchable throw, no parse error) → pinned inline under `cftry`, runner-safe. The scoped `q.grp` sequence is the in-suite control and passes today.

## Validation

Stock v0.552.0 release binary, full `tests/runner.cfm`: the pre-existing suite is byte-identical to the origin/main baseline; the only delta is the new suite:

```
FAIL | Tags: cfloop query bare column references | 1/5 passed (4 failed)
       FAIL: bare column read in a loop-body expression does not throw | expected: [] | got: [Variable 'grp' is undefined]
       FAIL: bare column read agrees with the scoped form | expected: [AABBBC] | got: []
       FAIL: bare column interpolation in the loop body does not throw | expected: [] | got: [Variable 'grp' is undefined]
       FAIL: bare column interpolation renders per row | expected: [A-1 A-2 B-3 B-4 B-5 C-6] | got: []
```

Lucee 7.0 (docker `lucee/lucee:7.0`): `PASS | Tags: cfloop query bare column references | 5/5 passed`.

Test-only; no engine change. Reduced from the titan (Moopa) codebase port — legacy report templates iterate line items with bare column names throughout. (The sibling `group=`/nested-bare-`<cfloop>` gaps from the same templates are already fixed on main (v0.554.0) and pinned by `test_tags_cfloop_query_window_group.cfm`, so this PR covers only the remaining scoping half.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
