### PR TITLE
Add CFML test: <cf_name> body does not inherit the caller's output context (cfmodule does)

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -509,6 +509,7 @@ include "harness.cfm";
 <!--- Fixture dirs under tests/tags/ctpathroot/; the path itself is declared --->
 <!--- in tests/Application.cfc. Reduced from the titan (Moopa) codebase port. --->
 <cf_runtest file="tags/test_customtag_path_deep_search.cfm">
+<cf_runtest file="tags/test_customtag_prefix_body_output.cfm">
 <cf_runtest file="tags/test_tags_buffer_recovery.cfm">
 <cf_runtest file="tags/test_tags_cfexecute.cfm">
 <cf_runtest file="tags/test_cfexecute_argument_quoting.cfm">

--- a/tests/tags/ctpathroot/ctpath_body_echo.cfm
+++ b/tests/tags/ctpathroot/ctpath_body_echo.cfm
@@ -1,0 +1,11 @@
+<!--- Fixture for tests/tags/test_customtag_prefix_body_output.cfm: record
+      exactly what the tag received as generatedContent in
+      request.ctpathBodyEcho and emit nothing (the caller asserts on the
+      request key, so no output capture is involved — cfsavecontent around
+      a custom tag inside a function drops the tag's output on BOTH engines,
+      which would mask the result). Lives at the custom-tag-path ROOT so it
+      resolves on both engines without deep search. --->
+<cfif thisTag.executionMode eq "end">
+    <cfset request.ctpathBodyEcho = trim(thisTag.generatedContent) />
+    <cfset thisTag.generatedContent = "" />
+</cfif>

--- a/tests/tags/test_customtag_prefix_body_output.cfm
+++ b/tests/tags/test_customtag_prefix_body_output.cfm
@@ -1,0 +1,98 @@
+<cfscript>
+suiteBegin("Tags: a prefix-invoked custom tag body inherits the caller's output context");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    The body of a custom tag is CFML executed in the CALLER's context: if the
+    caller is inside <cfoutput>, or inside a <cffunction output="true">, then
+    #expressions# in the body are evaluated before the tag sees them as
+    thisTag.generatedContent. Lucee 7.0.5 does this identically for all three
+    ways of invoking the tag: <cf_name>, <cfmodule name="name"> and
+    <cfmodule template="...">.
+
+    RustCFML evaluates the body for the two cfmodule forms but NOT for the
+    prefix form: <cf_name>#x#</cf_name> hands the tag the literal text "#x#",
+    which then reaches the browser. An inner <cfoutput> inside the body
+    works around it, so the gap is specifically "the prefix path does not
+    inherit the enclosing output context" — not "prefix tags can't output".
+
+    Repro class (titan/moopa): a form control tag wraps its Alpine component
+    script in <cf_once> (dedupe-once-per-request tag) inside the control's
+    own <cfoutput>; the script builds image URLs from
+    #server.system.environment.TWIC_PICS_URL#. On RustCFML every image link
+    became https://host/page#server.system.environment.TWIC_PICS_URL/... —
+    broken thumbnails and a "click to open" that navigated to a fragment.
+    Same for every page whose <cffunction output="true"> body is a
+    <cf_layout_default>...</cf_layout_default> block: any #expr# directly in
+    the layout body renders literally. 19 sites in that one app.
+
+    Fixture: tests/tags/ctpathroot/ctpath_body_echo.cfm (at the custom-tag-
+    path ROOT declared in tests/Application.cfc) records what it received in
+    request.ctpathBodyEcho and emits nothing, so the assertions need no
+    output capture. Every leg is under cftry so a throw is asserted as a
+    value rather than aborting the file.
+    ============================================================
+--->
+
+<cfset probeValue = "VALUE">
+
+<cffunction name="echoResult" output="false">
+    <cfreturn structKeyExists(request, "ctpathBodyEcho") ? request.ctpathBodyEcho : "(tag did not run)">
+</cffunction>
+
+<!--- Control 1: <cfmodule name=> inside the caller's cfoutput. --->
+<cfset structDelete(request, "ctpathBodyEcho")>
+<cftry>
+    <cfoutput><cfmodule name="ctpath_body_echo">#probeValue#</cfmodule></cfoutput>
+    <cfcatch type="any"><cfset request.ctpathBodyEcho = "THREW: " & cfcatch.message></cfcatch>
+</cftry>
+<cfscript>
+assert("control: cfmodule name= body evaluated inside caller's cfoutput", echoResult(), "VALUE");
+</cfscript>
+
+<!--- Control 2: <cfmodule template=> — same. --->
+<cfset structDelete(request, "ctpathBodyEcho")>
+<cftry>
+    <cfoutput><cfmodule template="ctpathroot/ctpath_body_echo.cfm">#probeValue#</cfmodule></cfoutput>
+    <cfcatch type="any"><cfset request.ctpathBodyEcho = "THREW: " & cfcatch.message></cfcatch>
+</cftry>
+<cfscript>
+assert("control: cfmodule template= body evaluated inside caller's cfoutput", echoResult(), "VALUE");
+</cfscript>
+
+<!--- Control 3: prefix form with its OWN inner cfoutput — proves the prefix
+      path can evaluate a body; only inheritance is at stake in the gap legs. --->
+<cfset structDelete(request, "ctpathBodyEcho")>
+<cftry>
+    <cf_ctpath_body_echo><cfoutput>#probeValue#</cfoutput></cf_ctpath_body_echo>
+    <cfcatch type="any"><cfset request.ctpathBodyEcho = "THREW: " & cfcatch.message></cfcatch>
+</cftry>
+<cfscript>
+assert("control: <cf_name> body with its own inner cfoutput", echoResult(), "VALUE");
+</cfscript>
+
+<!--- GAP 1: prefix form inside the caller's <cfoutput>. --->
+<cfset structDelete(request, "ctpathBodyEcho")>
+<cftry>
+    <cfoutput><cf_ctpath_body_echo>#probeValue#</cf_ctpath_body_echo></cfoutput>
+    <cfcatch type="any"><cfset request.ctpathBodyEcho = "THREW: " & cfcatch.message></cfcatch>
+</cftry>
+<cfscript>
+assert("<cf_name> body inherits the caller's enclosing cfoutput", echoResult(), "VALUE");
+</cfscript>
+
+<!--- GAP 2: prefix form inside a <cffunction output="true"> body (implicit
+      output context — no cfoutput tag anywhere). --->
+<cffunction name="renderViaPrefixTag" output="true"><cf_ctpath_body_echo>#probeValue#</cf_ctpath_body_echo></cffunction>
+<cfset structDelete(request, "ctpathBodyEcho")>
+<cftry>
+    <cfset renderViaPrefixTag()>
+    <cfcatch type="any"><cfset request.ctpathBodyEcho = "THREW: " & cfcatch.message></cfcatch>
+</cftry>
+<cfscript>
+assert("<cf_name> body inherits a cffunction output=true context", echoResult(), "VALUE");
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

`tests/tags/test_customtag_prefix_body_output.cfm` + fixture `tests/tags/ctpathroot/ctpath_body_echo.cfm` (at the custom-tag-path root already declared in `tests/Application.cfc`, so no deep search involved). The fixture records `thisTag.generatedContent` in `request.ctpathBodyEcho` and emits nothing — the assertions read the request key, so no output capture is in play. Every leg is under `cftry`.

- **Control — `<cfmodule name="…">` inside the caller's `<cfoutput>`**: body evaluated, tag receives `VALUE`. Passes on stock.
- **Control — `<cfmodule template="…">`**: same. Passes on stock.
- **Control — `<cf_name>` with its *own* inner `<cfoutput>`**: passes on stock — the prefix path *can* evaluate a body.
- **GAP 1 — `<cf_name>#x#</cf_name>` inside the caller's `<cfoutput>`**: expected `VALUE`; **stock hands the tag the literal `#probeValue#`.**
- **GAP 2 — `<cf_name>#x#</cf_name>` inside a `<cffunction output="true">` body** (implicit output context, no cfoutput tag anywhere): expected `VALUE`; **stock: literal `#probeValue#`.**

So the gap is precisely "the prefix invocation path does not inherit the enclosing output context" — the same tag through either `cfmodule` form does.

## Why

Moopa/titan form-control tags wrap their Alpine component script in `<cf_once>` (a dedupe-once-per-request tag) inside the control's own `<cfoutput>`; the script builds image URLs from `#server.system.environment.TWIC_PICS_URL#`. On RustCFML every thumbnail `src` and "click to open" link became `https://host/page#server.system.environment.TWIC_PICS_URL/…` — broken images and a click that navigated to a fragment. The second flavour is every route whose `<cffunction output="true">` body is a `<cf_layout_default>…</cf_layout_default>` block: any `#expr#` directly in the layout body renders literally. 19 sites in that one app (a scan for `cf_` bodies relying on an enclosing output context); the app-side workaround is an explicit inner `<cfoutput>` at each, which is a no-op on Lucee.

## Shape

- Fixture at the custom-tag-path root: resolves on both engines without deep search (the deep-search suite covers that separately).
- Result via request scope rather than `cfsavecontent`: wrapping a custom tag *inside a function* in `cfsavecontent` drops the tag's output on **both** engines, which masked GAP 2 in a first draft — worth knowing if you reach for that shape.
- Expected values are measured on Lucee 7.0.5.41, not assumed.

## Validation

**Stock v0.629.0** (`rustcfml-macos-aarch64` release binary, `tests/runner.cfm`):

```
FAIL | Tags: a prefix-invoked custom tag body inherits the caller's output context | 3/5 passed (2 failed)
       FAIL: <cf_name> body inherits the caller's enclosing cfoutput | expected: [VALUE] | got: [#probeValue#]
       FAIL: <cf_name> body inherits a cffunction output=true context | expected: [VALUE] | got: [#probeValue#]
SUMMARY: 8213/8215 passed across 838 suites
```

Baseline on `upstream/main` (a0030d2), same binary: `SUMMARY: 8210/8210 passed across 837 suites` — no other suite moved. Also reproduced on v0.624.0.

**Lucee 7.0.5.41** (`docker lucee/lucee:7.0`, repo as webroot):

```
PASS | Tags: a prefix-invoked custom tag body inherits the caller's output context | 5/5 passed
```

Test-only; no engine change or suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
