### PR TITLE
Add CFML tests: getBaseTagData() instance-number semantics (parity pin, green on both engines)

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -477,6 +477,7 @@ include "harness.cfm";
 <cf_runtest file="tags/test_tags_customtag.cfm">
 <cf_runtest file="tags/test_custom_tag_caller_cfc_method.cfm">
 <cf_runtest file="tags/test_customtag_caller_semantics.cfm">
+<cf_runtest file="tags/test_getbasetag_instance_numbers.cfm">
 <cf_runtest file="tags/test_getbasetag_functions.cfm">
 <cf_runtest file="tags/test_custom_tag_attribute_collection.cfm">
 <cf_runtest file="tags/test_tags_customtag_lifecycle.cfm">

--- a/tests/tags/basetag_instance_probe.cfm
+++ b/tests/tags/basetag_instance_probe.cfm
@@ -1,0 +1,37 @@
+<!---
+  getBaseTagData() instance-number probe. For a target ancestor tag name,
+  records what each spelling of the instance argument returns — the marker
+  attribute of whichever instance the engine resolved, or the thrown message.
+  Reports via request[attributes.report].
+
+  Attributes:
+    target — ancestor tag name to look up (e.g. CF_BASETAG_NEST)
+    report — request key for the report struct (default btinst)
+--->
+<cfif thisTag.executionMode eq "start">
+
+    <cfparam name="attributes.target" type="string" />
+    <cfparam name="attributes.report" default="btinst" />
+
+    <cfset p = {} />
+    <cfset p.list = getBaseTagList() />
+
+    <!--- Default argument (documented default: 1). --->
+    <cftry>
+        <cfset p.inst_default = getBaseTagData(attributes.target).attributes.marker ?: "(no-marker)" />
+        <cfcatch type="any"><cfset p.inst_default = "(threw: #cfcatch.message#)" /></cfcatch>
+    </cftry>
+
+    <!--- Explicit instances 0-3. When a lookup returns a struct without the
+          marker (Lucee's out-of-range shape), record what the struct held. --->
+    <cfloop from="0" to="3" index="i">
+        <cftry>
+            <cfset d = getBaseTagData(attributes.target, i) />
+            <cfset p["inst_#i#"] = d.attributes.marker ?: "(struct keys: #structKeyList(d)#; attributes keys: #structKeyExists(d, 'attributes') ? structKeyList(d.attributes) : 'NO ATTRIBUTES KEY'#)" />
+            <cfcatch type="any"><cfset p["inst_#i#"] = "(threw: #cfcatch.message#)" /></cfcatch>
+        </cftry>
+    </cfloop>
+
+    <cfset request[attributes.report] = p />
+
+</cfif>

--- a/tests/tags/basetag_nest.cfm
+++ b/tests/tags/basetag_nest.cfm
@@ -1,0 +1,25 @@
+<!---
+  Nestable host for instance-number measurement. When outer (inner="false",
+  the default) its End mode invokes a second instance of ITSELF with a
+  different marker; the innermost invokes the instance probe from its own
+  template, giving the probe an ancestry containing CF_BASETAG_NEST twice:
+
+      CF_BASETAG_INSTANCE_PROBE, CF_BASETAG_NEST (marker=nest-inner),
+      CF_BASETAG_NEST (marker=nest-outer), CF_RUNTEST, ...
+
+  Which marker "instance 1" and "instance 2" return is the ordering under
+  measurement (nearest-first vs outermost-first).
+--->
+<cfif thisTag.executionMode eq "start">
+    <cfparam name="attributes.marker" default="nest-outer" />
+    <cfparam name="attributes.inner" default="false" />
+</cfif>
+
+<cfif thisTag.executionMode eq "end">
+    <cfif attributes.inner>
+        <cf_basetag_instance_probe target="CF_BASETAG_NEST" report="btinst_dup" />
+    <cfelse>
+        <cf_basetag_nest marker="nest-inner" inner="true"></cf_basetag_nest>
+    </cfif>
+    <cfset thisTag.generatedContent = "" />
+</cfif>

--- a/tests/tags/test_getbasetag_instance_numbers.cfm
+++ b/tests/tags/test_getbasetag_instance_numbers.cfm
@@ -1,0 +1,72 @@
+<cfscript>
+// getBaseTagData(name, instancenumber) semantics — measured IDENTICAL on
+// Lucee 7.0 and RustCFML v0.591.0, pinned here so they stay that way:
+//
+//   - the instance number is PER NAME: "the Nth ancestor called CF_X",
+//     not "the Nth ancestor overall";
+//   - it is 1-based, defaulting to 1; instance 0 is clamped to 1;
+//   - ordering is NEAREST-first (instance 1 = closest enclosing instance);
+//   - out-of-range throws "can't find base tag with name [X]" — the same
+//     message on both engines.
+//
+// Repro class: titan (Moopa) walked its ancestor list passing one GLOBAL
+// counter as the instance number — instance 0 of the first CF_ tag, instance
+// N of the Nth regardless of name. The 0 was clamped, the walk usually broke
+// on the nearest slot host before going out of range, and the bug survived
+// for years — until a page where no slot matched early walked on to request
+// instance 3 of a once-present layout tag and threw. These semantics are
+// load-bearing for any fragment/slot tag library; an engine relaxing or
+// tightening them changes real ancestor walks.
+//
+// Measurement footnote (observed while writing this, NOT pinned here): the
+// throw is invisible inside a chained expression on Lucee —
+// `getBaseTagData(...).attributes.marker ?: "x"` yields "x" (the elvis
+// swallows the error), while RustCFML propagates it. That elvis-scope
+// difference is a separate compatibility topic.
+
+suiteBegin("getBaseTagData() instance numbers: per-name, 1-based, nearest-first (Lucee-measured)");
+</cfscript>
+
+<!--- ── A: single occurrence of the target name in the ancestry ── --->
+<cfset structDelete(request, "btinst_dup") />
+<cfset request.bti_err = "" />
+<cftry>
+    <cf_basetag_nest marker="solo-1" inner="true"></cf_basetag_nest>
+    <cfcatch type="any"><cfset request.bti_err = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<cfscript>
+assert( "A: probe completes", request.bti_err EQ "" ? "ok" : request.bti_err, "ok" );
+p = request.btinst_dup ?: {};
+assert( "A: default instance resolves the (single) nearest instance", p.inst_default ?: "(missing)", "solo-1" );
+assert( "A: instance 0 is clamped to 1", p.inst_0 ?: "(missing)", "solo-1" );
+assert( "A: instance 1 explicit", p.inst_1 ?: "(missing)", "solo-1" );
+assertTrue( "A: instance 2 of a once-present name throws can't-find (saw: " & ( p.inst_2 ?: "(missing)" ) & ")",
+    findNoCase( "can't find base tag", p.inst_2 ?: "" ) GT 0 );
+</cfscript>
+
+<!--- ── B: the target name appears TWICE (nested same-name hosts) ── --->
+<cfset structDelete(request, "btinst_dup") />
+<cfset request.bti_err2 = "" />
+<cftry>
+    <cf_basetag_nest marker="nest-outer"></cf_basetag_nest>
+    <cfcatch type="any"><cfset request.bti_err2 = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<cfscript>
+assert( "B: nested probe completes", request.bti_err2 EQ "" ? "ok" : request.bti_err2, "ok" );
+p = request.btinst_dup ?: {};
+dupCount = listValueCountNoCase( p.list ?: "", "CF_BASETAG_NEST" );
+assertTrue( "B: ancestry contains the nest tag twice (saw: " & ( p.list ?: "(none)" ) & ")", dupCount EQ 2 );
+assert( "B: instance 1 is the NEAREST instance", p.inst_1 ?: "(missing)", "nest-inner" );
+assert( "B: default = instance 1 (nearest)", p.inst_default ?: "(missing)", "nest-inner" );
+assert( "B: instance 2 is the next one out", p.inst_2 ?: "(missing)", "nest-outer" );
+assertTrue( "B: instance 3 of a twice-present name throws can't-find (saw: " & ( p.inst_3 ?: "(missing)" ) & ")",
+    findNoCase( "can't find base tag", p.inst_3 ?: "" ) GT 0 );
+
+structDelete(request, "btinst_dup");
+structDelete(request, "bti_err");
+structDelete(request, "bti_err2");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Follow-up to #322: pins the `instancenumber` argument of `getBaseTagData(name, instancenumber)` — the leg I cut from that PR for scope, which promptly bit us in production code. Unlike the previous PRs this one is **green on both engines**: measurement showed v0.591.0's implementation already matches Lucee 7.0 exactly, so these 11 assertions are a regression guard for semantics that are load-bearing in real ancestor walks:

- the instance number is **per name** ("the Nth ancestor called CF_X"), not a global ancestor index;
- **1-based, default 1, and instance 0 is clamped to 1**;
- ordering is **nearest-first** (instance 1 = closest enclosing instance; measured with two nested same-name hosts carrying distinct markers);
- out-of-range **throws** — and both engines produce the same message, `can't find base tag with name [X]`.

## Why

titan's slot-rendering tag walked `getBaseTagList()` passing a single global counter as the instance number: instance 0 of the first `CF_` tag, instance N of the Nth regardless of name. That's garbage per the semantics above — but the 0 was clamped, the walk usually broke on the nearest slot host before running out of range, and it survived for years on Lucee. On v0.591.0 a page where no slot matched early walked on to request instance 3 of a once-present layout tag and got the (correct) throw. The engine wasn't wrong — it found a latent app bug by being right. Pinning the semantics keeps that strictness from drifting in either direction, since loosening OR tightening changes how existing ancestor walks behave.

## Shape

Two fixture tags beside the existing base-tag fixtures: `basetag_instance_probe.cfm` records what instances 0–3 and the default-argument call each resolve to (marker attribute or the thrown message), `basetag_nest.cfm` nests itself once so the ancestry contains the same name twice with distinct markers. Leg A measures the single-occurrence case, leg B the duplicate-name ordering. All lookups run under `cftry` with the result assigned **before** any member access — deliberately, see footnote. Registered in `tests/runner.cfm` beside the other custom-tag suites.

## Validation

- RustCFML built from current `main` (v0.591.0): `PASS | … | 11/11 passed`, full suite `SUMMARY: 7578/7578` — no other suite moved.
- Lucee 7.0 (docker `lucee/lucee:7.0`, repo as webroot, runner over HTTP): `PASS | … | 11/11 passed`.

## Measurement footnote (observed, not pinned)

My first probe chained the call — `getBaseTagData(name, i).attributes.marker ?: "(no-marker)"` — and the two engines *appeared* to diverge: Lucee returned the elvis default for out-of-range while RustCFML threw. Isolating the call showed both engines throw identically; the difference is that **Lucee's `?:` swallows the exception inside a chained expression** while RustCFML's propagates it. That elvis error-scope difference is real, observable in defensive one-liners, and probably deserves its own test — flagging it here rather than smuggling it into this suite's scope.

Test-only; no engine change suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)