### PR TITLE
Add CFML test: Lucee's serializeJSON date form ("August, 25 2026 09:00:14 +0000") is rejected by the date BIFs

### DIFF
--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -299,6 +299,7 @@ include "harness.cfm";
 <cf_runtest file="database/test_query_error_sqlstate_members.cfm">
 <cf_runtest file="database/test_pg_comment_placeholder_scan.cfm">
 <cf_runtest file="stdlib/test_date_functions_extra.cfm">
+<cf_runtest file="stdlib/test_lucee_json_date_form.cfm">
 <cf_runtest file="stdlib/test_locale_functions.cfm">
 <cf_runtest file="stdlib/test_java_i18n_shims.cfm">
 <cf_runtest file="stdlib/test_cache_functions.cfm">

--- a/tests/stdlib/test_lucee_json_date_form.cfm
+++ b/tests/stdlib/test_lucee_json_date_form.cfm
@@ -1,0 +1,50 @@
+<cfscript>
+suiteBegin("Dates: Lucee's serializeJSON date form round-trips through the date BIFs");
+
+// Lucee serialises a CFML date as "Month, dd yyyy HH:mm:ss +0000" — e.g.
+//   serializeJSON({d: createDateTime(2026,8,25,9,0,14)})
+//   -> {"D":"August, 25 2026 09:00:14 +0000"}           (Lucee 7.0.5, measured)
+// and its date parser accepts that string back: isDate() is true, and
+// dateDiff / parseDateTime / dateFormat all treat it as the date it names.
+//
+// RustCFML rejects the string: isDate() is false and every date BIF given it
+// throws "Invalid date2" (or the equivalent for its argument position). Its
+// own serializeJSON emits "2026-08-25 09:00:14", which BOTH engines parse, so
+// data written by RustCFML is fine everywhere — the gap is one-directional:
+// any JSON/jsonb column written under Lucee that holds a raw date is
+// unreadable after switching engines.
+//
+// Repro class: titan's zoho_oauth.tokens jsonb row, written under Lucee with
+// expires_when = dateAdd('s', expires_in, now()). On RustCFML the token
+// expiry check ran dateDiff('s', now(), tokens.expires_when) and every Zoho
+// integration call died with {"success":false,"message":"Invalid date2"} —
+// before the refresh that would have rewritten the row could run.
+//
+// Every leg is under try/catch; a throw is asserted as a value.
+
+luceeForm    = "August, 25 2026 09:00:14 +0000";  // measured serializeJSON output
+luceeFormNoZ = "August, 25 2026 09:00:14";         // same, sans offset (older Lucee)
+isoForm      = "2026-08-25 09:00:14";              // what RustCFML's serializeJSON writes; both parse
+
+function tryDiff(required string a, required string b) {
+    try { return dateDiff("s", arguments.a, arguments.b); }
+    catch (any e) { return "THREW: " & (e.message ?: ""); }
+}
+function tryFormat(required string d) {
+    try { return dateFormat(parseDateTime(arguments.d), "yyyy-mm-dd") & " " & timeFormat(parseDateTime(arguments.d), "HH:mm:ss"); }
+    catch (any e) { return "THREW: " & (e.message ?: ""); }
+}
+
+// Control: the ISO-style form is a date on both engines.
+assertTrue("control: isDate on 'yyyy-mm-dd HH:mm:ss'", isDate(isoForm));
+assert("control: dateDiff between two ISO-style strings", tryDiff("2026-08-25 09:00:00", isoForm), 14);
+
+// The gap: Lucee's own JSON date form.
+assertTrue("isDate accepts Lucee's serializeJSON date form (with +0000)", isDate(luceeForm));
+assertTrue("isDate accepts Lucee's serializeJSON date form (no offset)", isDate(luceeFormNoZ));
+assert("dateDiff with the Lucee form as date2", tryDiff("2026-08-25 09:00:00", luceeForm), 14);
+assert("dateDiff with the Lucee form as date1", tryDiff(luceeForm, "2026-08-25 09:01:14"), 60);
+assert("parseDateTime + dateFormat/timeFormat of the Lucee form names the same instant", tryFormat(luceeFormNoZ), "2026-08-25 09:00:14");
+
+suiteEnd();
+</cfscript>


### PR DESCRIPTION
## What

`tests/stdlib/test_lucee_json_date_form.cfm`. Seven legs, every date call under try/catch so a throw is asserted as a value.

- **Controls** — `isDate("2026-08-25 09:00:14")` and `dateDiff` between two ISO-style strings: pass on stock. That form is what RustCFML's own `serializeJSON` emits, and both engines parse it.
- **GAP** — the string Lucee's `serializeJSON` emits for a date, `"August, 25 2026 09:00:14 +0000"` (measured on Lucee 7.0.5; also the offset-less variant older Lucee wrote):
  - `isDate(...)` → expected `true`; **stock `false`** (both variants)
  - `dateDiff("s", "2026-08-25 09:00:00", luceeForm)` → expected `14`; **stock throws `Invalid date2`**
  - `dateDiff("s", luceeForm, "2026-08-25 09:01:14")` → expected `60`; **stock throws `Invalid date1`**
  - `parseDateTime(luceeForm)` then `dateFormat`/`timeFormat` → expected `2026-08-25 09:00:14`; **stock throws `Cannot parse date: August, 25 2026 09:00:14`**

## Why

This is a data-compatibility gap rather than a code one, and it is one-directional. Anything written under Lucee into a JSON column with a raw CFML date inside carries Lucee's form forever; after switching engines every read of it throws. In titan the `zoho_oauth.tokens` jsonb row held `expires_when = dateAdd('s', expires_in, now())` from the Lucee era; on RustCFML the token-expiry check `dateDiff('s', now(), tokens.expires_when)` threw before the refresh that would have rewritten the row could run, so every Zoho integration call died with `{"success":false,"message":"Invalid date2"}`. A scan of all 27 jsonb columns in that app found two rows in that form — small blast radius there, but the shape ("serialised a struct with a date in it under Lucee") is common.

I've kept the serialiser's *output* format out of scope — RustCFML writing ISO is arguably the better choice and parses on both engines — this PR only pins that Lucee's form must be *readable*.

## Shape

- Pure stdlib, no fixtures, no datasource. Expected values measured on Lucee 7.0.5.41 (`serializeJSON({d: createDateTime(2026,8,25,9,0,14)})` → `{"D":"August, 25 2026 09:00:14 +0000"}`; `dateDiff` of the two strings above → `14`).
- Registered in `tests/runner.cfm` next to `stdlib/test_date_functions_extra.cfm`.

## Validation

**Stock v0.629.0** (`rustcfml-macos-aarch64` release binary, `tests/runner.cfm`):

```
FAIL | Dates: Lucee's serializeJSON date form round-trips through the date BIFs | 2/7 passed (5 failed)
       FAIL: isDate accepts Lucee's serializeJSON date form (with +0000) | expected truthy | got: [false]
       FAIL: isDate accepts Lucee's serializeJSON date form (no offset) | expected truthy | got: [false]
       FAIL: dateDiff with the Lucee form as date2 | expected: [14] | got: [THREW: Invalid date2]
       FAIL: dateDiff with the Lucee form as date1 | expected: [60] | got: [THREW: Invalid date1]
       FAIL: parseDateTime + dateFormat/timeFormat of the Lucee form names the same instant | expected: [2026-08-25 09:00:14] | got: [THREW: Cannot parse date: August, 25 2026 09:00:14]
SUMMARY: 8212/8217 passed across 838 suites
```

Baseline on `upstream/main` (a0030d2), same binary: `SUMMARY: 8210/8210 passed across 837 suites` — no other suite moved. Also reproduced on v0.624.0.

**Lucee 7.0.5.41** (`docker lucee/lucee:7.0`, repo as webroot):

```
PASS | Dates: Lucee's serializeJSON date form round-trips through the date BIFs | 7/7 passed
```

Test-only; no engine change or suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
