### PR TITLE
Add CFML tests: three gaps on the jwt-cfml surface the v0.606 crypto shims enabled

### DIFF
--- a/tests/java_shims/test_java_date_shim_date_bifs.cfm
+++ b/tests/java_shims/test_java_date_shim_date_bifs.cfm
@@ -1,0 +1,59 @@
+<cfscript>
+// A java.util.Date shim instance must be usable AS A DATE by the CFML date
+// BIFs — on Lucee (real JVM) isDate() is true and dateAdd/dateDiff/
+// dateCompare/dateTimeFormat all accept it. On RustCFML the shim exists and
+// its methods work (getTime() is fine), but every date BIF rejects it:
+//
+//   dateAdd:     Invalid date: java.util.date
+//   dateCompare: Invalid date1
+//
+// Repro class: this sits directly on the vendored jwt-cfml surface the
+// v0.606.0 Signature/KeyFactory shims enabled. jwt-cfml anchors epoch math
+// on `createObject('java','java.util.Date').init(javacast('int', 0))` and
+// converts exp/nbf claims via dateAdd/dateDiff against it — so the moment
+// canVerifyAsymmetric() went true, titan's Auth0 decode moved off its
+// fallback and died here instead: the shim unlocked a path the Date shim
+// then broke. (titan worked around it by rewriting the converters in pure
+// CFML; this pins the engine-side contract.)
+//
+// Assertions are timezone-agnostic (relative arithmetic, not absolute
+// formatting), measured on Lucee 7.0 (docker lucee/lucee:7.0).
+
+suiteBegin("java.util.Date shim instances work with the CFML date BIFs");
+
+epochBase = createObject("java", "java.util.Date").init(javacast("long", 0));
+
+// The shim itself is present and its methods work — that part is fine today.
+assert( "shim method getTime() works (control)", epochBase.getTime(), 0 );
+
+// isDate: a Date IS a date.
+assertTrue( "isDate() is true for a java.util.Date instance", isDate(epochBase) );
+
+// dateAdd accepts it and yields a real date.
+r1 = "(threw)";
+try { r1 = isDate(dateAdd("s", 60, epochBase)); } catch (any e) { r1 = "THREW: " & e.message; }
+assert( "dateAdd() accepts a java.util.Date base", r1, true );
+
+// Relative round trip: +2 minutes is 120 seconds, in any timezone.
+r2 = "(threw)";
+try { r2 = dateDiff("s", epochBase, dateAdd("n", 2, epochBase)); } catch (any e) { r2 = "THREW: " & e.message; }
+assert( "dateDiff() round-trips against a java.util.Date base", r2, 120 );
+
+// The epoch-conversion shape jwt-cfml uses: seconds offset -> whole days.
+r3 = "(threw)";
+try { r3 = dateDiff("d", epochBase, dateAdd("s", 86400, epochBase)); } catch (any e) { r3 = "THREW: " & e.message; }
+assert( "epoch-seconds conversion shape (dateAdd s / dateDiff d)", r3, 1 );
+
+// dateCompare: 1970 is before now.
+r4 = "(threw)";
+try { r4 = dateCompare(epochBase, now()); } catch (any e) { r4 = "THREW: " & e.message; }
+assert( "dateCompare() accepts a java.util.Date instance", r4, -1 );
+
+// dateTimeFormat accepts it (year is 1970 UTC / 1969 in negative-offset zones).
+r5 = "(threw)";
+try { r5 = dateTimeFormat(epochBase, "yyyy"); } catch (any e) { r5 = "THREW: " & e.message; }
+assertTrue( "dateTimeFormat() accepts a java.util.Date instance (saw: " & r5 & ")",
+    listFind("1969,1970", r5) GT 0 );
+
+suiteEnd();
+</cfscript>

--- a/tests/java_shims/test_java_util_base64.cfm
+++ b/tests/java_shims/test_java_util_base64.cfm
@@ -1,0 +1,39 @@
+<cfscript>
+// java.util.Base64 — the JDK's standard base64 API, unshimmed:
+//
+//   createObject: Java class [java.util.Base64] is not supported.
+//
+// Repro class: JWK-to-PEM builders (the JWKS verification path the v0.606.0
+// Signature/KeyFactory shims enabled) conventionally finish with
+// Base64.getEncoder().encodeToString(publicKey.getEncoded()) — titan's Auth0
+// callback did exactly that and had to switch to binaryEncode(). The pure-CFML
+// spelling exists, but any Lucee codebase reaching this class dies at
+// createObject before it can find out.
+
+suiteBegin("java.util.Base64: encoder/decoder shim (JWK-to-PEM surface)");
+
+b64 = "(threw)";
+try {
+    b64 = createObject("java", "java.util.Base64");
+} catch (any e) {
+    b64 = "THREW: " & e.message;
+}
+
+if ( isSimpleValue(b64) ) {
+    assert( "java.util.Base64 resolves via createObject", b64, "(an object)" );
+} else {
+    assertTrue( "java.util.Base64 resolves via createObject", true );
+
+    enc = "(threw)";
+    try { enc = b64.getEncoder().encodeToString(charsetDecode("AB", "utf-8")); }
+    catch (any e) { enc = "THREW: " & e.message; }
+    assert( "getEncoder().encodeToString() matches binaryEncode", enc, "QUI=" );
+
+    dec = "(threw)";
+    try { dec = charsetEncode(b64.getDecoder().decode("QUI="), "utf-8"); }
+    catch (any e) { dec = "THREW: " & e.message; }
+    assert( "getDecoder().decode() round-trips", dec, "AB" );
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -280,6 +280,7 @@ include "harness.cfm";
 <cf_runtest file="stdlib/test_xml.cfm">
 <cf_runtest file="stdlib/test_utility.cfm">
 <cf_runtest file="stdlib/test_encoding_functions.cfm">
+<cf_runtest file="stdlib/test_binarydecode_excess_padding.cfm">
 <cf_runtest file="stdlib/test_query_mutations.cfm">
 <cf_runtest file="stdlib/test_query_new_empty_addcolumn_metadata.cfm">
 <cf_runtest file="database/test_lucee_query_builder.cfm">
@@ -640,6 +641,8 @@ include "harness.cfm";
 <cf_runtest file="java_shims/test_commons_imaging.cfm">
 <cf_runtest file="java_shims/test_optional.cfm">
 <cf_runtest file="java_shims/test_masa_io_text_shims.cfm">
+<cf_runtest file="java_shims/test_java_date_shim_date_bifs.cfm">
+<cf_runtest file="java_shims/test_java_util_base64.cfm">
 
 <!--- --- Engine Compatibility --- --->
 <cf_runtest file="compat_engine/test_math_functions.cfm">

--- a/tests/stdlib/test_binarydecode_excess_padding.cfm
+++ b/tests/stdlib/test_binarydecode_excess_padding.cfm
@@ -1,0 +1,34 @@
+<cfscript>
+// binaryDecode(..., "base64") and EXCESS padding. Lucee ignores surplus '='
+// entirely; RustCFML agrees for partial-group excess but decodes a full
+// spurious "====" quad appended to complete groups into a trailing NUL byte:
+//
+//   "QUJD"      -> "ABC" (3 bytes)            both engines
+//   "QQ==="     -> 1 byte (one '=' surplus)   both engines
+//   "QUJD===="  -> "ABC" (3) on Lucee, "ABC\0" (4) on RustCFML
+//
+// Repro class: jwt-cfml's base64UrlToBinary pads with
+// `repeatString('=', 4 - (len % 4))` — i.e. FOUR '=' when the length is
+// already a multiple of 4, which is exactly the whole-quad shape. On Lucee
+// that lib bug is invisible; on RustCFML the NUL corrupts the decoded JWT
+// header/payload JSON ("Invalid JSON: trailing characters"), breaking token
+// decode on the surface the v0.606.0 crypto shims enabled. (titan fixed the
+// lib's padding math; this pins the decoder-side leniency contract.)
+
+suiteBegin("binaryDecode base64: excess padding is ignored, never decoded into bytes");
+
+function decoded(s) {
+    return charsetEncode(binaryDecode(s, "base64"), "utf-8");
+}
+
+assert( "control: exact-length group decodes clean", decoded("QUJD"), "ABC" );
+assert( "control: exact-length group byte count", len(decoded("QUJD")), 3 );
+assert( "partial excess (one surplus '=') is ignored", len(decoded("QQ===")), 1 );
+
+wholeQuad = decoded("QUJD====");
+assert( "whole-quad excess padding decodes to the same 3 bytes", len(wholeQuad), 3 );
+assert( "no trailing NUL is materialised (saw last byte: " & asc(right(wholeQuad, 1)) & ")",
+    wholeQuad, "ABC" );
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Three suites pinning what the v0.606.0 `Signature`/`KeyFactory` shims *unmasked*: real-world JWT verification now gets past the signature and dies (or silently corrupts) one layer further down. Found within the hour of pointing titan's Auth0 flow at v0.607.0.

1. **`tests/java_shims/test_java_date_shim_date_bifs.cfm`** — a `java.util.Date` shim instance must be usable *as a date* by the CFML date BIFs. The shim's own methods work (`getTime()` — pinned as a control), but `isDate()` is false and `dateAdd`/`dateDiff`/`dateCompare`/`dateTimeFormat` all throw `Invalid date: java.util.date`. jwt-cfml anchors its epoch claim conversion on exactly this object (`createObject('java','java.util.Date').init(javacast('int', 0))` + `dateAdd`/`dateDiff`), so every `decode()` of a token with an `exp` claim dies after the signature verifies. Assertions are timezone-agnostic (relative arithmetic; the one format leg accepts 1969/1970).

2. **`tests/stdlib/test_binarydecode_excess_padding.cfm`** — Lucee ignores surplus `=` in base64 entirely; RustCFML agrees for *partial*-group excess (`QQ===` → 1 byte, both engines — pinned as a control) but decodes a whole spurious `====` quad into a **trailing NUL byte** (`QUJD====` → 4 bytes vs Lucee's 3). jwt-cfml's `base64UrlToBinary` pads with `repeatString('=', 4 - (len % 4))` — i.e. four `=` when the length is already a multiple of 4 — so the lib's (admittedly buggy) idiom produces exactly this shape, and the NUL corrupts the decoded JWT header/payload JSON: `Invalid JSON: trailing characters`. Lucee's leniency is what the ecosystem has calibrated against.

3. **`tests/java_shims/test_java_util_base64.cfm`** — `java.util.Base64` is unshimmed. The conventional JWK→PEM finisher is `Base64.getEncoder().encodeToString(publicKey.getEncoded())`; a JWKS callback reaches this class right after `KeyFactory` succeeds. The suite is written resolution-first, so if/when the shim lands the encoder/decoder legs activate automatically (`encodeToString` ↔ `binaryEncode` parity, decoder round-trip).

## Why

These three are one story: v0.606 opened the road and the next three potholes became reachable. titan's login on v0.607.0 moved off its claims-only fallback automatically (`canVerifyAsymmetric()` went true) and then failed in the date conversion; fixing that exposed the NUL corruption; fixing *that* exposed the missing `Base64`. All three were patched app-side in pure CFML, so titan logs in with full JWKS/RS256 verification today — but every other Lucee codebase pointing jwt-cfml (or hand-rolled JWKS code) at RustCFML will hit the same sequence in the same order.

## Validation

- **Stock v0.607.0** (release binary, full runner): the three suites contribute exactly 9 red assertions — Date-shim 1/7 (the `getTime` control passes), padding 3/5 (both whole-quad legs red, the failure label prints the materialised NUL: `saw last byte: 0`), Base64 0/1. No other suite moves. (Amusing artifact: the NUL byte in the runner output makes grep treat the log as binary.)
- **Lucee 7.0** (docker `lucee/lucee:7.0`, repo as webroot, runner over HTTP): 7/7, 5/5, 3/3.

Test-only; no engine change suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)