### PR TITLE
Add CFML tests for four parser gaps: hash-wrapped struct attribute, cfparam bracket-colon key, cfquery escaped-hash body, tag-mode arrow functions

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -458,6 +458,14 @@ include "harness.cfm";
 <cf_runtest file="tags/test_tags_savecontent.cfm">
 <cf_runtest file="tags/test_tags_param.cfm">
 <cf_runtest file="tags/test_tags_param_dynamic.cfm">
+<!--- - cfparam_bracket_key_colon: cfparam name= is an lvalue path whose --->
+<!--- bracket segment holds a quoted string key -- including one with a --->
+<!--- colon (name="item['x-bind:href']", the Alpine.js attribute shape). --->
+<!--- RustCFML rejects it at PARSE time ("Expected RBracket, found Colon") --->
+<!--- though the same key works in ordinary expressions (inline control). --->
+<!--- Fixture-contained (parse errors escape try/catch); dotted-name control --->
+<!--- fixture guards the wiring. Reduced from the titan (Moopa) codebase port. --->
+<cf_runtest file="tags/test_cfparam_bracket_key_colon.cfm">
 <cf_runtest file="tags/test_tags_cfoutput_query.cfm">
 <cf_runtest file="tags/test_tags_misc.cfm">
 <cf_runtest file="tags/test_tags_cfsleep.cfm">
@@ -503,6 +511,14 @@ include "harness.cfm";
 <cf_runtest file="tags/test_pg_pool_stale_connection_retry.cfm">
 <cf_runtest file="tags/test_mssql_pool_stale_connection_retry.cfm">
 <cf_runtest file="tags/test_cfquery_quoted_identifier.cfm">
+<!--- - cfquery_escaped_hash_interpolation: an escaped hash immediately --->
+<!--- followed by an interpolation inside a cfquery-body string literal --->
+<!--- ('Order ###x#' -> "Order #5") must lower like it does in cfoutput/cfset --->
+<!--- (inline control). RustCFML rejects the body at PARSE time ("Expected --->
+<!--- RParen, found Identifier"). Fixture-contained; QoQ keeps the fixtures --->
+<!--- executable with no datasource, so the VALUE is asserted, not just --->
+<!--- parseability. Reduced from the titan (Moopa) codebase port. --->
+<cf_runtest file="tags/test_cfquery_escaped_hash_interpolation.cfm">
 <cf_runtest file="tags/test_cfquery_sql_line_comments.cfm">
 <cf_runtest file="tags/test_cte_with_query.cfm">
 <cf_runtest file="tags/test_tags_cfquery_control_tags.cfm">
@@ -926,6 +942,22 @@ include "harness.cfm";
 <cf_runtest file="tags/test_cfcookie_attributecollection.cfm">
 <cf_runtest file="tags/test_tag_attribute_escaped_hash.cfm">
 <cf_runtest file="tags/test_tag_attribute_escaped_quotes.cfm">
+<!--- - cfargument_hash_struct_default: an UNQUOTED hash-wrapped tag --->
+<!--- attribute may hold a STRUCT LITERAL (default=#{ "type": "json_object" }#); --->
+<!--- Lucee evaluates it as the argument default. RustCFML rejects it at --->
+<!--- PARSE time ("Unterminated '#' interpolation", reported away from the --->
+<!--- attribute) while the simple-expression form default=#lCase(..)# parses --->
+<!--- (control fixture). Fixture-contained (parse errors escape try/catch). --->
+<!--- Reduced from the titan (Moopa) codebase port. --->
+<cf_runtest file="tags/test_cfargument_hash_struct_default.cfm">
+<!--- - tag_mode_arrow_function: an arrow function is an expression, so it --->
+<!--- may appear in a TAG-MODE expression (<cfset t = arr.reduce((s, r) => --->
+<!--- s + r.count, 0)>), expression or block body. RustCFML rejects both at --->
+<!--- PARSE time ("Expected RParen, found Comma") while the identical code --->
+<!--- in cfscript and the classic function(){} spelling in tag mode both --->
+<!--- work (in-suite controls). Fixture-contained (parse errors escape --->
+<!--- try/catch). Found running titan (Moopa) on v0.574.0. --->
+<cf_runtest file="tags/test_tag_mode_arrow_function.cfm">
 <cf_runtest file="tags/test_cfspreadsheet.cfm">
 
 <!--- --- Query of Queries --- --->

--- a/tests/tags/CfargumentHashStructDefaultControlFixture.cfc
+++ b/tests/tags/CfargumentHashStructDefaultControlFixture.cfc
@@ -1,0 +1,15 @@
+<!---
+    Control fixture: an unquoted hash-wrapped SIMPLE expression as the
+    cfargument default -- default=#lCase("JSON_OBJECT")#. RustCFML already
+    parses and evaluates this, so it guards the fixture wiring: only the
+    STRUCT-LITERAL body of the hash expression trips the gap fixture.
+--->
+<cfcomponent output="false">
+    <cffunction name="t" returntype="string" output="false">
+        <cfargument name="rf" type="string" default=#lCase("JSON_OBJECT")#>
+        <cfreturn arguments.rf>
+    </cffunction>
+    <cffunction name="run" returntype="string" output="false">
+        <cfreturn t()>
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CfargumentHashStructDefaultFixture.cfc
+++ b/tests/tags/CfargumentHashStructDefaultFixture.cfc
@@ -1,0 +1,18 @@
+<!---
+    Gap fixture: a cfargument default= given as an UNQUOTED hash-wrapped
+    struct literal -- default=#{ "type": "json_object" }#. Lucee/ACF evaluate
+    the hash-wrapped expression and the paramless call t() returns
+    "json_object". RustCFML fails to PARSE the attribute ("Unterminated '#'
+    interpolation in string", reported at a position away from the offending
+    attribute), degrading this component to a catchable createObject()
+    failure -- hence the runtime-instantiated fixture.
+--->
+<cfcomponent output="false">
+    <cffunction name="t" returntype="string" output="false">
+        <cfargument name="rf" type="struct" default=#{ "type": "json_object" }#>
+        <cfreturn arguments.rf.type>
+    </cffunction>
+    <cffunction name="run" returntype="string" output="false">
+        <cfreturn t()>
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CfparamBracketColonControlFixture.cfc
+++ b/tests/tags/CfparamBracketColonControlFixture.cfc
@@ -1,0 +1,15 @@
+<!---
+    Control fixture: a cfparam name= with a DOTTED member path
+    (name="item.href"). RustCFML already parses and applies this, so it
+    guards the cfparam-in-fixture wiring. (A bracket key WITHOUT a colon,
+    name="item['href']", is not usable as the control: RustCFML parses it but
+    resolves the quoted key as an identifier at runtime -- "Variable 'href'
+    is undefined" -- a neighbouring gap not pinned here.)
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset item = {}>
+        <cfparam name="item.href" default="y">
+        <cfreturn item.href>
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CfparamBracketColonFixture.cfc
+++ b/tests/tags/CfparamBracketColonFixture.cfc
@@ -1,0 +1,17 @@
+<!---
+    Gap fixture: a cfparam name= whose target path uses a BRACKET key
+    containing a colon -- name="item['x-bind:href']" (an Alpine.js attribute
+    name). Lucee parses the name as an lvalue path with a quoted-string key
+    and creates the key. RustCFML fails to PARSE ("Expected RBracket, found
+    Colon"), degrading this component to a catchable createObject() failure
+    -- hence the runtime-instantiated fixture. The same key works in ordinary
+    expressions on RustCFML (item['x-bind:href'] = "x" -- asserted in the
+    test file), so the gap is specific to the cfparam name path parser.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset item = {}>
+        <cfparam name="item['x-bind:href']" default="x">
+        <cfreturn item['x-bind:href']>
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CfqueryEscapedHashControlFixture.cfc
+++ b/tests/tags/CfqueryEscapedHashControlFixture.cfc
@@ -1,0 +1,17 @@
+<!---
+    Control fixture: plain interpolation (no escaped hash) in the same
+    cfquery-body string literal -- 'Order #x#' yields "Order 5". RustCFML
+    already parses and executes this, so it guards the QoQ-in-fixture wiring:
+    only the ## escape immediately before the interpolation trips the gap
+    fixture.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset var x = 5>
+        <cfset var src = queryNew("id", "integer", [[1]])>
+        <cfquery name="local.q" dbtype="query">
+            SELECT 'Order #x#' AS t FROM src
+        </cfquery>
+        <cfreturn local.q.t>
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/CfqueryEscapedHashFixture.cfc
+++ b/tests/tags/CfqueryEscapedHashFixture.cfc
@@ -1,0 +1,22 @@
+<!---
+    Gap fixture: an ESCAPED hash immediately followed by an interpolation
+    inside a cfquery body's SQL string literal -- 'Order ###x#' (## is a
+    literal hash, #x# interpolates). On Lucee the query yields "Order #5"
+    when x=5. RustCFML fails to PARSE the body ("Expected RParen, found
+    Identifier(\"x\")"), degrading this component to a catchable
+    createObject() failure -- hence the runtime-instantiated fixture. The
+    same ###x# sequence works in cfoutput/cfset string contexts on RustCFML
+    (asserted inline in the test file); the gap is specific to the cfquery
+    body lowering. QoQ (dbtype="query") keeps the fixture executable with no
+    datasource on either engine.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset var x = 5>
+        <cfset var src = queryNew("id", "integer", [[1]])>
+        <cfquery name="local.q" dbtype="query">
+            SELECT 'Order ###x#' AS t FROM src
+        </cfquery>
+        <cfreturn local.q.t>
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/TagModeArrowBlockFixture.cfc
+++ b/tests/tags/TagModeArrowBlockFixture.cfc
@@ -1,0 +1,14 @@
+<!---
+    Gap fixture: the BLOCK-BODY arrow spelling in a tag-mode expression --
+    <cfset total = arr.reduce((s, r) => { return s + r.count; }, 0)>. Same
+    parse failure as the expression-body form (TagModeArrowFixture):
+    "Expected RParen, found Comma". Pinned separately so a fix for one body
+    shape cannot leave the other behind.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset var arr = [{count: 2}, {count: 3}]>
+        <cfset var total = arr.reduce((s, r) => { return s + r.count; }, 0)>
+        <cfreturn total>
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/TagModeArrowControlFixture.cfc
+++ b/tests/tags/TagModeArrowControlFixture.cfc
@@ -1,0 +1,13 @@
+<!---
+    Control fixture: the classic function(){} closure spelling in the same
+    tag-mode expression -- arr.reduce(function(s, r) { return s + r.count; }, 0).
+    RustCFML already parses and evaluates this, so it guards the fixture
+    wiring: only the ARROW spelling trips the gap fixtures.
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset var arr = [{count: 2}, {count: 3}]>
+        <cfset var total = arr.reduce(function(s, r) { return s + r.count; }, 0)>
+        <cfreturn total>
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/TagModeArrowFixture.cfc
+++ b/tests/tags/TagModeArrowFixture.cfc
@@ -1,0 +1,18 @@
+<!---
+    Gap fixture: an ARROW FUNCTION with an expression body inside a TAG-MODE
+    expression -- <cfset total = arr.reduce((s, r) => s + r.count, 0)>. Lucee
+    evaluates it (run() returns 5). RustCFML fails to PARSE the tag-mode
+    expression ("Expected RParen, found Comma" -- the parameter list is read
+    as a parenthesised expression), degrading this component to a catchable
+    createObject() failure -- hence the runtime-instantiated fixture. The
+    IDENTICAL code inside <cfscript> works (inline control in the test file),
+    as does the classic function(){} closure spelling in tag mode
+    (TagModeArrowControlFixture).
+--->
+<cfcomponent output="false">
+    <cffunction name="run" returntype="string" output="false">
+        <cfset var arr = [{count: 2}, {count: 3}]>
+        <cfset var total = arr.reduce((s, r) => s + r.count, 0)>
+        <cfreturn total>
+    </cffunction>
+</cfcomponent>

--- a/tests/tags/test_cfargument_hash_struct_default.cfm
+++ b/tests/tags/test_cfargument_hash_struct_default.cfm
@@ -1,0 +1,58 @@
+<cfscript>
+suiteBegin("Tags: cfargument unquoted hash-wrapped struct-literal default");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    A tag attribute may be given as an UNQUOTED hash-wrapped expression, and
+    that expression may be a struct literal:
+
+        <cfargument name="rf" type="struct" default=#{ "type": "json_object" }#>
+
+    Lucee 7 evaluates the expression, so a paramless call to the function
+    returns the default struct's member ("json_object"). Verified on Lucee 7.
+
+    RustCFML fails to PARSE the attribute -- "Unterminated '#' interpolation
+    in string", reported at a position away from the offending attribute --
+    apparently treating the `{ "type": ... }#` tail as string-interpolation
+    text instead of an expression body. The same unquoted hash-wrapped form
+    with a SIMPLE expression (default=#lCase(...)#) parses fine; that is the
+    control fixture.
+
+    Parse-class gap (it would abort this whole file), so both cases live in
+    runtime-instantiated fixtures: the parse failure degrades to a catchable
+    createObject() throw and shows up as a clean assertion mismatch.
+
+    Reduced from the titan (Moopa) codebase port: an LLM-call helper declares
+    <cfargument name="response_format" type="struct"
+    default=#{ "type": "json_object" }#>.
+    ============================================================
+--->
+
+<cfscript>
+// Instantiate a fixture and run run(); returns the value when the fixture
+// parsed and ran, or a diagnostic string when it did not.
+function loadRun(required string name) {
+    try {
+        var o = createObject("component", arguments.name);
+        if (!isObject(o)) {
+            return "NOT-A-COMPONENT";
+        }
+        return o.run();
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// --- control: unquoted hash-wrapped SIMPLE expression default --------------
+assert("control: unquoted hash-wrapped simple-expression default parses",
+    loadRun("CfargumentHashStructDefaultControlFixture"), "json_object");
+
+// --- gap: unquoted hash-wrapped STRUCT-LITERAL default ---------------------
+assert("unquoted hash-wrapped struct-literal default parses and evaluates",
+    loadRun("CfargumentHashStructDefaultFixture"), "json_object");
+
+suiteEnd();
+</cfscript>

--- a/tests/tags/test_cfparam_bracket_key_colon.cfm
+++ b/tests/tags/test_cfparam_bracket_key_colon.cfm
@@ -1,0 +1,63 @@
+<cfscript>
+suiteBegin("Tags: cfparam name with a bracket key containing a colon");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    cfparam's name= is an lvalue PATH, and a bracket segment holds a quoted
+    string key -- any string, including one with a colon:
+
+        <cfset item = {}>
+        <cfparam name="item['x-bind:href']" default="x">
+
+    (The key shape is an Alpine.js bound-attribute name, e.g. x-bind:href.)
+    Lucee parses the path and creates the key; item['x-bind:href'] reads "x".
+    Verified on Lucee 7.
+
+    RustCFML fails to PARSE the name path -- "Expected RBracket, found
+    Colon" -- even though the SAME key works in ordinary expressions
+    (item['x-bind:href'] = "x" assigns and reads fine; pinned as an inline
+    control below). Parse-class gap (it would abort this whole file), so the
+    failing shape lives in a runtime-instantiated fixture where the parse
+    failure degrades to a catchable createObject() throw. The control fixture
+    uses a dotted name path (name="item.href"), which RustCFML already
+    handles.
+
+    Reduced from the titan (Moopa) codebase port: form templates cfparam
+    Alpine x-bind:* attribute slots in an attribute struct.
+    ============================================================
+--->
+
+<cfscript>
+// Instantiate a fixture and run run(); returns the value when the fixture
+// parsed and ran, or a diagnostic string when it did not.
+function loadRun(required string name) {
+    try {
+        var o = createObject("component", arguments.name);
+        if (!isObject(o)) {
+            return "NOT-A-COMPONENT";
+        }
+        return o.run();
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// --- inline control: the same key in an ordinary expression ----------------
+item2 = {};
+item2["x-bind:href"] = "x";
+assert("control: colon key works in ordinary bracket expressions",
+    item2["x-bind:href"], "x");
+
+// --- control fixture: dotted cfparam name path -----------------------------
+assert("control: dotted cfparam name path parses and applies",
+    loadRun("CfparamBracketColonControlFixture"), "y");
+
+// --- gap: bracket key containing a colon -----------------------------------
+assert("cfparam name with a colon-bearing bracket key parses and applies",
+    loadRun("CfparamBracketColonFixture"), "x");
+
+suiteEnd();
+</cfscript>

--- a/tests/tags/test_cfquery_escaped_hash_interpolation.cfm
+++ b/tests/tags/test_cfquery_escaped_hash_interpolation.cfm
@@ -1,0 +1,62 @@
+<cfscript>
+suiteBegin("Tags: escaped hash + interpolation in a cfquery body");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    Inside a cfquery body, ## is a literal hash and #expr# interpolates --
+    the two compose, so a SQL string literal may contain an escaped hash
+    immediately followed by an interpolation:
+
+        <cfquery ...>SELECT 'Order ###x#' AS t</cfquery>
+
+    yields the value "Order #5" when x=5. Verified on Lucee 7. The identical
+    ###x# sequence in a cfset/cfoutput string works on BOTH engines (inline
+    control below).
+
+    RustCFML fails to PARSE the cfquery body -- "Expected RParen, found
+    Identifier(\"x\")" -- so the gap is specific to how the body's text is
+    lowered, not to hash escaping in general. Parse-class gap (it would abort
+    this whole file), so both query cases live in runtime-instantiated
+    fixtures where the parse failure degrades to a catchable createObject()
+    throw. The fixtures use QoQ (dbtype="query") so they execute -- and the
+    resulting VALUE is asserted, not just parseability -- with no datasource
+    on either engine.
+
+    Reduced from the titan (Moopa) codebase port: report queries build
+    display strings like 'Order ###ordernum#' in SELECT lists.
+    ============================================================
+--->
+
+<cfscript>
+// Instantiate a fixture and run run(); returns the value when the fixture
+// parsed and ran, or a diagnostic string when it did not.
+function loadRun(required string name) {
+    try {
+        var o = createObject("component", arguments.name);
+        if (!isObject(o)) {
+            return "NOT-A-COMPONENT";
+        }
+        return o.run();
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// --- inline control: the same sequence in an ordinary string ---------------
+x = 5;
+assert("control: escaped hash + interpolation in a cfset string",
+    "Order ###x#", "Order ##5");
+
+// --- control fixture: plain interpolation in the query body ----------------
+assert("control: plain interpolation in a cfquery-body string literal",
+    loadRun("CfqueryEscapedHashControlFixture"), "Order 5");
+
+// --- gap: escaped hash immediately before the interpolation ----------------
+assert("escaped hash + interpolation in a cfquery-body string literal",
+    loadRun("CfqueryEscapedHashFixture"), "Order ##5");
+
+suiteEnd();
+</cfscript>

--- a/tests/tags/test_tag_mode_arrow_function.cfm
+++ b/tests/tags/test_tag_mode_arrow_function.cfm
@@ -1,0 +1,67 @@
+<cfscript>
+suiteBegin("Tags: arrow functions in tag-mode expressions");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    An arrow function is an expression like any other, so it may appear in a
+    TAG-MODE expression context:
+
+        <cfset total = arr.reduce((s, r) => s + r.count, 0)>
+
+    Lucee 7 accepts both the expression-body and the block-body
+    ((s, r) => { return s + r.count; }) spellings and returns 5 for
+    [{count:2},{count:3}]. Verified on Lucee 7.
+
+    RustCFML fails to PARSE either arrow spelling in tag mode -- "Expected
+    RParen, found Comma" (the parameter list is consumed as a parenthesised
+    expression) -- while the IDENTICAL code inside <cfscript> works (inline
+    control below) and the classic function(){} closure spelling parses fine
+    in tag mode (control fixture). The gap is specific to arrow-function
+    syntax in the tag-mode expression parser.
+
+    Parse-class gap (it would abort this whole file), so both arrow shapes
+    live in runtime-instantiated fixtures where the parse failure degrades to
+    a catchable createObject() throw.
+
+    Found running titan (Moopa) on v0.574.0: the tag-mode arrow spelling
+    appears in legacy report code.
+    ============================================================
+--->
+
+<cfscript>
+// Instantiate a fixture and run run(); returns the value when the fixture
+// parsed and ran, or a diagnostic string when it did not.
+function loadRun(required string name) {
+    try {
+        var o = createObject("component", arguments.name);
+        if (!isObject(o)) {
+            return "NOT-A-COMPONENT";
+        }
+        return o.run();
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// --- inline control: the identical arrow reduce inside cfscript ------------
+arr = [{count: 2}, {count: 3}];
+assert("control: arrow function in cfscript",
+    arr.reduce((s, r) => s + r.count, 0), 5);
+
+// --- control fixture: classic closure spelling in tag mode -----------------
+assert("control: classic function(){} closure in a tag-mode expression",
+    loadRun("TagModeArrowControlFixture"), 5);
+
+// --- gap: arrow function (expression body) in tag mode ---------------------
+assert("arrow function (expression body) parses in a tag-mode expression",
+    loadRun("TagModeArrowFixture"), 5);
+
+// --- gap: arrow function (block body) in tag mode --------------------------
+assert("arrow function (block body) parses in a tag-mode expression",
+    loadRun("TagModeArrowBlockFixture"), 5);
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds four cross-engine CFML tests pinning parse-class gaps Lucee 7 accepts and RustCFML rejects:

1. An **unquoted hash-wrapped struct literal** as a tag attribute: `<cfargument name="rf" type="struct" default=#{ "type": "json_object" }#>` — a paramless call returns `json_object` on Lucee.
2. A **`cfparam` name with a bracket key containing a colon**: `<cfparam name="item['x-bind:href']" default="x">` (the Alpine.js attribute shape) — Lucee creates the key.
3. An **escaped hash immediately followed by an interpolation in a cfquery body**: `SELECT 'Order ###x#' AS t` yields `Order #5` when x=5 on Lucee.
4. An **arrow function in a tag-mode expression**: `<cfset total = arr.reduce((s, r) => s + r.count, 0)>` — expression or block body — returns 5 for `[{count:2},{count:3}]` on Lucee.

## Why

All four are constructs a Lucee codebase uses without thinking; on RustCFML each one fails to **parse**, so the file (or component) carrying it silently degrades:

- (1) `Unterminated '#' interpolation in string` — reported at a position away from the offending attribute. The simple-expression form `default=#lCase(..)#` parses fine (control fixture), so the gap is specific to a struct-literal expression body.
- (2) `Expected RBracket, found Colon` — though the **same key works in ordinary expressions** (`item['x-bind:href'] = "x"` — inline control), so the gap is specific to the `name=` lvalue-path parser. (A neighbouring runtime gap surfaced while writing the control: a bracket key **without** a colon, `name="item['href']"`, parses but resolves the quoted key as an identifier — `Variable 'href' is undefined`. Not pinned here; noted in the control fixture's comment.)
- (3) `Expected RParen, found Identifier("x")` — though the identical `###x#` sequence works in `cfset`/`cfoutput` strings (inline control), so the gap is in the cfquery body lowering.
- (4) `Expected RParen, found Comma` — the arrow's parameter list is consumed as a parenthesised expression. The **identical code inside `<cfscript>` works** (inline control), and the classic `function(){}` closure spelling parses fine in tag mode (control fixture), so the gap is specific to arrow syntax in the tag-mode expression parser. Both the expression-body and block-body spellings are pinned separately.

## Shape

Parse-class gaps (escape `try/catch`, would abort the runner) → each failing shape lives in a runtime-instantiated fixture CFC where the parse failure degrades to a catchable `createObject()` throw, with green controls guarding the wiring (the `CfqueryQuotedIdentFixture` pattern). The cfquery fixtures use **QoQ** (`dbtype="query"`) so they *execute* with no datasource on either engine — the resulting value (`Order #5`) is asserted, not just parseability.

## Validation

Stock v0.552.0 release binary, full `tests/runner.cfm`: pre-existing results identical to baseline; the only delta is one failed gap assertion per shape:

```
FAIL | Tags: cfargument unquoted hash-wrapped struct-literal default | 1/2 passed (1 failed)
       FAIL: ... | got: [THREW: Parse error in 'tests/tags/CfargumentHashStructDefaultFixture.cfc' [line 14, col 56]: Unterminated '#' interpolation in string: ... Escape a literal hash as '##'.]
FAIL | Tags: cfparam name with a bracket key containing a colon | 2/3 passed (1 failed)
       FAIL: ... | got: [THREW: Parse error in 'tests/tags/CfparamBracketColonFixture.cfc' [line 17, col 34]: Expected RBracket, found Colon]
FAIL | Tags: escaped hash + interpolation in a cfquery body | 2/3 passed (1 failed)
       FAIL: ... | expected: [Order #5] | got: [THREW: Parse error in 'tests/tags/CfqueryEscapedHashFixture.cfc' [line 21, col 47]: Expected RParen, found Identifier("x")]
FAIL | Tags: arrow functions in tag-mode expressions | 2/4 passed (2 failed)
       FAIL: arrow function (expression body) ... | got: [THREW: Parse error in 'tests/tags/TagModeArrowFixture.cfc' [line 18, col 37]: Expected RParen, found Comma]
       FAIL: arrow function (block body) ... | got: [THREW: Parse error in 'tests/tags/TagModeArrowBlockFixture.cfc' [line 14, col 37]: Expected RParen, found Comma]
```

On the v0.574.0 release binary the full run shows `FAILED: 6 assertion(s) in 5 suite(s)` — these 5 plus the one known pre-existing `cftransaction` failure — so the branch's REDs are the only delta on current main too. Lucee 7.0: 12/12 `ALL TESTS PASSED`.

Test-only; no engine change or suggested fix. Repros 1-3 reduced from the titan (Moopa) codebase port; repro 4 found running titan on v0.574.0, where the tag-mode arrow spelling appears in legacy report code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
