### PR TITLE
Test: a cfthread body inside a component method sees the component's methods

### DIFF
--- a/tests/core/CfthreadMethodScopeFixture.cfc
+++ b/tests/core/CfthreadMethodScopeFixture.cfc
@@ -1,0 +1,79 @@
+<cfcomponent>
+    <!---
+        A cfthread body spawned from inside a component method runs with that
+        component's context: its methods (public AND private) resolve by bare
+        name and through `variables.` exactly as they do in the method itself.
+        Each leg returns "STATUS|out" (or "STATUS|THREW:message") so the caller
+        asserts a value rather than an aborted request.
+    --->
+
+    <cffunction name="bareSiblingCall" access="public">
+        <cfthread name="ctms_bare" x="5">
+            <cfset thread.out = helper(attributes.x) />
+        </cfthread>
+        <cfthread action="join" name="ctms_bare" timeout="5000" />
+        <cfreturn describe(cfthread.ctms_bare) />
+    </cffunction>
+
+    <cffunction name="variablesScopedCall" access="public">
+        <cfthread name="ctms_vars" x="5">
+            <cfset thread.out = variables.helper(attributes.x) />
+        </cfthread>
+        <cfthread action="join" name="ctms_vars" timeout="5000" />
+        <cfreturn describe(cfthread.ctms_vars) />
+    </cffunction>
+
+    <cffunction name="bareSiblingCallNested" access="public">
+        <cfthread name="ctms_nested" x="5">
+            <cfset thread.out = helperNested(attributes.x) />
+        </cfthread>
+        <cfthread action="join" name="ctms_nested" timeout="5000" />
+        <cfreturn describe(cfthread.ctms_nested) />
+    </cffunction>
+
+    <cffunction name="thisPassedAsAttribute" access="public">
+        <cfthread name="ctms_this" x="5" self="#this#">
+            <cfset thread.out = attributes.self.publicHelper(attributes.x) />
+        </cfthread>
+        <cfthread action="join" name="ctms_this" timeout="5000" />
+        <cfreturn describe(cfthread.ctms_this) />
+    </cffunction>
+
+    <cffunction name="functionPassedAsAttribute" access="public">
+        <cfset var fn = helperNested />
+        <cfthread name="ctms_fnattr" x="5" fn="#fn#">
+            <cfset local.worker = attributes.fn />
+            <cfset thread.out = worker(attributes.x) />
+        </cfthread>
+        <cfthread action="join" name="ctms_fnattr" timeout="5000" />
+        <cfreturn describe(cfthread.ctms_fnattr) />
+    </cffunction>
+
+    <cffunction name="publicHelper" access="public">
+        <cfargument name="x">
+        <cfreturn helper(arguments.x) />
+    </cffunction>
+
+    <cffunction name="helper" access="private">
+        <cfargument name="x">
+        <cfreturn arguments.x * 2 />
+    </cffunction>
+
+    <!--- 5 -> helper(5) + variables.helper(1) = 10 + 2 --->
+    <cffunction name="helperNested" access="private">
+        <cfargument name="x">
+        <cfreturn helper(arguments.x) + variables.helper(1) />
+    </cffunction>
+
+    <cffunction name="describe" access="private">
+        <cfargument name="t">
+        <cfif structKeyExists(arguments.t, "out")>
+            <cfreturn arguments.t.status & "|" & arguments.t.out />
+        </cfif>
+        <cfset var err = arguments.t.error ?: "" />
+        <cfif isStruct(err)>
+            <cfset err = err.message ?: "" />
+        </cfif>
+        <cfreturn arguments.t.status & "|THREW:" & listFirst(err, chr(10)) />
+    </cffunction>
+</cfcomponent>

--- a/tests/core/test_cfthread_component_method_scope.cfm
+++ b/tests/core/test_cfthread_component_method_scope.cfm
@@ -1,0 +1,41 @@
+<cfscript>
+suiteBegin("cfthread inside a component method sees the component's methods");
+
+// A <cfthread> body written inside a CFC method runs in that component's
+// context on Lucee: sibling methods -- private ones included -- resolve by
+// bare name and via `variables.`, the same as from the method itself.
+// GH #360 (v0.630.0) stopped publishing method names into the ambient
+// function table, which was right for LATER templates, but the thread body
+// belongs to the component and lost them too.
+//
+// Real-world shape: a route method kicks off a long rebuild in a cfthread
+// and calls the private worker method from the body.
+
+ctmsFixture = createObject("component", "CfthreadMethodScopeFixture");
+
+function ctmsRun(name) {
+    try {
+        return invoke(ctmsFixture, name);
+    } catch (any e) {
+        return "THREW:" & e.message;
+    }
+}
+
+assert("bare sibling private call resolves inside the thread body",
+    ctmsRun("bareSiblingCall"), "COMPLETED|10");
+
+assert("variables.method resolves inside the thread body",
+    ctmsRun("variablesScopedCall"), "COMPLETED|10");
+
+assert("bare call whose target itself calls further private siblings",
+    ctmsRun("bareSiblingCallNested"), "COMPLETED|12");
+
+// Controls: the two shapes that already work on both engines.
+assert("control: `this` passed as an attribute, public method called on it",
+    ctmsRun("thisPassedAsAttribute"), "COMPLETED|10");
+
+assert("control: UDF passed as an attribute, aliased then called bare",
+    ctmsRun("functionPassedAsAttribute"), "COMPLETED|12");
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -27,6 +27,7 @@ include "harness.cfm";
 <cf_runtest file="core/test_gcm_leading_dot_path.cfm">
 <cf_runtest file="core/test_var_indexed_assignment.cfm">
 <cf_runtest file="core/test_function_scope_capture.cfm">
+<cf_runtest file="core/test_cfthread_component_method_scope.cfm">
 <cf_runtest file="core/test_bare_call_caller_stack_leak.cfm">
 <cf_runtest file="core/test_defaulted_param_variables_clobber.cfm">
 <cf_runtest file="core/test_scope_named_default_param.cfm">


### PR DESCRIPTION
## What
Pins Lucee's rule that a `<cfthread>` body written inside a CFC method runs in that component's context. Five legs against `tests/core/CfthreadMethodScopeFixture.cfc`, each returning `STATUS|out` (or `STATUS|THREW:message`) so stock's throw is asserted as a value, never an aborted file:

- **bare sibling private call** inside the thread body → `COMPLETED|10`
- **`variables.method`** inside the thread body → `COMPLETED|10`
- **bare call whose target itself calls further private siblings** (bare + `variables.`) → `COMPLETED|12`
- control: `this` passed as an attribute, public method called on it → `COMPLETED|10` (green on both)
- control: UDF passed as an attribute, aliased to a local then called bare → `COMPLETED|12` (green on both). Note Lucee's thread `attributes` is array-like, so `attributes.fn()` as a *member call* is not portable — the alias form is the one both engines accept.

## Why
v0.630.0 (GH #360) stopped publishing a component's method names into the ambient function table — right for *later templates*, but the thread body belongs to the component and lost them too. v0.629.0 resolved all three red legs. Real-world shape (titan): a route method kicks off a long SKU rebuild in a `cfthread` and calls the private worker from the body; on v0.634.0 every job now lands in the error state with `Variable 'rebuildSKUsNow' is undefined`.

## Shape
`tests/core/test_cfthread_component_method_scope.cfm` + fixture CFC beside it, registered in `tests/runner.cfm` after `core/test_function_scope_capture.cfm`. All expected values measured on Lucee 7.0 (`lucee/lucee:7.0`, repo as webroot).

## Validation
Stock v0.634.0 (release binary):
```
FAIL | cfthread inside a component method sees the component's methods | 2/5 passed (3 failed)
   FAIL: bare sibling private call resolves inside the thread body | expected: [COMPLETED|10] | got: [TERMINATED|THREW:Expression Error: Variable 'helper' is undefined]
   FAIL: variables.method resolves inside the thread body | expected: [COMPLETED|10] | got: [TERMINATED|THREW:Expression Error: Variable 'helper' is undefined]
   FAIL: bare call whose target itself calls further private siblings | expected: [COMPLETED|12] | got: [TERMINATED|THREW:Expression Error: Variable 'helperNested' is undefined]
FAIL | queryExecute failures are catchable as type=database | 3/4 passed (1 failed)
SUMMARY: 8534/8538 passed across 857 suites
FAILED:  4 assertion(s) in 2 suite(s)
```
Baseline before this suite: `SUMMARY: 8532/8533 passed across 856 suites` — the only other FAIL (queryExecute … type=database) is pre-existing; no other suite moved.

Lucee 7.0: `PASS | cfthread inside a component method sees the component's methods | 5/5 passed`.

Test-only; no engine change or suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)