### PR TITLE
Lucee-compat tests: s3GeneratePresignedURL key normalization, httpMethod, expiry, URL shape

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -671,6 +671,9 @@ include "harness.cfm";
 <!--- harness via /tmp/rustcfml-s3-harness/run_live.sh (see docs/s3.md), or --->
 <!--- invoke a single file directly: --->
 <!--- cargo run -- tests/s3/test_s3_functions.cfm --->
+<!--- Exception: tests/s3/test_s3_presigned_url_lucee_compat.cfm is pure --->
+<!--- (explicit dummy credentials, no network) and runs the same way with no --->
+<!--- env setup at all. --->
 
 <!--- --- Cross-engine compatibility (Wheels framework gaps) --- --->
 <!--- These tests exercise CFML behaviors Wheels depends on that pass on Lucee --->

--- a/tests/s3/test_s3_presigned_url_lucee_compat.cfm
+++ b/tests/s3/test_s3_presigned_url_lucee_compat.cfm
@@ -1,0 +1,176 @@
+<cfscript>
+include "../harness.cfm";
+
+// ============================================================================
+// s3GeneratePresignedURL — Lucee-compat contracts (pure, NO network, NO env)
+// ============================================================================
+// Presigning is offline computation, so every leg passes explicit dummy
+// credentials (the AWS documentation example keypair) and a custom host.
+// All expected values below were measured on Lucee 7.0.2.106 with the S3
+// Resource Extension (17AB52DE-B300-A94B-E058BD978511E39E).
+//
+// Real-world repro class: any app that stores object keys with a leading
+// slash (Lucee strips it when signing, so the objects live at the slash-less
+// key) and/or presigns browser PUT uploads via httpMethod="PUT".
+//
+// Every call is wrapped so a throw is asserted as a "THREW: ..." value and
+// can never abort the file.
+
+function psuGet(objectName) {
+    try {
+        return s3GeneratePresignedURL(
+            bucketName = "my-bucket",
+            objectName = arguments.objectName,
+            accessKeyId = "AKIAIOSFODNN7EXAMPLE",
+            awsSecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            host = "syd1.digitaloceanspaces.com");
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+function psuMethod(m, exp) {
+    try {
+        return s3GeneratePresignedURL(
+            bucketName = "my-bucket",
+            objectName = "a/b.txt",
+            httpMethod = arguments.m,
+            expireDate = arguments.exp,
+            accessKeyId = "AKIAIOSFODNN7EXAMPLE",
+            awsSecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            host = "syd1.digitaloceanspaces.com");
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+function psuGetAltSecretArg(objectName) {
+    try {
+        return s3GeneratePresignedURL(
+            bucketName = "my-bucket",
+            objectName = arguments.objectName,
+            accessKeyId = "AKIAIOSFODNN7EXAMPLE",
+            secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            host = "syd1.digitaloceanspaces.com");
+    } catch (any e) {
+        return "THREW: " & e.message;
+    }
+}
+
+// Path portion of an https URL (between host and '?'); non-URLs pass through
+// so a THREW string can never accidentally equal a real path.
+function urlPathOf(u) {
+    var s = arguments.u;
+    if (left(s, 8) != "https://") return s;
+    var rest = mid(s, 9, len(s));
+    var slashAt = find("/", rest);
+    if (slashAt == 0) return "";
+    var pathAndQuery = mid(rest, slashAt, len(rest));
+    var qAt = find("?", pathAndQuery);
+    if (qAt > 0) return left(pathAndQuery, qAt - 1);
+    return pathAndQuery;
+}
+
+function urlParamOf(u, name) {
+    var s = arguments.u;
+    var marker = arguments.name & "=";
+    var at = find(marker, s);
+    if (at == 0) return "";
+    var val = mid(s, at + len(marker), len(s));
+    var amp = find("&", val);
+    if (amp > 0) return left(val, amp - 1);
+    return val;
+}
+
+function isHttpsUrl(u) {
+    return left(arguments.u, 8) == "https://";
+}
+
+
+suiteBegin("s3GeneratePresignedURL key normalization (Lucee-compat)");
+
+uPlain = psuGet("a/b.txt");
+uSlash = psuGet("/a/b.txt");
+uDbl   = psuGet("//a/b.txt");
+
+assertTrue("dummy-cred presign returns a URL (pure, no network)",
+    isHttpsUrl(uPlain));
+
+// Lucee strips one leading slash: '/a/b.txt' signs the SAME path as 'a/b.txt'.
+// (Both isHttpsUrl guards matter: two identical THREW strings must not pass.)
+assertTrue("objectName '/a/b.txt' signs the same path as 'a/b.txt'",
+    isHttpsUrl(uSlash) && isHttpsUrl(uPlain) && urlPathOf(uSlash) == urlPathOf(uPlain));
+
+assertTrue("no '//' in the signed path for objectName '/a/b.txt'",
+    isHttpsUrl(uSlash) && find("//", urlPathOf(uSlash)) == 0);
+
+// Exactly ONE slash is stripped; a remaining leading slash is percent-encoded.
+// Measured Lucee path for '//a/b.txt': /%2Fa/b.txt
+assertTrue("objectName '//a/b.txt': path ends '/%2Fa/b.txt'",
+    isHttpsUrl(uDbl) && right(urlPathOf(uDbl), 11) == "/%2Fa/b.txt");
+
+suiteEnd();
+
+
+suiteBegin("s3GeneratePresignedURL URL shape (Lucee-compat)");
+
+// Lucee builds virtual-host-style URLs: https://{bucket}.{host}/{key}?...
+assertTrue("virtual-host style: https://my-bucket.syd1.digitaloceanspaces.com/a/b.txt",
+    left(uPlain, 46) == "https://my-bucket.syd1.digitaloceanspaces.com/"
+    && urlPathOf(uPlain) == "/a/b.txt");
+
+suiteEnd();
+
+
+suiteBegin("s3GeneratePresignedURL httpMethod (Lucee-compat)");
+
+// Same key, same expireDate: only the method differs, so the signatures MUST
+// differ. Retried until both URLs carry the same X-Amz-Date and X-Amz-Expires
+// so a second-boundary between the two calls cannot fake a difference.
+exp5 = dateAdd("n", 5, now());
+gUrl = "";
+pUrl = "";
+attempt = 0;
+while (attempt < 5) {
+    attempt = attempt + 1;
+    gUrl = psuMethod("GET", exp5);
+    pUrl = psuMethod("PUT", exp5);
+    if (urlParamOf(gUrl, "X-Amz-Date") == urlParamOf(pUrl, "X-Amz-Date")
+        && urlParamOf(gUrl, "X-Amz-Expires") == urlParamOf(pUrl, "X-Amz-Expires")) break;
+}
+
+assertTrue("httpMethod='PUT' signs differently from GET (same key + expiry)",
+    len(urlParamOf(gUrl, "X-Amz-Signature"))
+    && urlParamOf(gUrl, "X-Amz-Signature") != urlParamOf(pUrl, "X-Amz-Signature"));
+
+suiteEnd();
+
+
+suiteBegin("s3GeneratePresignedURL expiry (Lucee-compat)");
+
+// No expireDate → Lucee default of 15 minutes. Lucee computes the window
+// end first and then diffs against call time, so a second boundary can shave
+// a second off (measured values: 899 and 900).
+defExp = urlParamOf(uPlain, "X-Amz-Expires");
+assertTrue("default X-Amz-Expires is 900 (or 899 across a second boundary)",
+    isNumeric(defExp) && defExp >= 899 && defExp <= 900);
+
+// expireDate=now()+5min → X-Amz-Expires is the seconds remaining (Lucee
+// measured 299/300 — it counts down from call time, hence the small range).
+expVal = urlParamOf(gUrl, "X-Amz-Expires");
+assertTrue("expireDate now()+5min gives X-Amz-Expires in 240..301",
+    isNumeric(expVal) && expVal >= 240 && expVal <= 301);
+
+suiteEnd();
+
+
+suiteBegin("s3GeneratePresignedURL credential argument aliases (Lucee-compat)");
+
+// Lucee accepts both awsSecretKey and secretAccessKey for the secret; the two
+// spellings produce identical URLs (measured byte-identical on Lucee).
+uAlt = psuGetAltSecretArg("a/b.txt");
+assertTrue("awsSecretKey and secretAccessKey are aliases",
+    isHttpsUrl(uPlain) && isHttpsUrl(uAlt) && urlPathOf(uAlt) == urlPathOf(uPlain));
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

Pins the Lucee semantics of `s3GeneratePresignedURL` with a pure test file — every leg passes explicit dummy credentials (the AWS docs example keypair) and a custom host, so there is no network and no env setup. Five suites, nine assertions:

- **Key normalization**: `objectName="/a/b.txt"` signs the **same path** as `"a/b.txt"` — Lucee strips one leading slash. Stock signs the slash verbatim, producing a `bucket//key` URL whose key exists nowhere (every object ever written through Lucee lives at the slash-less key). Also: no `//` anywhere in the signed path, and **`"//a/b.txt"` strips exactly one slash and percent-encodes the remainder** (measured Lucee path: `/%2Fa/b.txt`).
- **URL shape**: Lucee emits virtual-host style — `https://{bucket}.{host}/{key}?...` (stock emits path-style `https://{host}/{bucket}/{key}` with an extra `x-id` param). Both stylings are accepted by S3-compatible stores, so this leg is about byte-shape parity; it is separate from the correctness legs above and below.
- **httpMethod**: `httpMethod="PUT"` must produce a different `X-Amz-Signature` than GET for the same key and expiry. Stock drops the named argument and signs every URL as `GetObject`, so browser PUTs against the returned URL fail with `SignatureDoesNotMatch` (403). The leg retries until both URLs carry the same `X-Amz-Date`/`X-Amz-Expires` so a second boundary cannot fake a difference. (Stock's *positional* form `(bucket, object, expiresMinutes, method)` signs PUT correctly — the gap is the Lucee named-argument surface: `objectName`/`httpMethod`/`expireDate` are not mapped.)
- **Expiry**: no `expireDate` → `X-Amz-Expires` of **900** (Lucee computes the window end then diffs against call time, so 899 appears across a second boundary — the leg accepts 899–900). `expireDate=now()+5min` → seconds-remaining in 240..301 (measured 299/300). Stock defaults to 3600.
- **Credential aliases**: `awsSecretKey` and `secretAccessKey` are both accepted and equivalent (measured byte-identical output on Lucee).

Every call is wrapped so a throw asserts as a `THREW: ...` value; the path/URL comparisons are guarded with `https://`-prefix checks so two identical THREW strings can never pass an equality leg.

## Why

Real-world repro (titan, hub.titanmanufacturing.com.au): purchasing-bill supporting-document uploads presign a browser PUT via `s3GeneratePresignedURL(bucketName=..., objectName="/document/...", httpMethod="PUT", expireDate=...)`. Under RustCFML the upload PUT 403s (`SignatureDoesNotMatch`, GET-signed URL) and previews of existing documents 404 (`NoSuchKey`, double-slash key) — both verified live against DigitalOcean Spaces. The same named-argument calls work on Lucee 7.0.2.106 in production.

## Shape

- New file `tests/s3/test_s3_presigned_url_lucee_compat.cfm`, following the tests/s3 area convention (not registered in the default runner). Unlike its live siblings it needs no credentials, so a note was added to the runner's S3 comment block pointing that out.
- All expected values are measured, none assumed: measured on Lucee 7.0.2.106 (S3 Resource Extension 17AB52DE-B300-A94B-E058BD978511E39E) and re-confirmed on `lucee/lucee:7.0` (7.0.4). The 403/NoSuchKey failure modes were confirmed live against DigitalOcean Spaces (syd1).

## Validation

Stock (`cargo run -- tests/s3/test_s3_presigned_url_lucee_compat.cfm`, upstream/main @ v0.609.0), deterministic across 3 runs:

```
FAIL | s3GeneratePresignedURL key normalization (Lucee-compat) | 1/4 passed (3 failed)
FAIL | s3GeneratePresignedURL URL shape (Lucee-compat) | 0/1 passed (1 failed)
FAIL | s3GeneratePresignedURL httpMethod (Lucee-compat) | 0/1 passed (1 failed)
FAIL | s3GeneratePresignedURL expiry (Lucee-compat) | 0/2 passed (2 failed)
PASS | s3GeneratePresignedURL credential argument aliases (Lucee-compat) | 1/1 passed
```

Full default runner on stock with this change applied: `SUMMARY: 7847/7847 passed across 822 suites` — no other suite moved (the new file is not registered; the runner edit is comment-only).

Lucee (`docker run -v $(pwd):/var/www -p 8898:8888 -e LUCEE_EXTENSIONS="17AB52DE-B300-A94B-E058BD978511E39E;label=S3 Resource Extension" lucee/lucee:7.0`, then curl the test file), stable across 4 runs:

```
PASS | s3GeneratePresignedURL key normalization (Lucee-compat) | 4/4 passed
PASS | s3GeneratePresignedURL URL shape (Lucee-compat) | 1/1 passed
PASS | s3GeneratePresignedURL httpMethod (Lucee-compat) | 1/1 passed
PASS | s3GeneratePresignedURL expiry (Lucee-compat) | 2/2 passed
PASS | s3GeneratePresignedURL credential argument aliases (Lucee-compat) | 1/1 passed
```

Test-only; no engine change or suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)