### PR TITLE
Add CFML test: a component method named url() replaces the caller's url scope

### DIFF
--- a/tests/core/test_component_method_named_url_scope.cfm
+++ b/tests/core/test_component_method_named_url_scope.cfm
@@ -1,0 +1,78 @@
+<cfscript>
+suiteBegin("A component method named url() does not replace the caller's url scope");
+
+// ============================================================
+// Background
+// ============================================================
+// A CFC may declare a method called url() -- an S3/CDN proxy exposing
+// url(key) is the common shape. On Lucee the method name is just a member of
+// that component; the caller's url scope is untouched before, during and
+// after createObject()/the call, and a later `url.x = ...` write is visible.
+//
+// On RustCFML, merely instantiating such a component empties the caller's
+// url scope for the REST OF THE REQUEST: structKeyList(url) goes from
+// "probe,shape" to "", url.probe becomes undefined, and `url.written = "yes"`
+// silently vanishes. The same happens when the createObject() runs inside a
+// function. A method named form() does not disturb the form scope, and an
+// ARGUMENT named url is fine -- the trigger is specifically a method named
+// after the url scope.
+//
+// Real-world shape (titan/Moopa): the framework instantiates every lib CFC in
+// onApplicationStart; one is an S3 proxy with url(). On the request that
+// re-boots the application after applicationStop(), url.route (injected by
+// the front-controller fallback) is gone by the time onRequestStart runs, so
+// a "?init=" re-init redirects back to the page and then dispatches "/" --
+// every re-init lands on the home page.
+//
+// Each shape runs in its OWN request via cfhttp against probe.cfm, so the
+// broken scope cannot leak into the runner's request and poison later suites.
+// Runs only when served (cgi.server_port present); skips from the CLI.
+// ============================================================
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+function urlMethodField(body, name) {
+    var m = reFind(name & "=\[([^\]]*)\]", body, 1, true);
+    if (arrayLen(m.pos) LT 2 || m.pos[2] EQ 0) return "MISSING";
+    return mid(body, m.pos[2], m.len[2]);
+}
+
+function urlMethodProbe(shape) {
+    var r = "";
+    cfhttp(url="http://127.0.0.1:#serverPort#/tests/core/url_method_scope/probe.cfm", result="r", timeout=15) {
+        cfhttpparam(type="url", name="shape", value=shape);
+        cfhttpparam(type="url", name="probe", value="1");
+    }
+    return r.filecontent;
+}
+
+if (skip) {
+    assertTrue("component method named url() skipped (no cgi.server_port)", true);
+} else {
+    // Shape 1: createObject() at page level, then read + write the url scope.
+    b1 = urlMethodProbe("method_url");
+    assert("control: url scope populated before createObject()", urlMethodField(b1, "before"), "shape,probe");
+    assert("control: the method itself is callable", urlMethodField(b1, "call"), "fn-url:k");
+    assert("url scope keys survive createObject() of a CFC with a url() method", urlMethodField(b1, "after_create"), "shape,probe");
+    assert("url.probe still readable after createObject()", urlMethodField(b1, "probe"), "1");
+    assert("a url-scope write after createObject() is visible", urlMethodField(b1, "written"), "yes");
+
+    // Shape 2: the createObject() happens inside a function.
+    b2 = urlMethodProbe("method_url_in_function");
+    assert("url scope intact inside the function that created the CFC", urlMethodField(b2, "inside"), "shape,probe");
+    assert("url scope intact in the caller after the function returns", urlMethodField(b2, "after"), "shape,probe");
+    assert("url.probe still readable after createObject() inside a function", urlMethodField(b2, "probe"), "1");
+
+    // Controls (green on both engines).
+    b3 = urlMethodProbe("arg_url");
+    assert("control: an argument named url does not disturb the url scope", urlMethodField(b3, "after_create") & "|" & urlMethodField(b3, "probe"), "shape,probe|1");
+    assert("control: argument named url binds normally", urlMethodField(b3, "call"), "arg:v");
+
+    b4 = urlMethodProbe("method_form");
+    assert("control: a method named form() does not disturb the url scope", urlMethodField(b4, "after_create") & "|" & urlMethodField(b4, "probe"), "shape,probe|1");
+    assert("control: method named form() is callable", urlMethodField(b4, "call"), "fn-form");
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/core/url_method_scope/FormMethodFixture.cfc
+++ b/tests/core/url_method_scope/FormMethodFixture.cfc
@@ -1,0 +1,5 @@
+<cfcomponent output="false" hint="Control: same shape with a method named form() -- the form scope is undisturbed on both engines.">
+    <cffunction name="form" returntype="string" output="false">
+        <cfreturn "fn-form" />
+    </cffunction>
+</cfcomponent>

--- a/tests/core/url_method_scope/UrlArgFixture.cfc
+++ b/tests/core/url_method_scope/UrlArgFixture.cfc
@@ -1,0 +1,6 @@
+<cfcomponent output="false" hint="Control: an ARGUMENT named url is fine on both engines.">
+    <cffunction name="go" returntype="string" output="false">
+        <cfargument name="url" type="string" required="true" />
+        <cfreturn "arg:" & arguments.url />
+    </cffunction>
+</cfcomponent>

--- a/tests/core/url_method_scope/UrlMethodFixture.cfc
+++ b/tests/core/url_method_scope/UrlMethodFixture.cfc
@@ -1,0 +1,6 @@
+<cfcomponent output="false" hint="A component whose public API includes a method named url() -- e.g. an S3 proxy exposing url(key). Lucee: a method name never touches the caller's scopes.">
+    <cffunction name="url" returntype="string" output="false">
+        <cfargument name="key" type="string" required="false" default="" />
+        <cfreturn "fn-url:" & arguments.key />
+    </cffunction>
+</cfcomponent>

--- a/tests/core/url_method_scope/probe.cfm
+++ b/tests/core/url_method_scope/probe.cfm
@@ -1,0 +1,33 @@
+<cfsetting enablecfoutputonly="true">
+<cfcontent type="text/plain; charset=utf-8">
+<!---
+    One request per shape (?shape=...), so the url scope observed here is this
+    request's own and nothing leaks into the runner's request.
+    Each line is name=[value]; the test reads them back by name.
+--->
+<cffunction name="makeAndRead" output="false">
+    <cfargument name="path" type="string" required="true" />
+    <cfset var o = createObject("component", arguments.path) />
+    <cfreturn structKeyList(url) />
+</cffunction>
+
+<cfset shape = url.shape ?: "" />
+<cfoutput>before=[#structKeyList(url)#];</cfoutput>
+
+<cfif shape EQ "method_url">
+    <cfset o = createObject("component", "UrlMethodFixture") />
+    <cfoutput>after_create=[#structKeyList(url)#];probe=[#url.probe ?: 'UNDEF'#];call=[#o.url("k")#];</cfoutput>
+    <cfset url.written = "yes" />
+    <cfoutput>written=[#url.written ?: 'LOST'#];</cfoutput>
+
+<cfelseif shape EQ "method_url_in_function">
+    <cfoutput>inside=[#makeAndRead("UrlMethodFixture")#];after=[#structKeyList(url)#];probe=[#url.probe ?: 'UNDEF'#];</cfoutput>
+
+<cfelseif shape EQ "arg_url">
+    <cfset o = createObject("component", "UrlArgFixture") />
+    <cfoutput>after_create=[#structKeyList(url)#];call=[#o.go(url="v")#];probe=[#url.probe ?: 'UNDEF'#];</cfoutput>
+
+<cfelseif shape EQ "method_form">
+    <cfset o = createObject("component", "FormMethodFixture") />
+    <cfoutput>after_create=[#structKeyList(url)#];probe=[#url.probe ?: 'UNDEF'#];call=[#o.form()#];</cfoutput>
+</cfif>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -30,6 +30,7 @@ include "harness.cfm";
 <cf_runtest file="core/test_gcm_leading_dot_path.cfm">
 <cf_runtest file="core/test_var_indexed_assignment.cfm">
 <cf_runtest file="core/test_function_scope_capture.cfm">
+<cf_runtest file="core/test_component_method_named_url_scope.cfm">
 <cf_runtest file="core/test_cfthread_component_method_scope.cfm">
 <cf_runtest file="core/test_bare_call_caller_stack_leak.cfm">
 <cf_runtest file="core/test_defaulted_param_variables_clobber.cfm">


### PR DESCRIPTION
## What
Pins Lucee's rule that a component's **method name never touches the caller's scopes** — specifically a method named `url()`. Four shapes, each in its own served request against `tests/core/url_method_scope/probe.cfm` (so the broken scope cannot leak into the runner's request), asserted as `name=[value]` fields:

- **`createObject()` at page level of a CFC with `url()`** → `structKeyList(url)` still `shape,probe`, `url.probe` still `1`, and a subsequent **`url.written = "yes"` is visible** (stock: keys `[]`, `UNDEF`, `LOST`)
- **the same `createObject()` inside a function** → url scope intact inside the function *and* in the caller after it returns (stock: `[]` / `UNDEF`)
- control: an **argument** named `url` → scope undisturbed, binds normally (green on both)
- control: a method named **`form()`** → `form`/`url` scopes undisturbed (green on both) — the trigger is specifically a method named after the `url` scope

The method itself stays callable on both engines (`fn-url:k`); it's the caller's scope that goes missing for the rest of the request.

## Why
Real-world shape (titan/Moopa): a lib CFC is an S3 proxy exposing `url(key)`. Moopa instantiates every lib in `onApplicationStart`, so on the request that re-boots the application after a `?init=` `applicationStop()`, `url.route` (injected by the `.cfconfig.json` front-controller fallback) is gone by the time `onRequestStart` runs — `cgi.query_string` still says `route=/theme/forms`, `structIsEmpty(url)` is true and writes to `url` vanish. Moopa's `cfparam url.route default="/"` then dispatches home: every re-init landed on the dashboard. Bisected with a per-lib header dump; the scope flipped to empty right after the lib with `url()` loaded and stayed that way.

## Shape
`tests/core/test_component_method_named_url_scope.cfm` + `tests/core/url_method_scope/{probe.cfm, UrlMethodFixture.cfc, UrlArgFixture.cfc, FormMethodFixture.cfc}`, registered in `tests/runner.cfm` after `core/test_function_scope_capture.cfm`. HTTP round-trip via `cfhttp` to `cgi.server_port` (skips from the CLI, same as the session-namespace suite). All expected values measured on Lucee 7.0 (`lucee/lucee:7.0`, repo as webroot, served on 8888 so `cgi.server_port` loops back).

## Validation
Stock v0.636.0 (release image), served from repo root:
```
FAIL | A component method named url() does not replace the caller's url scope | 6/12 passed (6 failed)
   FAIL: url scope keys survive createObject() of a CFC with a url() method | expected: [shape,probe] | got: []
   FAIL: url.probe still readable after createObject() | expected: [1] | got: [UNDEF]
   FAIL: a url-scope write after createObject() is visible | expected: [yes] | got: [LOST]
   FAIL: url scope intact inside the function that created the CFC | expected: [shape,probe] | got: []
   FAIL: url scope intact in the caller after the function returns | expected: [shape,probe] | got: []
   FAIL: url.probe still readable after createObject() inside a function | expected: [1] | got: [UNDEF]
SUMMARY: 8667/8689 passed across 869 suites
```
Baseline (`upstream/main` without this suite, same image): `SUMMARY: 8661/8677 passed across 868 suites` — the 8 pre-existing ERRORED files and the `cfhttp name= / file=` FAIL are identical in both runs; no other suite moved.

Lucee 7.0: `PASS | A component method named url() does not replace the caller's url scope | 12/12 passed`.

Test-only; no engine change or suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
