### PR TITLE
Add CFML tests: getBaseTagList()/getBaseTagData() custom-tag ancestry built-ins

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -466,6 +466,7 @@ include "harness.cfm";
 <cf_runtest file="tags/test_tags_customtag.cfm">
 <cf_runtest file="tags/test_custom_tag_caller_cfc_method.cfm">
 <cf_runtest file="tags/test_customtag_caller_semantics.cfm">
+<cf_runtest file="tags/test_getbasetag_functions.cfm">
 <cf_runtest file="tags/test_custom_tag_attribute_collection.cfm">
 <cf_runtest file="tags/test_tags_customtag_lifecycle.cfm">
 <cf_runtest file="tags/test_tags_buffer_recovery.cfm">

--- a/tests/tags/basetag_outer.cfm
+++ b/tests/tags/basetag_outer.cfm
@@ -1,0 +1,28 @@
+<!---
+  Base-tag ancestry outer host. In its End mode it invokes basetag_probe from
+  THIS template — that is how real tag libraries nest (a modal tag rendering
+  its fragment/slot children). Tags placed in this host's BODY also see it as
+  an ancestor when it is cf_-invoked (pinned separately in the test; a
+  cfmodule-invoked host would not appear there).
+
+  After the probe runs, reports (via request.btouter) whether the slot the
+  probe deposited into attributes through the getBaseTagData() reference is
+  visible — the mutation contract the fragment/slot pattern depends on.
+--->
+<cfif thisTag.executionMode eq "start">
+    <cfparam name="attributes.marker" default="outer-marker" />
+</cfif>
+
+<cfif thisTag.executionMode eq "end">
+
+    <cf_basetag_probe marker="inner-1" deposit="actions" report="btnested" />
+
+    <cfset request.btouter = {} />
+    <cfif structKeyExists(attributes, "slots")>
+        <cfset request.btouter.slots_report = structKeyList(attributes.slots) & "=" & (attributes.slots["actions"] ?: "(missing)") />
+    <cfelse>
+        <cfset request.btouter.slots_report = "(no slots key)" />
+    </cfif>
+    <cfset thisTag.generatedContent = "" />
+
+</cfif>

--- a/tests/tags/basetag_probe.cfm
+++ b/tests/tags/basetag_probe.cfm
@@ -1,0 +1,74 @@
+<!---
+  Base-tag ancestry probe (leaf). Reports what the engine's custom-tag
+  ancestry built-ins expose, via request[attributes.report] (request crosses
+  tag boundaries, so the report is readable however deep the probe is nested,
+  and a named report key lets several probe runs coexist in one test).
+
+  Attributes:
+    report  — request key to write the report struct to (default btprobe)
+    marker  — identifies this instance in parent-vs-self disambiguation
+    deposit — a slot name to write into the nearest ancestor's attributes
+              through the getBaseTagData() reference (the fragment/slot
+              pattern real custom-tag libraries use)
+--->
+<cfif thisTag.executionMode eq "start">
+
+    <cfparam name="attributes.marker" default="(unset)" />
+    <cfparam name="attributes.report" default="btprobe" />
+
+    <cfset p = {} />
+    <cfset p.list = getBaseTagList() />
+    <cfset p.len = listLen(p.list) />
+    <cfset p.first = listFirst(p.list) />
+
+    <cfif p.len GTE 2>
+        <cfset p.parent_name = listGetAt(p.list, 2) />
+        <cftry>
+            <cfset p.parent_marker = getBaseTagData(p.parent_name).attributes.marker ?: "(no-marker)" />
+            <cfcatch type="any"><cfset p.parent_marker = "(threw: #cfcatch.message#)" /></cfcatch>
+        </cftry>
+    </cfif>
+
+    <!--- Self lookup by own tag name: the nearest instance is this probe. --->
+    <cftry>
+        <cfset p.self_marker = getBaseTagData("CF_BASETAG_PROBE").attributes.marker ?: "(no-marker)" />
+        <cfcatch type="any"><cfset p.self_marker = "(threw: #cfcatch.message#)" /></cfcatch>
+    </cftry>
+
+    <!--- Module-name lookup: even when a CFMODULE entry is in getBaseTagList(),
+          getBaseTagData("CFMODULE") cannot find it (Lucee-measured). --->
+    <cftry>
+        <cfset p.cfmodule_lookup = "found" />
+        <cfset dummy = getBaseTagData("CFMODULE") />
+        <cfcatch type="any"><cfset p.cfmodule_lookup = "(threw: #cfcatch.message#)" /></cfcatch>
+    </cftry>
+
+    <!--- The deposit shape: mutate the ancestor's attributes through the
+          returned reference; the ancestor checks for it after the probe
+          returns. --->
+    <cfif structKeyExists(attributes, "deposit") AND p.len GTE 2>
+        <cftry>
+            <cfset depositData = getBaseTagData(p.parent_name) />
+            <cfif NOT structKeyExists(depositData.attributes, "slots")>
+                <cfset depositData.attributes.slots = {} />
+            </cfif>
+            <cfset depositData.attributes.slots[attributes.deposit] = "deposited-by-probe" />
+            <cfcatch type="any"><cfset p.deposit_err = cfcatch.message /></cfcatch>
+        </cftry>
+    </cfif>
+
+    <!--- Under the suite runner the ancestry always contains CF_RUNTEST exactly
+          once, so a by-name lookup is unambiguous: its attributes.file is the
+          running test's own registration path. --->
+    <cfif listFindNoCase(p.list, "CF_RUNTEST")>
+        <cftry>
+            <cfset p.runtest_file = getBaseTagData("CF_RUNTEST").attributes.file ?: "(missing)" />
+            <cfcatch type="any"><cfset p.runtest_file = "(threw: #cfcatch.message#)" /></cfcatch>
+        </cftry>
+    <cfelse>
+        <cfset p.runtest_file = "(no CF_RUNTEST ancestor)" />
+    </cfif>
+
+    <cfset request[attributes.report] = p />
+
+</cfif>

--- a/tests/tags/test_getbasetag_functions.cfm
+++ b/tests/tags/test_getbasetag_functions.cfm
@@ -1,0 +1,129 @@
+<cfscript>
+// getBaseTagList() / getBaseTagData(): the standard custom-tag ancestry API
+// (Lucee and ACF both ship them). They are how nested custom tags find and
+// talk to their ancestors — the fragment/slot pattern deposits content into a
+// parent's attributes through the getBaseTagData() reference, and layout/
+// modal/panel tag libraries are built on it.
+//
+// RustCFML implements neither: the first call resolves as a variable read and
+// throws "Variable 'GetBaseTagList' is undefined", so every template in such
+// a tag library dies on its first line. Repro class: titan (Moopa) on
+// v0.575.0 — /sales died in its slot tag; the whole mechanism (136 call
+// sites: every modal, layout and admin grid) had to be rewritten onto a
+// hand-rolled request-scope stack to run at all.
+//
+// Expected values measured on Lucee 7.0 (docker lucee/lucee:7.0, repo as
+// webroot, suite via tests/runner.cfm). Two measured subtleties pinned here
+// so an implementation gets them right:
+//   - a cf_-invoked host IS in the ancestry of tags placed in its body
+//     (leg D) — but a cfmodule-invoked host is NOT (its body runs in the
+//     caller's context with no CFMODULE ancestor added);
+//   - cfmodule-invoked tags appear in getBaseTagList() as CFMODULE but
+//     getBaseTagData("CFMODULE") cannot find them (leg E).
+
+suiteBegin("getBaseTagList()/getBaseTagData(): custom-tag ancestry built-ins");
+
+// ── A: direct calls from this page (which runs inside cf_runtest) ──
+aList = "(threw)";
+try { aList = getBaseTagList(); } catch (any e) { aList = "THREW: " & e.message; }
+assertTrue( "A: getBaseTagList() from an in-tag page returns the ancestry (saw: " & aList & ")",
+    listFindNoCase( aList, "CF_RUNTEST" ) GT 0 );
+
+aFile = "(threw)";
+try { aFile = getBaseTagData( "CF_RUNTEST" ).attributes.file ?: "(missing)"; } catch (any e) { aFile = "THREW: " & e.message; }
+assert( "A: getBaseTagData() by name reads that ancestor's attributes", aFile, "tags/test_getbasetag_functions.cfm" );
+</cfscript>
+
+<!--- ── B: leaf probe invoked as a cf_ tag directly from the test file ── --->
+<cfset structDelete(request, "btprobe") />
+<cfset request.bt_leaf_err = "" />
+<cftry>
+    <cf_basetag_probe marker="leaf-1" report="btprobe" />
+    <cfcatch type="any"><cfset request.bt_leaf_err = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<cfscript>
+assert( "B: probe using the ancestry built-ins completes", request.bt_leaf_err EQ "" ? "ok" : request.bt_leaf_err, "ok" );
+probe = request.btprobe ?: {};
+assert( "B: first element of getBaseTagList() is the tag's own entry", probe.first ?: "(missing)", "CF_BASETAG_PROBE" );
+assert( "B: element 2 is the nearest enclosing tag (the suite runner)", probe.parent_name ?: "(missing)", "CF_RUNTEST" );
+assert( "B: self lookup by own tag name reaches this instance", probe.self_marker ?: "(missing)", "leaf-1" );
+assert( "B: CF_RUNTEST.attributes.file readable via getBaseTagData", probe.runtest_file ?: "(missing)", "tags/test_getbasetag_functions.cfm" );
+</cfscript>
+
+<!--- ── C: genuine template nesting — the outer host invokes the probe from
+       its OWN template (how a modal tag renders its fragment/slot children);
+       the probe reaches the outer tag's attributes and mutates them through
+       the getBaseTagData() reference. --->
+<cfset structDelete(request, "btnested") />
+<cfset structDelete(request, "btouter") />
+<cfset request.bt_nested_err = "" />
+<cftry>
+    <cf_basetag_outer marker="outer-1"></cf_basetag_outer>
+    <cfcatch type="any"><cfset request.bt_nested_err = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<cfscript>
+assert( "C: outer host invoking the probe from its own template completes", request.bt_nested_err EQ "" ? "ok" : request.bt_nested_err, "ok" );
+probe = request.btnested ?: {};
+assertTrue( "C: nested ancestry has at least 3 entries (probe, outer, runner) (saw: " & ( probe.list ?: "(none)" ) & ")",
+    ( probe.len ?: 0 ) GTE 3 );
+assert( "C: element 2 is the outer host", probe.parent_name ?: "(missing)", "CF_BASETAG_OUTER" );
+assert( "C: getBaseTagData(parent) reads the outer host's attributes", probe.parent_marker ?: "(missing)", "outer-1" );
+assert( "C: self lookup still reaches the probe itself", probe.self_marker ?: "(missing)", "inner-1" );
+assert(
+    "C: slot deposited through the getBaseTagData() reference is visible to the host",
+    ( request.btouter.slots_report ?: "(no report)" ),
+    "actions=deposited-by-probe"
+);
+</cfscript>
+
+<!--- ── D: body placement (Lucee-measured): a tag invoked in a cf_ host's
+       BODY sees the host in its ancestry — element 2 is the host, and its
+       attributes are readable there. (Contrast: a cfmodule-invoked host does
+       NOT appear in its body tags' ancestry.) --->
+<cfset structDelete(request, "btbody") />
+<cfset request.bt_body_err = "" />
+<cftry>
+    <cf_basetag_outer marker="outer-2"><cf_basetag_probe marker="body-1" report="btbody" /></cf_basetag_outer>
+    <cfcatch type="any"><cfset request.bt_body_err = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<cfscript>
+assert( "D: body-nested probe completes", request.bt_body_err EQ "" ? "ok" : request.bt_body_err, "ok" );
+assert( "D: a cf_ host IS in its body tags' ancestry (element 2)",
+    ( request.btbody.parent_name ?: "(missing)" ), "CF_BASETAG_OUTER" );
+assert( "D: the body tag reads the host's attributes via getBaseTagData",
+    ( request.btbody.parent_marker ?: "(missing)" ), "outer-2" );
+</cfscript>
+
+<!--- ── E: cfmodule limitation (Lucee-measured): a module-invoked tag appears
+       in getBaseTagList() as CFMODULE, but getBaseTagData("CFMODULE") throws
+       ("can't find base tag with name [CFMODULE]") — module entries are not
+       findable by name. --->
+<cfset structDelete(request, "btmod") />
+<cfset request.bt_mod_err = "" />
+<cftry>
+    <cfmodule template="basetag_probe.cfm" marker="mod-1" report="btmod">
+    <cfcatch type="any"><cfset request.bt_mod_err = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<cfscript>
+assert( "E: module-invoked probe completes", request.bt_mod_err EQ "" ? "ok" : request.bt_mod_err, "ok" );
+modProbe = request.btmod ?: {};
+assert( "E: module-invoked tag's own getBaseTagList() entry is CFMODULE", modProbe.first ?: "(missing)", "CFMODULE" );
+assertTrue( "E: getBaseTagData('CFMODULE') cannot find module entries (saw: " & ( modProbe.cfmodule_lookup ?: "(missing)" ) & ")",
+    findNoCase( "(threw:", modProbe.cfmodule_lookup ?: "" ) GT 0 );
+
+structDelete(request, "btprobe");
+structDelete(request, "btnested");
+structDelete(request, "btbody");
+structDelete(request, "btmod");
+structDelete(request, "btouter");
+structDelete(request, "bt_leaf_err");
+structDelete(request, "bt_nested_err");
+structDelete(request, "bt_body_err");
+structDelete(request, "bt_mod_err");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Adds one suite (19 assertions, two fixture tags) pinning the custom-tag ancestry API — `getBaseTagList()` and `getBaseTagData()` — which RustCFML does not implement: the first call resolves as a variable read and throws `Variable 'getBaseTagList' is undefined`.

Five legs, each a distinct contract:

- **A** — direct calls from an in-tag page: the ancestry list is returned, and `getBaseTagData(name).attributes` reads a named ancestor's attributes (the suite runner's own `cf_runtest` is the unambiguous ancestor).
- **B** — a `cf_`-invoked leaf probe: element 1 of the list is the tag's own entry (`CF_BASETAG_PROBE`), element 2 the nearest enclosing tag; self-lookup by own name reaches the current instance.
- **C** — genuine template nesting (an outer host tag invokes the probe from its own template, the way a modal renders fragment/slot children): the host is element 2, its attributes are readable, and a **mutation through the `getBaseTagData()` reference is visible to the host** — the deposit contract slot systems are built on.
- **D** — body placement: a tag written in a `cf_`-invoked host's *body* DOES see that host in its ancestry — but a `cfmodule`-invoked host does NOT appear in its body tags' ancestry (measured; the two invocation styles differ).
- **E** — the `cfmodule` limitation: a module-invoked tag appears in `getBaseTagList()` as `CFMODULE`, yet `getBaseTagData("CFMODULE")` throws `can't find base tag with name [CFMODULE]` — module entries are not findable by name.

D and E are pinned precisely because they're the parts an implementation would plausibly get wrong — I got both wrong on the first draft and the measured Lucee behaviour corrected me twice.

## Why

This API is how nested custom tags communicate; layout/modal/panel tag libraries are built on it, and the failure kills the whole template on line 1. Repro class: titan (Moopa) on v0.575.0 — `/sales` died in its slot tag, and the mechanism behind it (136 call sites: every modal, layout and admin grid) had to be rewritten onto a hand-rolled request-scope stack to run on RustCFML at all.

## Shape

Runtime-class gap → no fixture CFCs needed. Probe/host fixture *tags* live beside the other custom-tag fixtures in `tests/tags/` (`basetag_probe.cfm`, `basetag_outer.cfm`) and are invoked with `cf_` syntax (same-directory resolution, like `cf_greeting`); every leg runs under `cftry`/`try` so the throw on stock is asserted as a value, not an aborted template. The probe reports through a caller-named `request` key so multiple probe runs coexist in one test. Registered in `tests/runner.cfm` beside `test_customtag_caller_semantics.cfm`.

## Validation

- **Stock engine** built from current `main` (v0.575.0, 391bebc), full `tests/runner.cfm`: `FAIL | … | 0/19 passed` — every failure is `Variable 'getBaseTagList' is undefined` or a downstream `(missing)` report; `SUMMARY: 7496/7515` with all 19 reds in this suite and no other suite moved.
- **Lucee 7.0** (docker `lucee/lucee:7.0`, repo as webroot, `tests/runner.cfm` over HTTP): `PASS | … | 19/19 passed`. All expected values are Lucee-measured, including the two subtleties above.

Test-only; no engine change or suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)