### PR TITLE
Add CFML tests: cffunction output="true" bodies interpolate as if inside cfoutput

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -477,6 +477,7 @@ include "harness.cfm";
 <cf_runtest file="tags/test_tags_customtag.cfm">
 <cf_runtest file="tags/test_custom_tag_caller_cfc_method.cfm">
 <cf_runtest file="tags/test_customtag_caller_semantics.cfm">
+<cf_runtest file="tags/test_cffunction_output_true_body.cfm">
 <cf_runtest file="tags/test_getbasetag_functions.cfm">
 <cf_runtest file="tags/test_custom_tag_attribute_collection.cfm">
 <cf_runtest file="tags/test_tags_customtag_lifecycle.cfm">

--- a/tests/tags/OutputTrueBodyFixture.cfc
+++ b/tests/tags/OutputTrueBodyFixture.cfc
@@ -1,0 +1,31 @@
+<cfcomponent hint="Fixture: the three output modes of a tag-based cffunction body.">
+
+    <!--- The gap under test: output='true' means the body is processed AS IF
+          INSIDE CFOUTPUT — hash expressions interpolate and ## collapses to a
+          literal # — with no explicit cfoutput anywhere. --->
+    <cffunction name="implicitBody" output="true">
+        <cfargument name="val" default="42" />
+        IMPLICIT VAL:#arguments.val# ESC:[##] TICK:[`Job ##${js}`] END
+    </cffunction>
+
+    <!--- Control: the same body explicitly wrapped — works on both engines. --->
+    <cffunction name="explicitBody" output="true">
+        <cfargument name="val" default="42" />
+        <cfoutput>EXPLICIT VAL:#arguments.val# ESC:[##] END</cfoutput>
+    </cffunction>
+
+    <!--- Control: output='false' suppresses body text entirely; only the
+          return value escapes. --->
+    <cffunction name="suppressedBody" output="false">
+        <cfargument name="val" default="42" />
+        SUPPRESSED VAL:#arguments.val# SHOULD-NOT-APPEAR
+        <cfreturn "ret:#arguments.val#" />
+    </cffunction>
+
+    <!--- Measured leg: no output attribute at all. --->
+    <cffunction name="defaultBody">
+        <cfargument name="val" default="42" />
+        DEFAULT VAL:#arguments.val# ESC:[##] END
+    </cffunction>
+
+</cfcomponent>

--- a/tests/tags/test_cffunction_output_true_body.cfm
+++ b/tests/tags/test_cffunction_output_true_body.cfm
@@ -1,0 +1,70 @@
+<cfscript>
+// Tag-based cffunction bodies have THREE output modes (all Lucee-measured,
+// docker lucee/lucee:7.0):
+//
+//   output="true"   -> body is processed AS IF INSIDE CFOUTPUT: hash
+//                      expressions interpolate and ## collapses to a literal
+//                      #, with no explicit cfoutput anywhere. THE GAP:
+//                      RustCFML emits these bodies raw.
+//   output="false"  -> body text suppressed entirely; only the return value
+//                      escapes. (Already matches.)
+//   attr omitted    -> body text is emitted RAW — no interpolation, ## stays
+//                      doubled. (Already matches; pinned so the output="true"
+//                      fix doesn't overshoot into this mode.)
+//
+// Repro class: titan (Moopa) route CFCs render whole screens from
+// output="true" function bodies with no explicit cfoutput — Lucee has always
+// interpolated them. On RustCFML the sale-edit screen emitted a raw
+// `#application.lib.auth.signedEndpoint(route="...")#` into an Alpine x-data
+// attribute: the quote inside the un-evaluated expression terminated the
+// attribute, spilled the rest of the component as page text, and every
+// subsequent hash flipped between raw/literal — six SyntaxErrors and a dead
+// page from one missing interpolation mode. 31 functions needed explicit
+// cfoutput wraps to run.
+
+suiteBegin("cffunction output=""true"": body is processed as if inside cfoutput (Lucee parity)");
+
+// Resolution differs by harness: RustCFML resolves "tags.X" relative to the
+// running template's directory (tests/); a plain-docker Lucee webroot resolves
+// "tests.tags.X" from the repo root. Try the repo-convention spelling first,
+// fall back to webroot-relative.
+try {
+    fx = createObject("component", "tags.OutputTrueBodyFixture");
+} catch (any e) {
+    fx = createObject("component", "tests.tags.OutputTrueBodyFixture");
+}
+</cfscript>
+
+<cfsavecontent variable="implicitOut"><cfset fx.implicitBody(val=7) /></cfsavecontent>
+<cfsavecontent variable="explicitOut"><cfset fx.explicitBody(val=7) /></cfsavecontent>
+<cfsavecontent variable="suppressedOut"><cfset suppressedRet = fx.suppressedBody(val=7) /></cfsavecontent>
+<cfsavecontent variable="defaultOut"><cfset fx.defaultBody(val=7) /></cfsavecontent>
+
+<cfscript>
+// ── The gap: implicit interpolation in an output="true" body ──
+assertTrue( "implicit: hash expression interpolates (saw: " & trim( implicitOut ) & ")",
+    findNoCase( "VAL:7", implicitOut ) GT 0 );
+assertFalse( "implicit: no raw ##arguments.val## reaches the output",
+    findNoCase( "arguments.val", implicitOut ) GT 0 );
+assertTrue( "implicit: ## collapses to a single literal hash",
+    find( "ESC:[#chr(35)#]", implicitOut ) GT 0 AND find( "ESC:[#chr(35)##chr(35)#]", implicitOut ) EQ 0 );
+assertTrue( "implicit: ## collapses inside a JS template literal too",
+    find( "TICK:[`Job #chr(35)#${js}`]", implicitOut ) GT 0 );
+
+// ── Control: the same body with an explicit cfoutput (works today) ──
+assertTrue( "explicit-cfoutput control interpolates", findNoCase( "EXPLICIT VAL:7", explicitOut ) GT 0 );
+assertTrue( "explicit-cfoutput control collapses ##",
+    find( "ESC:[#chr(35)#]", explicitOut ) GT 0 );
+
+// ── Control: output="false" suppresses the body, return value intact ──
+assert( "output=false: body text fully suppressed", trim( suppressedOut ), "" );
+assert( "output=false: return value unaffected", suppressedRet, "ret:7" );
+
+// ── Pinned third state: omitted attribute emits the body RAW ──
+assertTrue( "omitted attr: body emits with hashes UNinterpolated",
+    findNoCase( "VAL:#chr(35)#arguments.val#chr(35)#", defaultOut ) GT 0 );
+assertTrue( "omitted attr: ## stays doubled",
+    find( "ESC:[#chr(35)##chr(35)#]", defaultOut ) GT 0 );
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Pins the three output modes of a tag-based `<cffunction>` body (all Lucee-measured):

1. **`output="true"` — THE GAP.** Lucee processes the body *as if inside cfoutput*: `#expr#` interpolates and `##` collapses to a literal `#`, with no explicit cfoutput anywhere. RustCFML emits the body raw. Four RED legs (interpolation, no raw expression text, `##` collapse, `##` collapse inside a JS template literal).
2. **`output="false"`** — body text suppressed entirely, return value intact. Already matches; pinned as a control.
3. **Attribute omitted** — the body is emitted **raw**: no interpolation, `##` stays doubled. Already matches on both engines — pinned so a fix for (1) doesn't overshoot into this mode, which is a genuinely different third state, not a default for either of the others.

A fourth control (the same body with an explicit `<cfoutput>` wrap) passes on stock today and pins the target semantics from the working side.

## Why

This is how classic tag-based CFCs render output — Moopa route components emit whole screens from `output="true"` function bodies with no explicit cfoutput, and Lucee has always interpolated them. On titan (v0.595.1) the sale-edit screen emitted a raw `#application.lib.auth.signedEndpoint(route="…")#` into an Alpine `x-data` attribute; the quote inside the un-evaluated expression terminated the attribute, spilled the rest of the component into the page as text, and every later hash flipped between raw and literal — six JS SyntaxErrors and a dead screen from one missing interpolation mode. The interim fix was wrapping 31 functions in explicit `<cfoutput>`, which is exactly the boilerplate `output="true"` exists to remove.

## Shape

Runtime-class gap → one fixture CFC (`tests/tags/OutputTrueBodyFixture.cfc`) with one function per mode, invoked under `<cfsavecontent>` so the emitted (or suppressed) body text is asserted as a value. Expected strings are built with `chr(35)` so the *test file's* own hash handling can't interfere with what it asserts. Fixture resolution tries the repo-convention `tags.X` spelling and falls back to webroot-relative `tests.tags.X` (harness environments differ on which resolves; both are tried so the suite runs everywhere). Registered in `tests/runner.cfm` beside the custom-tag suites.

## Validation

- **Stock v0.595.1** (release binary, full `tests/runner.cfm`): `FAIL | … | 6/10 passed (4 failed)` — the four failures are exactly the implicit-interpolation legs, each label quoting the raw body it saw; all six controls pass and no other suite moves.
- **Lucee 7.0** (docker `lucee/lucee:7.0`, repo as webroot, runner over HTTP): `PASS | … | 10/10 passed`.

Test-only; no engine change suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)