### PR TITLE
Add CFML tests: cfquery bodies strip CFML comments before executing SQL

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -532,6 +532,7 @@ include "harness.cfm";
 <!--- parseability. Reduced from the titan (Moopa) codebase port. --->
 <cf_runtest file="tags/test_cfquery_escaped_hash_interpolation.cfm">
 <cf_runtest file="tags/test_cfquery_sql_line_comments.cfm">
+<cf_runtest file="tags/test_cfquery_cfml_comments.cfm">
 <cf_runtest file="tags/test_cte_with_query.cfm">
 <cf_runtest file="tags/test_tags_cfquery_control_tags.cfm">
 <cf_runtest file="tags/test_cfquery_result_delivery.cfm">

--- a/tests/tags/test_cfquery_cfml_comments.cfm
+++ b/tests/tags/test_cfquery_cfml_comments.cfm
@@ -1,0 +1,89 @@
+<cfscript>
+// CFML comments inside a cfquery BODY never reach the database: Lucee strips
+// <!--- ---> lexically at compile time, wherever it appears — annotating SQL
+// with CFML comments is idiomatic and safe there. RustCFML passes them
+// through to the driver:
+//
+//   PostgreSQL:  prepare error — ERROR: operator does not exist: <! numeric
+//                (or: syntax error at or near "<!")
+//   QoQ:         Query of Queries syntax error: unexpected token in
+//                expression: Error("unexpected '!'")  [inline]
+//                / unexpected token in expression: Lt  [multi-line]
+//
+// Repro class: titan (Moopa) annotates pricing SQL with CFML comments —
+// 88 comments across 13 route files, all fine on Lucee for years. On
+// RustCFML the sale-edit lines query died the first time it ran, and every
+// one of the 88 had to be stripped app-side.
+//
+// Note the contrast pinned by the controls: SQL `--` comments are DATA and
+// must reach the engine/driver (both engines agree), and a CFML comment in a
+// queryExecute STRING is string content, not markup — only the tag BODY is
+// CFML-lexed. The PostgreSQL leg is live-gated on RUSTCFML_TEST_PG_DS (same
+// convention as test_query_error_catch_type_database.cfm):
+//   docker run -d -p 55432:5432 -e POSTGRES_PASSWORD=test -e POSTGRES_DB=testdb postgres:16
+//   RUSTCFML_TEST_PG_DS=postgres://postgres:test@127.0.0.1:55432/testdb \
+//     cargo run --features all-databases -- tests/runner.cfm
+
+suiteBegin("cfquery body: CFML comments are stripped before the SQL is executed");
+
+function envDs(required string varName) {
+	try { return getEnvironmentVariable(arguments.varName, ""); }
+	catch (any e) { return ""; }
+}
+
+src = queryNew("a,b", "integer,integer", [ [1, 2] ]);
+</cfscript>
+
+<!--- ── QoQ legs: engine-parsed, cross-engine, no external DB ── --->
+<cftry>
+    <cfquery name="qInline" dbtype="query">SELECT a <!--- pricing note: markup from base cost ---> , b FROM src</cfquery>
+    <cfset inlineResult = "#qInline.a#/#qInline.b#" />
+    <cfcatch type="any"><cfset inlineResult = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<cftry>
+    <cfquery name="qMulti" dbtype="query">
+        SELECT a,
+        <!--- a multi-line comment,
+              the way real annotations wrap --->
+        b FROM src
+    </cfquery>
+    <cfset multiResult = "#qMulti.a#/#qMulti.b#" />
+    <cfcatch type="any"><cfset multiResult = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<!--- Control: a SQL -- comment is data and must SURVIVE (both engines agree).
+      Newline-terminated: Lucee's QoQ parser errors on a line comment that
+      ends at EOF, which is a different quirk than the one under test. --->
+<cftry>
+    <cfquery name="qSqlCmt" dbtype="query">
+        SELECT a, b -- sql comment, kept
+        FROM src
+    </cfquery>
+    <cfset sqlCmtResult = "#qSqlCmt.a#/#qSqlCmt.b#" />
+    <cfcatch type="any"><cfset sqlCmtResult = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<cfscript>
+assert( "QoQ: inline CFML comment in the body is stripped", inlineResult, "1/2" );
+assert( "QoQ: multi-line CFML comment in the body is stripped", multiResult, "1/2" );
+assert( "control: a SQL -- comment in the body still executes", sqlCmtResult, "1/2" );
+
+// ── PostgreSQL leg: the real-world shape (prepare on a live server) ──
+pgDs = envDs("RUSTCFML_TEST_PG_DS");
+</cfscript>
+
+<cfif len(pgDs) EQ 0>
+    <cfscript>assertTrue( "PostgreSQL CFML-comment leg skipped (RUSTCFML_TEST_PG_DS not set)", true );</cfscript>
+<cfelse>
+    <cftry>
+        <cfquery name="qPg" datasource="#pgDs#">SELECT 1 AS a <!--- cfml annotation ---> , 2 AS b</cfquery>
+        <cfset pgResult = "#qPg.a#/#qPg.b#" />
+        <cfcatch type="any"><cfset pgResult = "THREW: " & cfcatch.message /></cfcatch>
+    </cftry>
+    <cfscript>assert( "PostgreSQL: CFML comment in a tag body never reaches the server", pgResult, "1/2" );</cfscript>
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Pins that a `<!--- --->` comment inside a `<cfquery>` **body** never reaches the SQL engine — Lucee strips CFML comments lexically wherever they appear, so annotating SQL with them is idiomatic and safe there. RustCFML passes them through to the driver:

```
QoQ (inline):     Query of Queries syntax error: unexpected token in expression: Error("unexpected '!'")
QoQ (multi-line): Query of Queries syntax error: unexpected token in expression: Lt
PostgreSQL:       prepare error — ERROR: syntax error at or near "<!"
                  (real-world variant: operator does not exist: <! numeric)
```

Four legs: inline and multi-line CFML comments through QoQ (cross-engine, no external DB — these carry the RED), the same shape against live PostgreSQL (`RUSTCFML_TEST_PG_DS`-gated, the real-world class), and a control pinning the contrast that a SQL `--` comment is *data* and must survive to the engine (both engines agree; the existing `test_cfquery_sql_line_comments.cfm` covers that side in depth — this suite pins the boundary between the two comment kinds).

## Why

titan (Moopa) annotates its pricing SQL with CFML comments — 88 of them across 13 route files, all silently stripped by Lucee for years. On v0.595.1 the sale-edit lines query died the first time it ever executed (`operator does not exist: <! numeric`), and the interim fix was deleting every one of the 88 app-side. Any Lucee codebase that comments its SQL the CFML way will hit this on first contact.

## Shape

Runtime-class → plain tag-mode `<cfquery>` calls under `cftry`, results asserted as values. Registered in `tests/runner.cfm` beside `test_cfquery_sql_line_comments.cfm`. One measured quirk noted in the control's comment: Lucee's QoQ parser errors on a `--` comment that ends at EOF with no trailing newline — the control uses the newline-terminated form so it pins the intended contrast, not that separate quirk.

## Validation

- **Stock v0.595.1** (release binary, full runner): with `RUSTCFML_TEST_PG_DS` set — `1/4 passed (3 failed)`, the three failures being exactly the two QoQ legs and the PG leg, each label quoting the driver error; without the env var — `2/4` (PG leg skip-passes). No other suite moves.
- **Lucee 7.0** (docker `lucee/lucee:7.0`, repo as webroot, runner over HTTP): `PASS | … | 4/4 passed`.

Test-only; no engine change suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)