### PR TITLE
Add CFML test: hyphenated custom-tag attribute names (x-ref, data-foo) are parsed as expressions

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -509,6 +509,7 @@ include "harness.cfm";
 <!--- Fixture dirs under tests/tags/ctpathroot/; the path itself is declared --->
 <!--- in tests/Application.cfc. Reduced from the titan (Moopa) codebase port. --->
 <cf_runtest file="tags/test_customtag_path_deep_search.cfm">
+<cf_runtest file="tags/test_customtag_hyphenated_attributes.cfm">
 <cf_runtest file="tags/test_tags_buffer_recovery.cfm">
 <cf_runtest file="tags/test_tags_cfexecute.cfm">
 <cf_runtest file="tags/test_cfexecute_argument_quoting.cfm">

--- a/tests/tags/ctpathroot/ctpath_attr_echo.cfm
+++ b/tests/tags/ctpathroot/ctpath_attr_echo.cfm
@@ -1,0 +1,9 @@
+<!--- Fixture for tests/tags/test_customtag_hyphenated_attributes.cfm: record
+      the attribute names (sorted) and the value of the hyphenated ones in
+      request scope. Emits nothing. Lives at the custom-tag-path ROOT so it
+      resolves on both engines without deep search. --->
+<cfif thisTag.executionMode eq "start">
+    <cfset request.ctpathAttrKeys = listSort(structKeyList(attributes), "textnocase") />
+    <cfset request.ctpathAttrXref = structKeyExists(attributes, "x-ref") ? attributes["x-ref"] : "(absent)" />
+    <cfset request.ctpathAttrData = structKeyExists(attributes, "data-foo") ? attributes["data-foo"] : "(absent)" />
+</cfif>

--- a/tests/tags/test_customtag_hyphenated_attributes.cfm
+++ b/tests/tags/test_customtag_hyphenated_attributes.cfm
@@ -1,0 +1,79 @@
+<cfscript>
+suiteBegin("Tags: hyphenated attribute names on a custom tag are attribute keys, not expressions");
+</cfscript>
+
+<!---
+    ============================================================
+    Background
+    ============================================================
+    <cf_name id="m" x-ref="r1"> passes an attribute literally named "x-ref"
+    (attributes["x-ref"] = "r1") on Lucee 7.0.5 — for the prefix form and
+    for <cfmodule name=> alike. HTML-flavoured names (x-ref, x-data,
+    data-foo, aria-label) are common on tags that wrap markup, and the tag
+    reads them with attributes["x-data"] / cfparam name="attributes['x-data']".
+
+    RustCFML parses the name as an expression: `x-ref` becomes `x - ref` and
+    the call throws "Variable 'x' is undefined" before the tag runs. The
+    throw is catchable, so each leg is pinned under cftry.
+
+    Repro class (titan/moopa): <cf_modal id="modal_cost_line" title="Cost
+    Line" x-ref="modal_cost_line"> — the whole route 500s on RustCFML with
+    a stack line that points nowhere near the attribute.
+
+    Fixture: tests/tags/ctpathroot/ctpath_attr_echo.cfm (at the custom-tag-
+    path ROOT declared in tests/Application.cfc) records the attribute names
+    and the hyphenated values in request scope; no output capture involved.
+    ============================================================
+--->
+
+<cffunction name="attrResult" output="false">
+    <cfreturn structKeyExists(request, "ctpathAttrKeys")
+        ? request.ctpathAttrKeys & " | x-ref=" & request.ctpathAttrXref & " | data-foo=" & request.ctpathAttrData
+        : "(tag did not run)">
+</cffunction>
+<cffunction name="resetAttrResult" output="false">
+    <cfset structDelete(request, "ctpathAttrKeys")>
+    <cfset structDelete(request, "ctpathAttrXref")>
+    <cfset structDelete(request, "ctpathAttrData")>
+</cffunction>
+
+<!--- Control: plain attribute names only — the fixture and the path resolve. --->
+<cfset resetAttrResult()>
+<cftry>
+    <cf_ctpath_attr_echo id="m" title="Plain" />
+    <cfcatch type="any"><cfset request.ctpathAttrKeys = "THREW: " & cfcatch.message><cfset request.ctpathAttrXref = ""><cfset request.ctpathAttrData = ""></cfcatch>
+</cftry>
+<cfscript>
+assert("control: plain attribute names reach the tag", attrResult(), "id,title | x-ref=(absent) | data-foo=(absent)");
+</cfscript>
+
+<!--- GAP 1: x-ref on the prefix form. --->
+<cfset resetAttrResult()>
+<cftry>
+    <cf_ctpath_attr_echo id="m" x-ref="r1" />
+    <cfcatch type="any"><cfset request.ctpathAttrKeys = "THREW: " & cfcatch.message><cfset request.ctpathAttrXref = ""><cfset request.ctpathAttrData = ""></cfcatch>
+</cftry>
+<cfscript>
+assert("<cf_name x-ref=...>: hyphenated name is an attribute key, value intact", attrResult(), "id,x-ref | x-ref=r1 | data-foo=(absent)");
+</cfscript>
+
+<!--- GAP 2: same through <cfmodule name=>. --->
+<cfset resetAttrResult()>
+<cftry>
+    <cfmodule name="ctpath_attr_echo" id="m" x-ref="r2" />
+    <cfcatch type="any"><cfset request.ctpathAttrKeys = "THREW: " & cfcatch.message><cfset request.ctpathAttrXref = ""><cfset request.ctpathAttrData = ""></cfcatch>
+</cftry>
+<cfscript>
+assert("<cfmodule name= x-ref=...>: hyphenated name is an attribute key, value intact", attrResult(), "id,x-ref | x-ref=r2 | data-foo=(absent)");
+</cfscript>
+
+<!--- GAP 3: a data-* name — not an Alpine special case, any hyphen. --->
+<cfset resetAttrResult()>
+<cftry>
+    <cf_ctpath_attr_echo id="m" data-foo="d" />
+    <cfcatch type="any"><cfset request.ctpathAttrKeys = "THREW: " & cfcatch.message><cfset request.ctpathAttrXref = ""><cfset request.ctpathAttrData = ""></cfcatch>
+</cftry>
+<cfscript>
+assert("<cf_name data-foo=...>: any hyphenated name, not just x-*", attrResult(), "data-foo,id | x-ref=(absent) | data-foo=d");
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

`tests/tags/test_customtag_hyphenated_attributes.cfm` + fixture `tests/tags/ctpathroot/ctpath_attr_echo.cfm` (custom-tag-path root already declared in `tests/Application.cfc`; no deep search involved). The fixture records the sorted attribute names and the values of `x-ref` / `data-foo` in request scope and emits nothing. Every leg is under `cftry`, so the throw is asserted as a value.

- **Control — plain names** (`id`, `title`): tag runs, keys `id,title`. Passes on stock.
- **GAP 1 — `<cf_name id="m" x-ref="r1" />`**: expected keys `id,x-ref` with `attributes["x-ref"] = "r1"`. **Stock: throws `Variable 'x' is undefined` before the tag runs.**
- **GAP 2 — same via `<cfmodule name="…" x-ref="r2" />`**: **stock: same throw** — so it is the attribute parser, not the prefix-resolution path.
- **GAP 3 — `data-foo="d"`**: **stock: `Variable 'data' is undefined`** — any hyphenated name, not an Alpine/`x-*` special case.

## Why

Tags that wrap markup routinely take HTML-flavoured attribute names and read them with `attributes["x-data"]` / `<cfparam name="attributes['x-data']">` (the bracket-key `cfparam` spelling was pinned earlier in #318–#322; this is the caller side of the same idiom). In titan: `<cf_modal id="modal_cost_line" title="Cost Line" x-ref="modal_cost_line">` — the whole route 500s on RustCFML, and the reported stack line points at an unrelated part of the file, so it reads as a phantom variable bug.

## Shape

- Result via request scope rather than output capture (same reasoning as #363).
- Expected values measured on Lucee 7.0.5.41; keys are `listSort`ed so the assertion is order-independent across engines.

## Validation

**Stock v0.629.0** (`rustcfml-macos-aarch64` release binary, `tests/runner.cfm`):

```
FAIL | Tags: hyphenated attribute names on a custom tag are attribute keys, not expressions | 1/4 passed (3 failed)
       FAIL: <cf_name x-ref=...>: hyphenated name is an attribute key, value intact | expected: [id,x-ref | x-ref=r1 | data-foo=(absent)] | got: [THREW: Variable 'x' is undefined | x-ref= | data-foo=]
       FAIL: <cfmodule name= x-ref=...>: hyphenated name is an attribute key, value intact | expected: [id,x-ref | x-ref=r2 | data-foo=(absent)] | got: [THREW: Variable 'x' is undefined | x-ref= | data-foo=]
       FAIL: <cf_name data-foo=...>: any hyphenated name, not just x-* | expected: [data-foo,id | x-ref=(absent) | data-foo=d] | got: [THREW: Variable 'data' is undefined | x-ref= | data-foo=]
SUMMARY: 8211/8214 passed across 838 suites
```

Baseline on `upstream/main` (a0030d2), same binary: `SUMMARY: 8210/8210 passed across 837 suites` — no other suite moved. Also reproduced on v0.624.0.

**Lucee 7.0.5.41** (`docker lucee/lucee:7.0`, repo as webroot):

```
PASS | Tags: hyphenated attribute names on a custom tag are attribute keys, not expressions | 4/4 passed
```

Test-only; no engine change or suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
