### PR TITLE
Add CFML test: cfqueryparam collection crosses between threads sharing one component instance

### DIFF
--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -30,6 +30,10 @@ component {
     // resolves (issue #69 fixture).
     this.mappings["/comments"] = getDirectoryFromPath(getCurrentTemplatePath()) & "comments/";
 
+    // Map "database" so createObject("component", "database.SharedQueryInstanceFixture")
+    // resolves on Lucee too (same reason as /comments above).
+    this.mappings["/database"] = getDirectoryFromPath(getCurrentTemplatePath()) & "database/";
+
     // Distinct mapping name (NOT a real webroot subdirectory) used by
     // tags/test_mapping_include.cfm to isolate this.mappings-based cfinclude
     // resolution: a `/wheelsmapprobe/...` include can ONLY be found via this

--- a/tests/database/SharedQueryInstanceFixture.cfc
+++ b/tests/database/SharedQueryInstanceFixture.cfc
@@ -1,0 +1,57 @@
+<!---
+    Fixture for test_cfqueryparam_shared_instance_threads.cfm.
+
+    One instance of this component is shared by several threads at once (the
+    application-scoped singleton shape: a framework's db/record-writer object
+    held in application.lib.db). Each method runs a tag-mode cfquery whose
+    placeholder set is fixed, then returns the bound values so the caller can
+    check the ROW as well as the absence of an error.
+--->
+<cfcomponent output="false">
+
+    <!--- The datasource is injected (an inline sqlite JDBC struct in the test)
+          so the same fixture runs on Lucee, which has no named `testds`. --->
+    <cffunction name="init" access="public" returntype="any" output="false">
+        <cfargument name="ds" type="any" required="true" />
+        <cfset variables.ds = arguments.ds />
+        <cfreturn this />
+    </cffunction>
+
+    <!--- Builds a cfqueryparam attribute struct. Called from INSIDE the query
+          body below, mid-way through accumulating the statement's parameters
+          (the moopa write_mapper.buildQueryParam shape). --->
+    <cffunction name="paramFor" access="public" returntype="struct" output="false">
+        <cfargument name="v" type="string" required="true" />
+        <cfreturn { cfsqltype: "varchar", value: arguments.v, null: false } />
+    </cffunction>
+
+    <!--- LEG A shape: the query body calls a method on this same instance while
+          its cfqueryparams are being collected. Three placeholders:
+          ?  ,  ?  ,  ?   ->  a | b1 | b2 --->
+    <cffunction name="selectViaHelper" access="public" returntype="string" output="false">
+        <cfargument name="tag" type="string" required="true" />
+        <cfargument name="i" type="numeric" required="true" />
+        <cfquery name="local.q" datasource="#variables.ds#">
+            SELECT <cfqueryparam cfsqltype="integer" value="#arguments.i#" /> AS a
+            <cfloop from="1" to="2" index="local.k">
+                <cfset local.p = paramFor(arguments.tag) />
+                , <cfqueryparam attributeCollection="#local.p#" /> AS b#local.k#
+            </cfloop>
+        </cfquery>
+        <cfreturn local.q.a & "|" & local.q.b1 & "|" & local.q.b2 />
+    </cffunction>
+
+    <!--- CONTROL shape: same instance, same three placeholders, but every
+          cfqueryparam is inline — no method call inside the query body. --->
+    <cffunction name="selectInline" access="public" returntype="string" output="false">
+        <cfargument name="tag" type="string" required="true" />
+        <cfargument name="i" type="numeric" required="true" />
+        <cfquery name="local.q" datasource="#variables.ds#">
+            SELECT <cfqueryparam cfsqltype="integer" value="#arguments.i#" /> AS a
+                 , <cfqueryparam cfsqltype="varchar" value="#arguments.tag#" /> AS b1
+                 , <cfqueryparam cfsqltype="varchar" value="#arguments.tag#" /> AS b2
+        </cfquery>
+        <cfreturn local.q.a & "|" & local.q.b1 & "|" & local.q.b2 />
+    </cffunction>
+
+</cfcomponent>

--- a/tests/database/test_cfqueryparam_shared_instance_threads.cfm
+++ b/tests/database/test_cfqueryparam_shared_instance_threads.cfm
@@ -1,0 +1,145 @@
+<!---
+    cfqueryparam accumulation must be per-call, not per-component-instance.
+
+    Shape: ONE component instance shared by N concurrent threads (the
+    application-scoped singleton every framework keeps for its data layer —
+    moopa's record_writer lives in application.lib.db, and each request's
+    db.save() goes through that same object). Its cfquery body calls a method
+    on the same instance WHILE the statement's cfqueryparams are being
+    collected:
+
+        <cfquery>
+            SELECT <cfqueryparam .../> AS a
+            <cfloop ...>
+                <cfset local.p = paramFor(...) />        <!--- same instance --->
+                , <cfqueryparam attributeCollection="#local.p#" /> AS b#k#
+            </cfloop>
+        </cfquery>
+
+    Under concurrency the bind lists of DIFFERENT threads cross. Two failure
+    modes, both observed:
+      - bind-count errors: "Wrong number of parameters passed to query.
+        Got 2, needed 3" (PostgreSQL wording: "N positional parameter(s)
+        supplied but the SQL only consumes M" / "statement needs 20
+        placeholder(s) but only 3 of 3 supplied remain");
+      - WORSE: no error, but the row comes back with another thread's values
+        (thread 3 reads b1 = "t7"). A silent wrong-answer under load.
+
+    The same instance running the same three placeholders with inline
+    cfqueryparams (no method call in the body) is clean, and the helper shape
+    is clean when each thread has its own instance and when run sequentially.
+    So the accumulator is keyed to the component instance / call frame rather
+    than to the executing request or thread.
+
+    Repro class: two users saving records through a framework's shared
+    write path at the same moment (titan: a quote's line editor autosaving on
+    each keystroke — overlapping requests through moopa's db.save threw the
+    bind-count errors above and, less visibly, could persist one request's
+    values under another's parameters).
+
+    Live in-process test on an inline in-memory SQLite datasource — needs no
+    server and no PG. Lucee ships no SQLite JDBC driver, so the live legs are
+    skipped there with one informational pass (the test_dml_returns_empty_query
+    convention); with the sqlite-jdbc jar on Lucee's classpath the file runs and
+    is green on Lucee 7 (cfthread, shared instance, same fixture).
+    Every leg is caught so an engine that throws reports a count rather than
+    aborting the file.
+--->
+<cfscript>
+suiteBegin("cfqueryparam collection is per-call under concurrent use of one component instance");
+
+THREADS = 8;
+ITERS   = 40;
+memDs   = { class: "org.sqlite.JDBC", connectionString: "jdbc:sqlite::memory:" };
+
+function newFixture() {
+    return createObject("component", "database.SharedQueryInstanceFixture").init(memDs);
+}
+
+// Run `iters` calls of `method` on `obj` for thread tag `tag`; return
+// {errors, wrong}. wrong = rows that came back with values that were bound by
+// SOME OTHER caller (the tag or counter does not match what this caller bound).
+function hammer(required any obj, required string method, required string tag, required numeric iters) {
+    var out = { errors: 0, wrong: 0, firstError: "" };
+    var i = 0;
+    var got = "";
+    var want = "";
+    for (i = 1; i <= arguments.iters; i++) {
+        want = i & "|" & arguments.tag & "|" & arguments.tag;
+        try {
+            got = invoke(arguments.obj, arguments.method, { tag: arguments.tag, i: i });
+            if (got != want) { out.wrong++; }
+        } catch (any e) {
+            out.errors++;
+            if (out.firstError == "") { out.firstError = e.message ?: ""; }
+        }
+    }
+    return out;
+}
+
+// Fan `method` across THREADS threads, each with its own tag; `sharedObj`
+// is used by every thread when supplied, otherwise each thread creates its
+// own instance. Returns the summed {errors, wrong, firstError}.
+function fanOut(required string method, any sharedObj) {
+    var t = 0;
+    var names = [];
+    var total = { errors: 0, wrong: 0, firstError: "" };
+    var res = {};
+    var runId = replace(createUUID(), "-", "", "all");
+    for (t = 1; t <= THREADS; t++) {
+        var tname = "qp_" & runId & "_" & t;
+        arrayAppend(names, tname);
+        if (structKeyExists(arguments, "sharedObj")) {
+            thread name=tname action="run" tag="t#t#" method=arguments.method obj=arguments.sharedObj {
+                thread.res = hammer(attributes.obj, attributes.method, attributes.tag, ITERS);
+            }
+        } else {
+            thread name=tname action="run" tag="t#t#" method=arguments.method {
+                thread.res = hammer(newFixture(), attributes.method, attributes.tag, ITERS);
+            }
+        }
+    }
+    for (t = 1; t <= arrayLen(names); t++) {
+        thread action="join" name=names[t] timeout=60000;
+        res = cfthread[names[t]].res ?: { errors: ITERS, wrong: 0, firstError: "thread did not complete: " & (cfthread[names[t]].error.message ?: "no result") };
+        total.errors += res.errors;
+        total.wrong  += res.wrong;
+        if (total.firstError == "" && res.firstError != "") { total.firstError = res.firstError; }
+    }
+    return total;
+}
+
+driverAvailable = true;
+try { queryExecute("SELECT 1 AS ok", [], { datasource: memDs }); }
+catch (any e) { driverAvailable = false; }
+
+if (!driverAvailable) {
+    assertTrue("shared-instance cfqueryparam legs skipped (no SQLite JDBC driver on this engine)", true);
+} else {
+
+shared = newFixture();
+
+// ---- 0. Sequential control: the helper shape is fine when nobody overlaps ----
+seq = hammer(shared, "selectViaHelper", "seq", ITERS);
+assert("sequential: helper-built params on one instance bind correctly (" & ITERS & " calls, errors)", seq.errors, 0);
+assert("sequential: helper-built params on one instance bind correctly (wrong rows)", seq.wrong, 0);
+
+// ---- 1. THE GAP: shared instance, method call inside the query body ---------
+gap = fanOut("selectViaHelper", shared);
+assert("shared instance + method call inside query body: " & THREADS & " threads x " & ITERS & " — no bind-count errors [first: " & gap.firstError & "]", gap.errors, 0);
+assert("shared instance + method call inside query body: no row carries another thread's bound values", gap.wrong, 0);
+
+// ---- 2. Control: same instance, same placeholders, inline params -------------
+inline = fanOut("selectInline", shared);
+assert("shared instance, inline cfqueryparams only: no bind-count errors [first: " & inline.firstError & "]", inline.errors, 0);
+assert("shared instance, inline cfqueryparams only: no crossed rows", inline.wrong, 0);
+
+// ---- 3. Control: helper shape, but one instance PER THREAD -------------------
+perThread = fanOut("selectViaHelper");
+assert("per-thread instances + method call inside query body: no bind-count errors [first: " & perThread.firstError & "]", perThread.errors, 0);
+assert("per-thread instances + method call inside query body: no crossed rows", perThread.wrong, 0);
+
+} // driverAvailable
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -298,6 +298,7 @@ include "harness.cfm";
 <cf_runtest file="database/test_query_error_catch_type_database.cfm">
 <cf_runtest file="database/test_query_error_sqlstate_members.cfm">
 <cf_runtest file="database/test_pg_comment_placeholder_scan.cfm">
+<cf_runtest file="database/test_cfqueryparam_shared_instance_threads.cfm">
 <cf_runtest file="stdlib/test_date_functions_extra.cfm">
 <cf_runtest file="stdlib/test_locale_functions.cfm">
 <cf_runtest file="stdlib/test_java_i18n_shims.cfm">


### PR DESCRIPTION
## What

`tests/database/test_cfqueryparam_shared_instance_threads.cfm` + fixture `tests/database/SharedQueryInstanceFixture.cfc` (and a `/database` mapping in `tests/Application.cfc` so the fixture resolves on Lucee, same reason as `/comments`).

One fixture instance, 8 `cfthread`s, 40 calls each. Every leg is caught, so a throwing engine reports counts rather than aborting the file. Each call returns the bound values (`i|tag|tag`) so a row is checked against what *this* caller bound, not just for the absence of an error.

- **Sequential control** — the helper shape, one caller, 40 calls: 0 errors, 0 wrong rows.
- **THE GAP — shared instance, method call inside the query body**: the `cfquery` body does `<cfset local.p = paramFor(...)/>` (a method on the *same* instance) between two `cfqueryparam`s. Expected 0 errors / 0 crossed rows. **Stock: 254 bind-count errors (`Wrong number of parameters passed to query. Got 4, needed 3`) and 44 rows that came back carrying another thread's bound values with no error raised.** The silent second mode is the one that matters — under load it persists one caller's values under another's parameters.
- **Control — same instance, same three placeholders, inline `cfqueryparam`s only**: clean on stock. So it is not "a shared instance running queries concurrently".
- **Control — helper shape, one instance per thread**: clean on stock. So it is not "a method call inside a query body". The accumulator is keyed to the component instance / call frame rather than to the executing request or thread.

## Why

Every framework's data layer is an application-scoped singleton, and building a `cfqueryparam` attribute struct through a mapper method *while the statement is being assembled* is a natural shape (moopa's `record_writer.updateRecord` → `writeMapper.buildQueryParam`, inside the `cfquery`). In titan a quote's line editor autosaves per keystroke; two overlapping requests through `db.save` produced `queryExecute: 6 positional parameter(s) supplied but the SQL only consumes 4` and `statement needs 20 placeholder(s) but only 3 of 3 supplied remain` — the sale UPDATE (4 slots) receiving the sale_line UPDATE's parameters and vice versa. The error points at the parameter count, nowhere near the cause, so it presents as a payload bug (it was first reported as "deleting text in the description breaks saving"). Sequentially the same payloads save fine; 12 parallel saves fail 12/12. Any two users saving anything at the same moment through a shared write path can hit it, and per the wrong-row leg, not always loudly.

## Shape

- Inline in-memory SQLite datasource (`{ class: "org.sqlite.JDBC", connectionString: "jdbc:sqlite::memory:" }`), the `test_duplicate_result_columns` / `test_dml_returns_empty_query` convention — no server, no PG. Probe-and-skip guard: where the engine has no SQLite driver the live legs are replaced by one informational pass.
- Concurrency is in-process via `cfthread` (join with timeout), so the runner exercises it on the CLI — no `--serve` needed. Thread names carry a per-run UUID so a rerun in the same request cannot collide.
- The fixture takes the datasource in `init()` so the identical component runs on both engines.
- All expected values are measured, not assumed: the failure counts above are from stock v0.629.0 (macOS aarch64 release binary) and vary run to run (262/32, 266/43, 254/44 across three runs); the assertions expect 0 so the numbers only appear in the failure message.

## Validation

**Stock v0.629.0** (`rustcfml-macos-aarch64` release binary, `tests/runner.cfm`):

```
FAIL | cfqueryparam collection is per-call under concurrent use of one component instance | 6/8 passed (2 failed)
       FAIL: shared instance + method call inside query body: 8 threads x 40 — no bind-count errors [first: queryExecute: query error: Wrong number of parameters passed to query. Got 4, needed 3] | expected: [0] | got: [254]
       FAIL: shared instance + method call inside query body: no row carries another thread's bound values | expected: [0] | got: [44]
SUMMARY: 8216/8218 passed across 838 suites
```

Baseline on `upstream/main` (a0030d2) with the same binary: `SUMMARY: 8210/8210 passed across 837 suites` — no other suite moved.

**Lucee 7.0.5.41** (`docker lucee/lucee:7.0`, repo as webroot, `sqlite-jdbc-3.46.1.3.jar` dropped in `lucee-server/context/lib` so every leg runs live rather than skipping):

```
PASS | cfqueryparam collection is per-call under concurrent use of one component instance | 8/8 passed
```

Test-only; no engine change or suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
