### PR TITLE
Add CFML tests: cfexecute quote parsing, cfqueryparam array list values (+ elvis error-scope pin)

### DIFF
--- a/tests/core/test_elvis_error_scope.cfm
+++ b/tests/core/test_elvis_error_scope.cfm
@@ -1,0 +1,39 @@
+<cfscript>
+// Elvis (?:) error scope — a PARITY PIN, currently green on both engines.
+//
+// On Lucee the left side of `?:` is evaluated in a swallow-everything scope:
+// not just null/undefined, but a genuinely THROWN exception anywhere in the
+// chain yields the default. Measured identical on RustCFML v0.607.0 — but it
+// has not always been: at v0.595.1 a thrown left side PROPAGATED here
+// (observed during the getBaseTagData work, PR #323's measurement footnote:
+// `getBaseTagData(...).attributes.marker ?: "x"` threw on RustCFML while
+// Lucee returned "x"). The behaviour converged silently somewhere in
+// v0.596–v0.607; this suite pins it so any future change is deliberate.
+//
+// Real-world weight: defensive one-liners lean on this scope constantly —
+// `cfg().setting ?: default` is written assuming a failing cfg() means
+// "use the default", not "500".
+
+suiteBegin("elvis (?:) swallows thrown left sides, not just null/undefined (Lucee parity)");
+
+function boomFn() { throw(message="boom"); }
+
+r1 = "(propagated)";
+try { r1 = boomFn() ?: "dflt"; } catch (any e) { r1 = "THREW: " & e.message; }
+assert( "a thrown function call yields the default", r1, "dflt" );
+
+r2 = "(propagated)";
+try { r2 = boomFn().member ?: "dflt"; } catch (any e) { r2 = "THREW: " & e.message; }
+assert( "a throw inside a call-then-member chain yields the default", r2, "dflt" );
+
+emptySt = {};
+r3 = "(propagated)";
+try { r3 = emptySt.a.b ?: "dflt"; } catch (any e) { r3 = "THREW: " & e.message; }
+assert( "an undefined deep path yields the default (the documented case)", r3, "dflt" );
+
+r4 = "(propagated)";
+try { r4 = totally_unknown_fn_xyz() ?: "dflt"; } catch (any e) { r4 = "THREW: " & e.message; }
+assert( "an unknown function name yields the default", r4, "dflt" );
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -101,6 +101,7 @@ include "harness.cfm";
 <cf_runtest file="core/test_arg_ref_writeback_deferred.cfm">
 <cf_runtest file="core/test_arrow_functions.cfm">
 <cf_runtest file="core/test_comma_less_params.cfm">
+<cf_runtest file="core/test_elvis_error_scope.cfm">
 <cf_runtest file="core/test_required_param_with_default.cfm">
 <cf_runtest file="core/test_self_named_default_arg.cfm">
 <cf_runtest file="core/test_member_index_incdec.cfm">
@@ -501,6 +502,7 @@ include "harness.cfm";
 <cf_runtest file="tags/test_customtag_path_deep_search.cfm">
 <cf_runtest file="tags/test_tags_buffer_recovery.cfm">
 <cf_runtest file="tags/test_tags_cfexecute.cfm">
+<cf_runtest file="tags/test_cfexecute_argument_quoting.cfm">
 <cf_runtest file="tags/test_tags_cfmail.cfm">
 <cf_runtest file="tags/test_tags_cfcache.cfm">
 <cf_runtest file="tags/test_tags_cfstoredproc.cfm">
@@ -544,6 +546,7 @@ include "harness.cfm";
 <cf_runtest file="tags/test_cfquery_escaped_hash_interpolation.cfm">
 <cf_runtest file="tags/test_cfquery_sql_line_comments.cfm">
 <cf_runtest file="tags/test_cfquery_cfml_comments.cfm">
+<cf_runtest file="tags/test_cfqueryparam_list_array_value.cfm">
 <cf_runtest file="tags/test_cte_with_query.cfm">
 <cf_runtest file="tags/test_tags_cfquery_control_tags.cfm">
 <cf_runtest file="tags/test_cfquery_result_delivery.cfm">

--- a/tests/tags/test_cfexecute_argument_quoting.cfm
+++ b/tests/tags/test_cfexecute_argument_quoting.cfm
@@ -1,0 +1,44 @@
+<cfscript>
+// cfexecute `arguments` string parsing: Lucee tokenizes SHELL-STYLE — a
+// double-quoted span is ONE argument with the quotes stripped. RustCFML
+// splits on whitespace straight through the quotes and passes the quote
+// characters to the program literally:
+//
+//   arguments='"quoted arg" plain'
+//     Lucee    -> argv: [quoted arg] [plain]        (echo: quoted arg plain)
+//     RustCFML -> argv: ["quoted] [arg"] [plain]    (echo: "quoted arg" plain)
+//
+// The whitespace-preservation leg is the discriminating one: '"two  spaces"'
+// must keep its DOUBLE space (one argv entry); splitting loses it when echo
+// rejoins with single spaces.
+//
+// Repro class: titan (Moopa) renders every PDF by shelling out to the typst
+// CLI with conventionally-quoted paths — and it turned out typst had NEVER
+// run via cfexecute on this engine: it received '"/path/out.pdf"' quotes
+// included and died with `could not infer output format for path` (extension
+// = `pdf"`). All call sites had to be rewritten unquoted with space-free
+// paths. Any Lucee code that quotes an argument — which is what you do the
+// moment a path may contain spaces — mis-executes here.
+//
+// (The existing CfexecuteQuotedArgFixture pins only that the SOURCE parses;
+// it sits behind <cfif false> and never executes. This suite pins runtime
+// semantics. POSIX-only by the same convention as the other cfexecute tests.)
+
+suiteBegin("cfexecute arguments: double-quoted spans group as one argument, quotes stripped");
+</cfscript>
+
+<cfset plainOut = "" />
+<cfexecute name="/bin/echo" arguments='plain one' variable="plainOut" timeout="10" />
+<cfscript>assert( "control: unquoted arguments split on whitespace", trim( plainOut ), "plain one" );</cfscript>
+
+<cfset quotedOut = "" />
+<cfexecute name="/bin/echo" arguments='"quoted arg" plain' variable="quotedOut" timeout="10" />
+<cfscript>assert( "double quotes are stripped, not passed to the program", trim( quotedOut ), "quoted arg plain" );</cfscript>
+
+<cfset groupOut = "" />
+<cfexecute name="/bin/echo" arguments='"two  spaces"' variable="groupOut" timeout="10" />
+<cfscript>
+assert( "a quoted span is ONE argument (internal double space preserved)", trim( groupOut ), "two  spaces" );
+
+suiteEnd();
+</cfscript>

--- a/tests/tags/test_cfqueryparam_list_array_value.cfm
+++ b/tests/tags/test_cfqueryparam_list_array_value.cfm
@@ -1,0 +1,86 @@
+<cfscript>
+// cfqueryparam list="true" with an ARRAY value: Lucee coerces the array and
+// expands one bind per element — `value="#someArray#"` inside `IN (...)` is
+// a standard Lucee idiom. RustCFML instead serializes the whole array as ONE
+// parameter, and the failure mode differs by driver:
+//
+//   QoQ:        SILENTLY WRONG — `a IN (?)` with [2,4] matches 0 rows,
+//               no error raised.
+//   PostgreSQL: throws — cannot bind "[<uuid>]" as PostgreSQL uuid:
+//               invalid character: found `[` at 0.
+//
+// The silent QoQ leg is the dangerous one: a search that returns nothing
+// looks like "no results", not like a bug.
+//
+// Repro class: titan (Moopa) binds pg_trgm search results with exactly this
+// shape at 21 call sites — `id IN (<cfqueryparam cfsqltype="other"
+// list="true" value="#idsInSearchTerm(...)#">)` where idsInSearchTerm
+// returns an ARRAY of uuids. Every search screen died (or silently emptied)
+// on this engine until each site was wrapped in arrayToList().
+//
+// The PostgreSQL leg is live-gated on RUSTCFML_TEST_PG_DS (same convention
+// as test_query_error_catch_type_database.cfm):
+//   docker run -d -p 55432:5432 -e POSTGRES_PASSWORD=test -e POSTGRES_DB=testdb postgres:16
+//   RUSTCFML_TEST_PG_DS=postgres://postgres:test@127.0.0.1:55432/testdb \
+//     cargo run --features all-databases -- tests/runner.cfm
+
+suiteBegin("cfqueryparam list=""true"": an array value expands one bind per element");
+
+function envDs(required string varName) {
+	try { return getEnvironmentVariable(arguments.varName, ""); }
+	catch (any e) { return ""; }
+}
+
+src = queryNew("a", "integer", [ [1], [2], [3], [4] ]);
+idsArr = [ 2, 4 ];
+oneId = [ 3 ];
+</cfscript>
+
+<!--- Control: a string list expands on both engines. --->
+<cftry>
+    <cfquery name="qStr" dbtype="query">SELECT a FROM src WHERE a IN (<cfqueryparam cfsqltype="integer" list="true" value="#arrayToList(idsArr)#" />)</cfquery>
+    <cfset strResult = qStr.recordcount />
+    <cfcatch type="any"><cfset strResult = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<!--- The gap: the same values as an ARRAY. --->
+<cftry>
+    <cfquery name="qArr" dbtype="query">SELECT a FROM src WHERE a IN (<cfqueryparam cfsqltype="integer" list="true" value="#idsArr#" />)</cfquery>
+    <cfset arrResult = qArr.recordcount />
+    <cfcatch type="any"><cfset arrResult = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<!--- Single-element array: the shape a no-match sentinel produces. --->
+<cftry>
+    <cfquery name="qOne" dbtype="query">SELECT a FROM src WHERE a IN (<cfqueryparam cfsqltype="integer" list="true" value="#oneId#" />)</cfquery>
+    <cfset oneResult = qOne.recordcount />
+    <cfcatch type="any"><cfset oneResult = "THREW: " & cfcatch.message /></cfcatch>
+</cftry>
+
+<cfscript>
+assert( "control: string list matches both rows", strResult, 2 );
+assert( "array value matches the same two rows (saw: " & arrResult & ")", arrResult, 2 );
+assert( "single-element array matches its row", oneResult, 1 );
+
+// ── PostgreSQL leg: the uuid shape that throws rather than silently missing ──
+pgDs = envDs("RUSTCFML_TEST_PG_DS");
+</cfscript>
+
+<cfif len(pgDs) EQ 0>
+    <cfscript>assertTrue( "PostgreSQL array-list leg skipped (RUSTCFML_TEST_PG_DS not set)", true );</cfscript>
+<cfelse>
+    <cfset uuidArr = [ "607ceee8-2cc0-4f9a-bed8-9f2f3affc575", "9fd8e0be-57ce-4aa5-aa2f-492d4808094c" ] />
+    <cftry>
+        <cfquery name="qPg" datasource="#pgDs#">
+            SELECT 1 AS hit
+            WHERE '607ceee8-2cc0-4f9a-bed8-9f2f3affc575'::uuid IN (<cfqueryparam cfsqltype="other" list="true" value="#uuidArr#" />)
+        </cfquery>
+        <cfset pgResult = qPg.recordcount />
+        <cfcatch type="any"><cfset pgResult = "THREW: " & cfcatch.message /></cfcatch>
+    </cftry>
+    <cfscript>assert( "PostgreSQL: uuid array expands into the IN list (saw: " & pgResult & ")", pgResult, 1 );</cfscript>
+</cfif>
+
+<cfscript>
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Two gaps with the same shape — **Lucee coerces, RustCFML takes the value literally** — plus one green parity pin. All found running titan's full PDF pipeline and search screens on v0.607.0.

1. **`tests/tags/test_cfexecute_argument_quoting.cfm`** — Lucee tokenizes the `arguments` string shell-style: a double-quoted span is ONE argument with the quotes stripped. RustCFML splits on whitespace straight *through* the quotes and passes the quote characters to the program. The discriminating leg: `arguments='"two  spaces"'` must preserve its internal double space (one argv entry); RustCFML yields `"two spaces"` — split into `"two` + `spaces"`, rejoined by echo. (The existing `CfexecuteQuotedArgFixture` pins only that such source *parses* — it sits behind `<cfif false>`; this pins runtime semantics.)

2. **`tests/tags/test_cfqueryparam_list_array_value.cfm`** — `cfqueryparam list="true"` with an **array** value: Lucee expands one bind per element (`value="#someArray#"` inside `IN (...)` is a standard idiom). RustCFML binds the serialized array as a single parameter, and the failure mode differs by driver: **QoQ silently matches 0 rows** — no error, a search just looks empty — while PostgreSQL throws `cannot bind "[<uuid>…" as PostgreSQL uuid: invalid character: found `[` at 0`. Cross-engine QoQ legs carry the RED; the uuid leg is `RUSTCFML_TEST_PG_DS`-gated per convention.

3. **`tests/core/test_elvis_error_scope.cfm`** — a **green pin**: elvis (`?:`) swallows a *thrown* left side (not just null/undefined) identically on both engines now — thrown call, throw-inside-chain, undefined deep path, unknown function all yield the default. This was NOT true at v0.595.1, where a thrown left side propagated (the measurement footnote in #323); the convergence happened silently somewhere in v0.596–v0.607, so this pins it against re-divergence in either direction. Defensive one-liners (`cfg().setting ?: default`) lean on this scope constantly.

## Why

Repro classes, both from titan on v0.607.0 this week:

- **cfexecute**: titan renders every PDF by shelling out to the typst CLI with conventionally-quoted paths — and it turned out typst had *never* successfully run via cfexecute on RustCFML: it received `"/path/out.pdf"` quotes-included and died with `could not infer output format` (extension = `pdf"`). Every call site had to be rewritten unquoted with space-free paths — a workaround that collapses the moment a path legitimately contains a space.
- **cfqueryparam**: titan's pg_trgm search idiom binds `id IN (<cfqueryparam list="true" value="#idsInSearchTerm(...)#">)` where the helper returns an array of uuids — 21 call sites, every search screen. All broke (Postgres) or would silently empty (QoQ) until wrapped in `arrayToList()`.

## Validation

- **Stock v0.607.0** (release binary, full runner, PG container up): exactly 5 red assertions — cfexecute 1/3 (both quote legs, labels show the literal-quote output), array-list 1/4 (both QoQ legs at 0 rows + the live PG bind error), elvis pin 4/4 green. No other suite moves.
- **Lucee 7.0** (docker `lucee/lucee:7.0`, repo as webroot, runner over HTTP): 3/3, 4/4, 4/4.

## Related, filed separately

The same session also hit the S3 shim ignoring `Application.cfc`'s `this.s3` settings (its header comment notes the integration is "currently routed via env vars") — titan now aliases `S3_*` → `AWS_*`/`LUCEE_S3_HOST` in compose as a workaround. That one needs an application-context switch plus a live bucket to test cleanly, so I'm opening it as an issue rather than forcing a test shape.

Test-only; no engine change suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)