### PR TITLE
Add CFML test: onApplicationStart gates all concurrent requests, not just the one that triggers it

### DIFF
--- a/tests/lifecycle/application_start_gate/Application.cfc
+++ b/tests/lifecycle/application_start_gate/Application.cfc
@@ -1,0 +1,23 @@
+component {
+	// Fresh application per test run: the runner passes a unique token so a
+	// warm server re-running the suite still exercises a cold app start.
+	this.name = "appstartgate_" & (url.app ?: "default");
+	this.sessionmanagement = false;
+
+	public boolean function onApplicationStart() {
+		application.runs = (application.runs ?: 0) + 1;
+		application.phase = "starting";
+		sleep(1500);
+		application.ready = true;
+		return true;
+	}
+
+	public boolean function onRequest(required string targetPage) output=true {
+		if ((url.op ?: "") == "runs") {
+			writeOutput("runs=" & (application.runs ?: 0));
+		} else {
+			writeOutput("ready=" & (application.ready ?: "MISSING"));
+		}
+		return true;
+	}
+}

--- a/tests/lifecycle/application_start_gate/page.cfm
+++ b/tests/lifecycle/application_start_gate/page.cfm
@@ -1,0 +1,1 @@
+<!--- Output is written by onRequest in Application.cfc --->

--- a/tests/lifecycle/test_application_start_serialisation.cfm
+++ b/tests/lifecycle/test_application_start_serialisation.cfm
@@ -1,0 +1,100 @@
+<cfscript>
+suiteBegin("Requests serialise behind a running onApplicationStart");
+
+// ============================================================
+// Background
+// ============================================================
+// CFML's application lifecycle contract: onApplicationStart runs to
+// completion before ANY request executes against the new application scope.
+// Lucee implements this as a gate -- the request that triggers app start runs
+// it, and every other request that arrives while it is mid-flight BLOCKS
+// until it finishes, then proceeds against the fully-built scope.
+//
+// RustCFML gates only the triggering request. Concurrent requests see that
+// the application scope exists and proceed straight into onRequest against
+// whatever half-built state onApplicationStart has reached. In a real app
+// that initialises singletons and a route registry progressively, a restart
+// under live traffic serves a window of 500s ("Variable 'auth' is
+// undefined") and then 404s (route registry not yet loaded) -- every
+// concurrent in-flight request during app start is another bypass.
+//
+// Behavioural round-trip: the fixture app under application_start_gate/
+// sets application.phase, sleeps 1500ms inside onApplicationStart, then sets
+// application.ready. Three threads: t1 fires immediately (triggers app
+// start); t2 and t3 fire at +400ms and +800ms, landing mid-app-start. Each
+// records the response body ("ready=true" or "ready=MISSING"). The fixture
+// keys this.name on a per-run token so a warm server still starts cold.
+// Runs only when served (cgi.server_port present); skips from the CLI.
+// ============================================================
+
+serverPort = structKeyExists(cgi, "server_port") ? trim(cgi.server_port) : "";
+skip = serverPort == "" || serverPort == "0";
+
+if (skip) {
+    assertTrue("app-start serialisation skipped (no cgi.server_port)", true);
+} else {
+    token = replace(createUUID(), "-", "", "all");
+    base = "http://127.0.0.1:" & serverPort & "/tests/lifecycle/application_start_gate/page.cfm?app=" & token;
+
+    thread name="gateT1" action="run" reqUrl="#base#" {
+        try {
+            cfhttp(url="#attributes.reqUrl#", result="r", timeout=20);
+            thread.body = r.filecontent;
+        } catch (any e) {
+            thread.body = "THREW " & e.message;
+        }
+    }
+    thread name="gateT2" action="run" reqUrl="#base#" {
+        try {
+            sleep(400);
+            cfhttp(url="#attributes.reqUrl#", result="r", timeout=20);
+            thread.body = r.filecontent;
+        } catch (any e) {
+            thread.body = "THREW " & e.message;
+        }
+    }
+    thread name="gateT3" action="run" reqUrl="#base#" {
+        try {
+            sleep(800);
+            cfhttp(url="#attributes.reqUrl#", result="r", timeout=20);
+            thread.body = r.filecontent;
+        } catch (any e) {
+            thread.body = "THREW " & e.message;
+        }
+    }
+    threadJoin("gateT1,gateT2,gateT3", 30000);
+
+    // Leg 1 (control): the triggering request runs app start and sees the
+    // completed scope. Green on both engines.
+    assert("triggering request runs onApplicationStart and sees ready=true",
+        cfthread.gateT1.body ?: "NO-BODY", "ready=true");
+
+    // Legs 2-3 (the contract): requests arriving mid-app-start must block
+    // until it completes, never observe the half-built scope.
+    assert("request at +400ms blocks behind app start and sees ready=true",
+        cfthread.gateT2.body ?: "NO-BODY", "ready=true");
+    assert("request at +800ms blocks behind app start and sees ready=true",
+        cfthread.gateT3.body ?: "NO-BODY", "ready=true");
+
+    // Leg 4 (control): steady state after app start.
+    try {
+        cfhttp(url="#base#", result="rAfter", timeout=20);
+        after = rAfter.filecontent;
+    } catch (any e) {
+        after = "THREW " & e.message;
+    }
+    assert("steady-state request sees ready=true", after, "ready=true");
+
+    // Leg 5: onApplicationStart ran exactly once for the application --
+    // blocked requests must not re-trigger it.
+    try {
+        cfhttp(url="#base#&op=runs", result="rRuns", timeout=20);
+        runs = rRuns.filecontent;
+    } catch (any e) {
+        runs = "THREW " & e.message;
+    }
+    assert("onApplicationStart ran exactly once", runs, "runs=1");
+}
+
+suiteEnd();
+</cfscript>

--- a/tests/runner.cfm
+++ b/tests/runner.cfm
@@ -663,6 +663,11 @@ include "harness.cfm";
 <cf_runtest file="lifecycle/test_mapping_symlink_paths.cfm">
 <cf_runtest file="lifecycle/test_application_lifecycle_case_override.cfm">
 <cf_runtest file="lifecycle/test_application_load_errors.cfm">
+
+<!--- onApplicationStart must gate ALL concurrent requests, not just the one that
+     triggers it: bypassers observe the half-built application scope (boot-window
+     500s/404s under live traffic). --->
+<cf_runtest file="lifecycle/test_application_start_serialisation.cfm">
 <cf_runtest file="lifecycle/test_application_scope_custom_tag.cfm">
 <cf_runtest file="lifecycle/test_application_onerror_onabort.cfm">
 <cf_runtest file="lifecycle/test_appscope_receiver_no_resurrect.cfm">


### PR DESCRIPTION
## What

CFML's application lifecycle contract: `onApplicationStart` runs to completion before **any** request executes against the new application scope. Lucee implements this as a gate — the request that triggers app start runs it, and every other request arriving mid-flight **blocks** until it finishes, then proceeds against the fully-built scope.

Stock gates only the triggering request. Concurrent requests see that the application scope exists and proceed straight into `onRequest` against whatever half-built state `onApplicationStart` has reached.

Five legs (the subtle ones bold):

1. Control: the triggering request runs `onApplicationStart`, blocks through it, sees `ready=true`.
2. **A request arriving at +400ms (mid-app-start) blocks and sees `ready=true` — never the half-built scope.**
3. **Same at +800ms.**
4. Control: steady-state request after app start sees `ready=true`.
5. **`onApplicationStart` ran exactly once — blocked requests must not re-trigger it.**

## Why

Real-world shape: an app whose `onApplicationStart` initialises singletons and a route registry progressively. On stock, every container (re)start under live traffic serves a window of failures staged by how far app start has progressed — first 500s ("Variable 'auth' is undefined": the request reached a `application.lib` that exists but doesn't hold `auth` yet), then 404s (route registry not yet loaded), then 200s. Every concurrent in-flight request during app start is another bypass, so ordinary healthcheck + proxy + user traffic widens the window: three 20ms pollers observed 344 × 500 across three restarts of a production app. The same three-poller probe against Lucee across a full boot: 2,688 samples, zero bypasses.

## Shape

`tests/lifecycle/test_application_start_serialisation.cfm`, registered in `tests/runner.cfm` beside the other application-lifecycle suites. Fixture app under `tests/lifecycle/application_start_gate/`: `onApplicationStart` sets `application.phase`, sleeps 1500ms, sets `application.ready`; `onRequest` reports `ready=true|MISSING` (or `runs=N` for leg 5). `this.name` is keyed on a per-run token passed by the test, so a warm server re-running the suite still exercises a cold app start. Probes are three `cfthread`s doing `cfhttp` to self at +0/+400/+800ms — same served-only skip guard (`cgi.server_port`) as the session-namespace suite. The 400/800ms offsets sit in the middle of the 1500ms sleep with wide margins on both sides.

## Validation

Stock v0.645.0 (release binary, repo as webroot):

```
FAIL | Requests serialise behind a running onApplicationStart | 3/5 passed (2 failed)
  - request at +400ms blocks behind app start and sees ready=true | expected: [ready=true] | got: [ready=MISSING]
  - request at +800ms blocks behind app start and sees ready=true | expected: [ready=true] | got: [ready=MISSING]
SUMMARY: 8842/8845 passed across 883 suites
```

Baseline (main without this test, same binary/host): `SUMMARY: 8839/8840 passed across 882 suites` — the only failing suite is the timezone-environment-dependent dates leg (`the +0000 offset is honoured | expected: [0] | got: [-3600]`, host TZ AEST), identical in both runs. No other suite moved.

Lucee 7.0.5.41 (`lucee/lucee:7.0`, repo as webroot, `curl tests/runner.cfm`):

```
PASS | Requests serialise behind a running onApplicationStart | 5/5 passed
```

Test-only; no engine change or suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
