### PR TITLE
Add CFML tests: PostgreSQL placeholder rewriters must not scan comment bodies

### DIFF
--- a/tests/database/test_pg_comment_placeholder_scan.cfm
+++ b/tests/database/test_pg_comment_placeholder_scan.cfm
@@ -1,0 +1,102 @@
+<cfscript>
+// The PostgreSQL placeholder rewriters treat an apostrophe inside a SQL
+// comment as a string OPENER. rewrite_positional / rewrite_named
+// (crates/cfml-stdlib/src/pg_sql.rs) skip quoted strings and dollar-quoted
+// bodies but NOT `--` / `/* */` comments — while split_sql_statements in the
+// SAME file skips all three. So a contraction in a comment ("it's", "don't")
+// opens a phantom string literal and everything up to the next apostrophe or
+// end of statement — including `?` placeholders — is copied through as string
+// body, and the statement under-counts its parameters:
+//
+//   queryExecute: 2 positional parameter(s) supplied but the SQL only consumes 1
+//
+// The named rewriter has a second failure mode needing no apostrophe at all:
+// a bare `:word` inside a comment is rewritten to `$n` and consumes a
+// parameter slot, so binding fails (or every later bind shifts by one).
+//
+// Repro class: English contractions in SQL comments are everywhere. A titan
+// dashboard query with six `?` binds died on a `-- ... project's margin ...`
+// annotation — the error points at the parameter count, nowhere near the
+// comment, so it presents as a baffling caller-side bug. Lucee/ACF hand the
+// SQL to a driver that parses comments correctly, so this only bites here.
+//
+// Live test, gated on RUSTCFML_TEST_PG_DS (same convention as
+// test_query_error_catch_type_database.cfm; skipped when unset). To run:
+//   docker run -d -p 55432:5432 -e POSTGRES_PASSWORD=test -e POSTGRES_DB=testdb postgres:16
+//   RUSTCFML_TEST_PG_DS=postgres://postgres:test@127.0.0.1:55432/testdb \
+//     cargo run --features all-databases -- tests/runner.cfm
+
+suiteBegin("PG placeholder scan: comments are not string regions (live; skipped without DS env var)");
+
+function envDs(required string varName) {
+	try { return getEnvironmentVariable(arguments.varName, ""); }
+	catch (any e) { return ""; }
+}
+
+// Run a two-column SELECT and normalize the outcome: either the row values or
+// the error. queryExecute on the broken engine throws (param under-count /
+// unknown named param), so every leg must be catchable or the first failure
+// would abort the whole template.
+function selectAB(required string sql, required any params, required string ds) {
+	try {
+		var q = queryExecute(arguments.sql, arguments.params, {datasource: arguments.ds});
+		return "a=" & q.a[1] & ";b=" & q.b[1];
+	} catch (any e) {
+		return "ERROR: " & (e.message ?: "");
+	}
+}
+
+pgDs = envDs("RUSTCFML_TEST_PG_DS");
+if ( len(pgDs) == 0 ) {
+	assertTrue("PG comment/placeholder scan skipped (RUSTCFML_TEST_PG_DS not set)", true);
+} else {
+	nl = chr(10);
+
+	// Control: a comment WITHOUT an apostrophe or :word never confused the
+	// scanner — this leg passing while the others fail localizes the bug to
+	// comment-body content, not comment handling per se.
+	assert(
+		"control: positional binds with a plain line comment",
+		selectAB("SELECT ?::int AS a -- plain comment" & nl & ", ?::int AS b", [1, 2], pgDs),
+		"a=1;b=2"
+	);
+
+	// An apostrophe in a `--` comment must not swallow the `?` after it.
+	assert(
+		"positional `?` after an apostrophe in a line comment",
+		selectAB("SELECT ?::int AS a -- it's a comment" & nl & ", ?::int AS b", [1, 2], pgDs),
+		"a=1;b=2"
+	);
+
+	// Same, block comment: /* don't */ sits between the two binds.
+	assert(
+		"positional `?` after an apostrophe in a block comment",
+		selectAB("SELECT ?::int AS a, /* don't panic */ ?::int AS b", [1, 2], pgDs),
+		"a=1;b=2"
+	);
+
+	// Named binds after an apostrophe in a line comment.
+	assert(
+		"named `:b` after an apostrophe in a line comment",
+		selectAB("SELECT CAST(:a AS int) AS a -- it's a comment" & nl & ", CAST(:b AS int) AS b", {a: 1, b: 2}, pgDs),
+		"a=1;b=2"
+	);
+
+	// No apostrophe needed for the named rewriter: a bare `:word` inside a
+	// comment must not be taken as a placeholder (here it would demand a third
+	// parameter that the caller — correctly — never supplied).
+	assert(
+		"`:word` inside a line comment is not a placeholder",
+		selectAB("SELECT CAST(:a AS int) AS a, CAST(:b AS int) AS b -- see :note for details", {a: 1, b: 2}, pgDs),
+		"a=1;b=2"
+	);
+
+	assert(
+		"`:word` inside a block comment is not a placeholder",
+		selectAB("SELECT CAST(:a AS int) AS a, /* cf. :note */ CAST(:b AS int) AS b", {a: 1, b: 2}, pgDs),
+		"a=1;b=2"
+	);
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -284,6 +284,7 @@ include "harness.cfm";
 <cf_runtest file="database/test_dml_returns_empty_query.cfm">
 <cf_runtest file="database/test_query_error_catch_type_database.cfm">
 <cf_runtest file="database/test_query_error_sqlstate_members.cfm">
+<cf_runtest file="database/test_pg_comment_placeholder_scan.cfm">
 <cf_runtest file="stdlib/test_date_functions_extra.cfm">
 <cf_runtest file="stdlib/test_locale_functions.cfm">
 <cf_runtest file="stdlib/test_java_i18n_shims.cfm">


### PR DESCRIPTION
## What

Adds one live-gated test suite pinning a PostgreSQL parameter-scanning gap: SQL comments are not opaque to the placeholder rewriters.

1. An **apostrophe inside a `--` or `/* */` comment** (`-- it's a comment`) is taken as a string **opener**, so everything up to the next apostrophe or end of statement — including `?` placeholders — is copied through as string body and the statement under-counts its parameters.
2. A **bare `:word` inside a comment** (`-- see :note for details`) is rewritten to `$n` and consumes a parameter slot — no apostrophe needed.

Six legs: a no-apostrophe control (green on stock — localizes the gap to comment-body *content*, not comment handling per se) plus five failing shapes covering positional × named and line × block comments.

## Why

English contractions in SQL comments are everywhere, and the failure presents nowhere near the cause: a titan (Moopa) dashboard query with six `?` binds died with `6 positional parameter(s) supplied but the SQL only consumes 1` because of an apostrophe in a `--` annotation — it reads as a caller-side bug in the queryExecute arguments. (Its first fix then failed the same way: the replacement comment said "RustCFML's param scanner", apostrophe included.)

The five shapes fail five different ways on stock, which is part of what makes this confusing in the wild:

```
FAIL: positional `?` after an apostrophe in a line comment  | got: [ERROR: queryExecute: 2 positional parameter(s) supplied but the SQL only consumes 1]
FAIL: positional `?` after an apostrophe in a block comment | got: [ERROR: queryExecute: 2 positional parameter(s) supplied but the SQL only consumes 1]
FAIL: named `:b` after an apostrophe in a line comment      | got: [ERROR: queryExecute: PostgreSQL prepare error: db error — ERROR: syntax error at or near ":"]
FAIL: `:word` inside a line comment is not a placeholder    | got: [ERROR: queryExecute: PostgreSQL query error: expected 2 parameters but got 3]
FAIL: `:word` inside a block comment is not a placeholder   | got: [ERROR: queryExecute: PostgreSQL prepare error: db error — ERROR: could not determine data type of parameter $2]
```

Locus note (no fix suggested): `split_sql_statements` in `crates/cfml-stdlib/src/pg_sql.rs` already treats `--` / `/* */` as opaque; `rewrite_positional` / `rewrite_named` in the same file skip quoted strings and dollar-quoted bodies but not comments.

## Shape

Runtime-class gap against a live server adapter → gated on `RUSTCFML_TEST_PG_DS` with a single skip-pass when unset (the `test_query_error_catch_type_database.cfm` convention). Every leg runs through a catching helper so the throw on stock is asserted as a value, not an aborted template. Registered in `tests/runner.cfm` beside the other database suites.

```
docker run -d -p 55432:5432 -e POSTGRES_PASSWORD=test -e POSTGRES_DB=testdb postgres:16
RUSTCFML_TEST_PG_DS=postgres://postgres:test@127.0.0.1:55432/testdb \
  cargo run --features all-databases -- tests/runner.cfm
```

## Validation

Stock engine built from current `main` (v0.575.0, 391bebc), full `tests/runner.cfm` against postgres:16:

- With `RUSTCFML_TEST_PG_DS` set: `SUMMARY: 7519/7524` — the 5 failures are exactly this suite's five gap legs (control green); no other suite moves.
- Without the env var: `SUMMARY: 7497/7497` — single skip-pass, fully green.

Lucee 7.0 (docker `lucee/lucee:7.0`, repo as webroot, `tests/runner.cfm` over HTTP): suite parses and reports `PASS | PG placeholder scan … | 1/1 passed` (gated leg skips; the URL-string inline datasource is a RustCFML spelling, same as the existing gated PG suites).

Test-only; no engine change or suggested fix. Reduced from titan (Moopa) running on v0.574.0/v0.575.0 with the PostgreSQL adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)