### PR TITLE
Add CFML test for custom tag path deep search

### DIFF
--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -38,6 +38,15 @@ component {
     // _getAllObjectPaths prefix-strip. Points at tests/oop/ via tests/tags/../oop/.
     this.mappings["/dotdotprobe"] = getDirectoryFromPath(getCurrentTemplatePath()) & "tags/../oop/";
 
+    // Custom tag path for tests/tags/test_customtag_path_deep_search.cfm.
+    // The control tag sits at the path ROOT (ctpath_shallow.cfm); the gap tag
+    // one subdirectory down (nested/ctpath_deep.cfm). Lucee searches custom
+    // tag paths recursively when the engine's customTagDeepSearch flag is on
+    // (server-level; the per-app this.customTagDeepSearch spelling is inert on
+    // Lucee 7), so cross-engine runs of that suite need customTagDeepSearch
+    // enabled in the Lucee config. String form, as Lucee also accepts.
+    this.customtagpaths = getDirectoryFromPath(getCurrentTemplatePath()) & "tags/ctpathroot/";
+
     // Per-application datasources (Lucee/BoxLang parity). Scoped to THIS
     // application and resolved by cfquery/queryExecute ahead of the global
     // cfconfig registry. Exercised by tests/config/test_app_datasources.cfm.

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -468,6 +468,14 @@ include "harness.cfm";
 <cf_runtest file="tags/test_customtag_caller_semantics.cfm">
 <cf_runtest file="tags/test_custom_tag_attribute_collection.cfm">
 <cf_runtest file="tags/test_tags_customtag_lifecycle.cfm">
+<!--- - customtag_path_deep_search: a custom tag in a SUBDIRECTORY of a --->
+<!--- this.customtagpaths dir must resolve (Lucee with customTagDeepSearch --->
+<!--- on, which is how Lucee-based projects ship). RustCFML resolves the --->
+<!--- path root (in-suite control) but never descends: "Custom tag --->
+<!--- 'cf_ctpath_deep' not found". Runtime-level (catchable), runner-safe. --->
+<!--- Fixture dirs under tests/tags/ctpathroot/; the path itself is declared --->
+<!--- in tests/Application.cfc. Reduced from the titan (Moopa) codebase port. --->
+<cf_runtest file="tags/test_customtag_path_deep_search.cfm">
 <cf_runtest file="tags/test_tags_buffer_recovery.cfm">
 <cf_runtest file="tags/test_tags_cfexecute.cfm">
 <cf_runtest file="tags/test_tags_cfmail.cfm">

--- a/tests/tags/ctpathroot/ctpath_shallow.cfm
+++ b/tests/tags/ctpathroot/ctpath_shallow.cfm
@@ -1,0 +1,8 @@
+<!---
+    Control custom tag: lives at the ROOT of the this.customtagpaths directory
+    declared in tests/Application.cfc. RustCFML already resolves this, so it
+    guards the custom-tag-path wiring for test_customtag_path_deep_search.cfm.
+--->
+<cfif thisTag.executionMode eq "start">
+    <cfoutput>shallow-hello #attributes.name#</cfoutput>
+</cfif>

--- a/tests/tags/ctpathroot/nested/ctpath_deep.cfm
+++ b/tests/tags/ctpathroot/nested/ctpath_deep.cfm
@@ -1,0 +1,10 @@
+<!---
+    Gap custom tag: lives in a SUBDIRECTORY of the this.customtagpaths
+    directory declared in tests/Application.cfc. Lucee resolves it when
+    custom-tag deep search is on (engine config customTagDeepSearch=true --
+    see test_customtag_path_deep_search.cfm); RustCFML searches only the
+    path root and throws "Custom tag 'cf_ctpath_deep' not found".
+--->
+<cfif thisTag.executionMode eq "start">
+    <cfoutput>deep-hello #attributes.name#</cfoutput>
+</cfif>

--- a/tests/tags/test_customtag_path_deep_search.cfm
+++ b/tests/tags/test_customtag_path_deep_search.cfm
@@ -1,0 +1,62 @@
+<cfscript>
+suiteBegin("Tags: custom tag path deep search (tag in a subdirectory)");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    A custom tag file in a SUBDIRECTORY of a custom tag path must resolve:
+    with this.customtagpaths pointing at dir X and the tag file at
+    X/nested/hello.cfm, <cf_hello> executes. Lucee searches the declared
+    custom tag paths RECURSIVELY when deep search is enabled
+    (customTagDeepSearch=true in the engine config; the per-application
+    this.customTagDeepSearch spelling is inert on Lucee 7 -- verified). Deep
+    search is OFF in a stock Lucee install, but enabling it is how Lucee-based
+    projects ship (e.g. titan's config.json sets "customTagDeepSearch":"true"
+    and keeps app tags in nested per-app directories), so the cross-engine
+    run for this suite needs that engine flag on.
+
+    RustCFML resolves a tag at the ROOT of this.customtagpaths (the control
+    below passes today) but never descends into subdirectories: the nested
+    tag throws "Custom tag 'cf_ctpath_deep' not found". The throw is
+    catchable, so the gap is pinned inline under cftry and registration is
+    runner-safe.
+
+    Fixtures: tests/Application.cfc declares
+        this.customtagpaths = <tests dir> & "tags/ctpathroot/"
+    with the control tag at ctpathroot/ctpath_shallow.cfm and the gap tag at
+    ctpathroot/nested/ctpath_deep.cfm. The test file itself lives in
+    tests/tags/, so neither tag is findable by caller-relative search --
+    resolution can only come through the declared custom tag path.
+
+    Reduced from the titan (Moopa) codebase port: its custom tag path points
+    at an app's tags/ dir whose tags are organised in subdirectories.
+    ============================================================
+--->
+
+<!--- Control: a tag at the custom-tag-path ROOT resolves today. --->
+<cfset shallowOut = "">
+<cfset shallowErr = "">
+<cftry>
+    <cfsavecontent variable="shallowOut"><cf_ctpath_shallow name="World"></cfsavecontent>
+    <cfcatch type="any"><cfset shallowErr = cfcatch.message></cfcatch>
+</cftry>
+<cfscript>
+assert("control: tag at the custom-tag-path root resolves", shallowErr, "");
+assertTrue("control: root tag executed", findNoCase("shallow-hello World", shallowOut) GT 0);
+</cfscript>
+
+<!--- Gap: the same path with the tag one subdirectory down. --->
+<cfset deepOut = "">
+<cfset deepErr = "">
+<cftry>
+    <cfsavecontent variable="deepOut"><cf_ctpath_deep name="World"></cfsavecontent>
+    <cfcatch type="any"><cfset deepErr = cfcatch.message></cfcatch>
+</cftry>
+<cfscript>
+assert("tag in a custom-tag-path subdirectory resolves", deepErr, "");
+assertTrue("subdirectory tag executed", findNoCase("deep-hello World", deepOut) GT 0);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds a cross-engine CFML test pinning that a custom tag file in a **subdirectory** of a declared custom tag path resolves: with `this.customtagpaths` pointing at dir X and the tag at `X/nested/hello.cfm`, `<cf_hello>` executes.

## Why

Lucee searches custom tag paths recursively when the engine's `customTagDeepSearch` flag is on — which is how Lucee-based projects ship (titan's Lucee config sets `"customTagDeepSearch": "true"` and organises app tags in nested directories). RustCFML resolves a tag at the path **root** but never descends into subdirectories: `Custom tag 'cf_ctpath_deep' not found`. Verified red on the v0.552.0 and current-main release binaries.

One Lucee wrinkle, verified live on Lucee 7.0: deep search is a **server-level** engine setting (`customTagDeepSearch` in `.CFConfig.json`); the per-application `this.customTagDeepSearch` spelling is inert, and the flag defaults to off. The cross-engine run for this suite therefore needs `customTagDeepSearch=true` in the Lucee config (with it on, the suite is 4/4 green on Lucee 7.0; the rest of the suite is unaffected — the pre-existing custom tag suites stay 45/45 on both engines with the new path declared).

## Shape

Runtime-class gap (catchable throw) → pinned inline under `cftry`, runner-safe. Fixtures live under `tests/tags/ctpathroot/` (control tag at the root — passes today, guarding the `this.customtagpaths` wiring — gap tag in `nested/`); the path is declared in `tests/Application.cfc`. The test file sits in `tests/tags/`, so neither tag is findable by caller-relative search — resolution can only come through the declared path.

## Validation

Stock v0.552.0 release binary, full `tests/runner.cfm`: pre-existing results identical to baseline; the only delta:

```
FAIL | Tags: custom tag path deep search (tag in a subdirectory) | 2/4 passed (2 failed)
       FAIL: tag in a custom-tag-path subdirectory resolves | expected: [] | got: [Custom tag 'cf_ctpath_deep' not found]
       FAIL: subdirectory tag executed | expected truthy | got: [false]
```

Lucee 7.0 with `customTagDeepSearch=true`: `PASS | Tags: custom tag path deep search (tag in a subdirectory) | 4/4 passed`.

Test-only; no engine change. Reduced from the titan (Moopa) codebase port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
