### PR TITLE
Bound expression recursion depth to prevent stack overflow on deeply nested source

### DIFF
--- a/crates/cfml-compiler/src/parser.rs
+++ b/crates/cfml-compiler/src/parser.rs
@@ -11,7 +11,18 @@ pub struct Parser {
     current: usize,
     /// Map from token index → javadoc comment text immediately preceding it.
     doc_comments: std::collections::HashMap<usize, String>,
+    /// Current expression-recursion depth, bounded by `MAX_EXPR_DEPTH` so a
+    /// deeply nested expression (e.g. `((((...))))`) returns a parse error
+    /// instead of overflowing the stack.
+    expr_depth: usize,
 }
+
+/// Maximum expression nesting depth. Deeply nested untrusted source would
+/// otherwise recurse until the stack overflows and the process aborts. Each
+/// nesting level walks the full precedence chain (~10 frames), so this stays
+/// well below what a thread stack can hold while remaining far above any
+/// hand-written CFML expression.
+const MAX_EXPR_DEPTH: usize = 64;
 
 #[derive(Debug)]
 pub struct ParseError {
@@ -29,6 +40,7 @@ impl Parser {
             tokens,
             current: 0,
             doc_comments,
+            expr_depth: 0,
         }
     }
 
@@ -5735,7 +5747,16 @@ impl Parser {
     // ---- Expression Parsing (Pratt-style precedence climbing) ----
 
     fn parse_expression(&mut self) -> Result<Expression, ParseError> {
-        self.parse_assignment_expr()
+        // Bound expression recursion so deeply nested input (e.g. `((((...))))`)
+        // returns a parse error instead of overflowing the stack.
+        self.expr_depth += 1;
+        if self.expr_depth > MAX_EXPR_DEPTH {
+            self.expr_depth -= 1;
+            return Err(self.parse_error("expression nesting too deep"));
+        }
+        let result = self.parse_assignment_expr();
+        self.expr_depth -= 1;
+        result
     }
 
     fn parse_assignment_expr(&mut self) -> Result<Expression, ParseError> {

--- a/crates/cfml-compiler/tests/expr_depth_limit.rs
+++ b/crates/cfml-compiler/tests/expr_depth_limit.rs
@@ -1,0 +1,41 @@
+//! A deeply nested expression must return a parse error rather than recursing
+//! until the stack overflows and the process aborts. `Parser::parse` runs on
+//! untrusted CFML source, so unbounded expression recursion is a denial of
+//! service (a few hundred bytes of `((((...))))` crashes the host).
+
+use cfml_compiler::parser::Parser;
+
+fn parse_on_stack(source: String) -> bool {
+    // 8 MiB matches the default main-thread stack. Without a depth bound this
+    // input overflows and aborts; with the bound it returns Err and joins ok.
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            let mut p = Parser::new(source);
+            let _ = p.parse();
+        })
+        .expect("spawn parse thread")
+        .join()
+        .is_ok()
+}
+
+#[test]
+fn deeply_nested_expression_does_not_overflow_stack() {
+    for depth in [10_000usize, 100_000] {
+        let src = format!("<cfset x = {}1{}>", "(".repeat(depth), ")".repeat(depth));
+        assert!(
+            parse_on_stack(src),
+            "deeply nested expression (depth {depth}) must not overflow the stack"
+        );
+    }
+}
+
+#[test]
+fn normal_expressions_still_parse() {
+    // A realistic nested expression, well under the limit, must still parse.
+    let mut p = Parser::new("<cfset x = (1 + 2) * (3 - 4) / (5 + 6)>".to_string());
+    assert!(p.parse().is_ok());
+
+    let mut p2 = Parser::new(format!("<cfset y = {}1{}>", "(".repeat(30), ")".repeat(30)));
+    assert!(p2.parse().is_ok(), "30-deep nesting is under the limit");
+}


### PR DESCRIPTION
## What

The recursive-descent expression parser has no depth limit. Deeply nested source — e.g. `<cfset x = ((((...))))>` or `#((((...))))#` — recurses through the full precedence chain (`parse_expression` → `parse_ternary` → … → `parse_primary` → back to `parse_expression` for the grouped sub-expression) once per nesting level, until the thread stack overflows and the process aborts:

```
fatal runtime error: stack overflow, aborting
```

On the default 8 MB main-thread stack this triggers at roughly **300 nested parens** — about 600 bytes of source. Since `Parser::parse` runs untrusted CFML (a template engine processes user-supplied templates/input), a tiny crafted source string is a denial of service.

## Reproduce (before this change)

```rust
let src = format!("<cfset x = {}1{}>", "(".repeat(400), ")".repeat(400));
let mut p = cfml_compiler::parser::Parser::new(src);
let _ = p.parse(); // stack overflow -> process aborts
```

## Fix

Track expression-recursion depth on the `Parser` and return a `ParseError` ("expression nesting too deep") once it exceeds `MAX_EXPR_DEPTH` (64) instead of recursing further. `parse_expression` is the single chokepoint every nesting level passes through, so the guard covers parens, operators, calls, etc.

64 is far above any hand-written CFML expression (each level walks ~10 precedence frames, so this stays comfortably within a normal stack). Normal expressions are unaffected — a realistic `(1 + 2) * (3 - 4) / (5 + 6)` and 30-deep nesting still parse, and all existing tests pass.

## Test

`tests/expr_depth_limit.rs` parses deeply nested input (10k / 100k deep) on the default 8 MB stack and asserts a returned error rather than an abort, plus a check that normal expressions still parse. On `main` this aborts; with the fix it passes. `cargo test -p cfml-compiler` (35 pass) and `cargo clippy` are clean.

---
*Disclosure: prepared with AI assistance; the crash was reproduced and the fix compiled/tested locally before submitting.*
